### PR TITLE
[WIP] repo: squash previous commit history into one "initial commit"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+JobCompletion.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+_NOTE: The interfaces of flux-accounting are being actively developed and are not yet stable. The Github issue tracker is the primary way to communicate with the developers._
+
+## flux-accounting
+
+Development for a bank/accounting interface for the Flux resource manager. Writes and saves job step history, user account information, and priority calculation to persistent storage using Python's SQLite3 API. 
+
+##### job step history
+
+Running as a cron job, `write_jobs.py` uses a flux-core RPC to retrieve job data that have recently transitioned to an INACTIVE state in the past _x_ minutes. It parses the job record data and writes it to a SQLite database, which can be queried at a later time. 
+
+##### user account information
+
+Users have banks that they can charge their jobs against; this will affect their priority when submitting future jobs in order to maintain a fair balance of resources between users running jobs on a single cluster. Multiple factors play a role in determining a user's job priority, but in general, the amount of resources used vs. the resource limits initially allocated will either lower or heighten a user's job priority. 
+
+Priority will be calculated by calling another Python file, `fairshare.py`, which will retrieve user account information amd job record history and perform a "fairshare" calculation to determine a user's job priority on a cluster. 

--- a/cmd/fairshare.py
+++ b/cmd/fairshare.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+module for calculating a user's fairshare value when
+submitting jobs
+"""
+
+import sys
+import sqlite3
+
+
+def check_user_id(usr_id):
+
+    # ensure that id specified is a valid int
+    if isinstance(usr_id, int):
+        return "user id specified: " + str(usr_id)
+    else:
+        print("user id specified is not an integer")
+        print("aborting...")
+        return -1
+
+
+def fetch_usr_data(usr_id):
+    # check that user id is in user table
+    # open connection to database
+    print("Opening JobCompletion DB...")
+    conn = sqlite3.connect("JobCompletion.db")
+    print("Opened JobCompletion DB successfully\n")
+
+    # check if user exists in table
+    print("obtaining user data from database... ")
+    sel_statement = "SELECT * FROM users_assoc_table WHERE userid=" + str(usr_id)
+    cursor = conn.cursor()
+    cursor.execute(sel_statement)
+    records = cursor.fetchall()
+
+    if len(records) == 0:
+        return "user not found in database"
+    else:
+        for col in records:
+            usr_acct_info = {"user_id": col[0], "acct": col[1], "shares": col[2]}
+
+        print("\tuserid: ", usr_acct_info["user_id"])
+        print("\tacct: ", usr_acct_info["acct"])
+        print("\tshares: ", usr_acct_info["shares"])
+        return usr_acct_info
+
+
+print(fetch_usr_data(12345))

--- a/cmd/fs_unittest.py
+++ b/cmd/fs_unittest.py
@@ -1,0 +1,45 @@
+"""
+unit testing for fairshare.py
+"""
+
+import unittest
+import fairshare as f
+import sys
+import os
+
+
+class TestFairshare(unittest.TestCase):
+
+    # make sure user id can be read correctly
+    def test_check_user_id_valid(self):
+        expected = "user id specified: 10514"
+        test = f.check_user_id(10514)
+        self.assertEqual(test, expected)
+
+    # make sure function returns -1 if string is passed
+    def test_check_user_id_bad_val_str(self):
+        expected = -1
+        test = f.check_user_id("bad val")
+        self.assertEqual(test, expected)
+
+    # make sure function returns -1 if a float is passed
+    def test_check_user_id_bad_val_float(self):
+        expected = -1
+        test = f.check_user_id(3.14159)
+        self.assertEqual(test, expected)
+
+    # fetch valid user's information from database
+    def test_fetch_valid_user_info(self):
+        expected = {"user_id": "12345", "acct": "lc", "shares": "1"}
+        test = f.fetch_usr_data(12345)
+        self.assertDictEqual(test, expected)
+
+    # make sure invalid user id fails successfully
+    def test_fetch_bad_user_id(self):
+        expected = "user not found in database"
+        test = f.fetch_usr_data(0)
+        self.assertEqual(test, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/create_db.py
+++ b/src/create_db.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import sqlite3
+
+
+def create_db():
+    # open connection to database
+    print("Creating JobCompletion DB...")
+    conn = sqlite3.connect("JobCompletion.db")
+    print("Created JobCompletion DB sucessfully")
+
+    # create table in DB
+    print("Creating inactive table in DB...")
+    conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS inactive (
+                t_submit   text NOT NULL,
+                name       text NOT NULL,
+                t_run      text NOT NULL,
+                t_cleanup  text NOT NULL,
+                userid     text NOT NULL,
+                ntasks     text NOT NULL,
+                t_inactive text NOT NULL,
+                t_depend   text NOT NULL,
+                priority   text NOT NULL,
+                state      text NOT NULL,
+                t_sched    text NOT NULL,
+                id         text PRIMARY KEY
+            );"""
+    )
+    print("Created table successfully")
+
+    # create user table in DB
+    print("Creating user table in DB...")
+    conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS users_assoc_table (
+                userid     text PRIMARY KEY,
+                acct       text NOT NULL,
+                shares     text NOT NULL
+            );"""
+    )
+    print("Created table successfully")
+
+
+def main():
+    create_db()
+
+
+main()

--- a/src/write_jobs.py
+++ b/src/write_jobs.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+
+import sys
+import sqlite3
+import pandas as pd
+import time
+
+import flux.job
+import flux.constants
+import flux.util
+from flux.core.inner import raw
+
+
+def write_to_db(inactive):
+    # open connection to database
+    print("Opening JobCompletion DB...")
+    conn = sqlite3.connect("JobCompletion.db")
+    print("Opened JobCompletion DB successfully\n")
+
+    # insert values into DB one at a time by getting the values from
+    # each job completion tuple
+    print("Inserting values into DB...\n")
+    for job in inactive:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO inactive
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                job["t_submit"],
+                job["name"],
+                job["t_run"],
+                job["t_cleanup"],
+                job["userid"],
+                job["ntasks"],
+                job["t_inactive"],
+                job["t_depend"],
+                job["priority"],
+                job["state"],
+                job["t_sched"],
+                job["id"],
+            ),
+        )
+        print("insertion into inactive table successful")
+
+    # commit changes
+    conn.commit()
+
+    # make sure the writes to DB were successful and we can
+    # retrieve them
+    sel_statement = "SELECT * FROM inactive"
+    print(pd.read_sql_query(sel_statement, conn))
+    print()
+
+    conn.close()
+
+
+def save_last_job():
+    # open connection to database
+    print("Opening JobCompletion DB...")
+    conn = sqlite3.connect("JobCompletion.db")
+    print("Opened JobCompletion DB successfully\n")
+
+    # get the last submitted job and query its t_submit and job id
+    print("Getting last submitted job...")
+    sel_statement = "SELECT id, t_submit FROM inactive ORDER BY t_inactive DESC LIMIT 1"
+    cursor = conn.cursor()
+    cursor.execute(sel_statement)
+    records = cursor.fetchall()
+
+    for row in records:
+        last_job_id = row[0]
+        last_t_inactive = row[1]
+
+    print("Last job id:", last_job_id, "t_inactive:", last_t_inactive)
+    print("Query complete\n")
+
+    # write the last job's job id to a temporary text file for retrieval later
+    # if the file doesn't exist yet, it will be created
+    print("writing last job id to tmp file...")
+    f = open("tmp_id.txt", "w")
+    f.truncate(0)
+    f.write(last_job_id + "\n")
+    f.close()
+    print("write complete\n")
+
+    # <demo> show contents of last job's job id
+    print("showing contents of tmp file...")
+    f = open("tmp_id.txt", "r")
+    for line in f:
+        print(line)
+
+
+def main():
+    h = flux.Flux()
+
+    attrs = [
+        "userid",
+        "priority",
+        "state",
+        "name",
+        "ntasks",
+        "t_submit",
+        "t_depend",
+        "t_sched",
+        "t_run",
+        "t_cleanup",
+        "t_inactive",
+    ]
+
+    # get jobs that have run in the past 5 minutes
+    rpc_handle = flux.job.job_list_inactive(h, time.time() - 300, 1000, attrs)
+
+    try:
+        jobs = rpc_handle.get_jobs()
+    except EnvironmentError as e:
+        print("{}: {}".format("rpc", e.strerror), file=sys.stderr)
+        sys.exit(1)
+
+    write_to_db(jobs)
+    save_last_job()
+
+
+main()


### PR DESCRIPTION
As mentioned in #2, when this repo was imported, all of the previous commit history came along with it. This PR cleans up the commit history and squashes all commits into just one "initial commit," so from now on the project can follow the C4.1 guidelines. 