### PR TITLE
repo: add install instructions, Makefile to install dependencies and run unit tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ accounting/FluxAccounting.db
 accounting/db_creation.log
 test/FluxAccounting.db
 build/
+.tox

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+# minimal Makefile to run Python unit tests
+# for flux-accounting
+
+check:
+	pip3 install -r requirements.txt
+	python3 -m unittest discover

--- a/README.md
+++ b/README.md
@@ -2,14 +2,43 @@ _NOTE: The interfaces of flux-accounting are being actively developed and are no
 
 ## flux-accounting
 
-Development for a bank/accounting interface for the Flux resource manager. Writes and saves job step history, user account information, and priority calculation to persistent storage using Python's SQLite3 API. 
+Development for a bank/accounting interface for the Flux resource manager. Writes and saves user account information to persistent storage using Python's SQLite3 API.
 
-##### job step history
+### Build Requirements
 
-Running as a cron job, `write_jobs.py` uses a flux-core RPC to retrieve job data that have recently transitioned to an INACTIVE state in the past _x_ minutes. It parses the job record data and writes it to a SQLite database, which can be queried at a later time. 
+flux-accounting requires the following packages to build:
+
+| centos8       | ubuntu      | version |
+| ------        | --------    | ------- |
+| python3-devel | python3-dev | >= 3.6  |
+| python3-pip   | python3-pip | 20.0.2  |
+| tox           | tox         | 3.15.0  |
+
+### Install Instructions
+
+You can install the dependencies required by flux-accounting (located in **requirements.txt**) with the following command:
+
+```
+$ pip3 install -r requirements.txt
+```
+
+### Test Instructions
+
+Run the unit tests with `tox` to ensure the correctness of this package on your platform::
+
+```
+$ tox
+python3.6 run-test: commands[0] | python -m unittest discover
+....
+----------------------------------------------------------------------
+Ran 4 tests in 0.008s
+
+OK
+_______________________________summary _______________________________
+  python3.6: commands succeeded
+  congratulations :)
+```
 
 ##### user account information
 
-Users have banks that they can charge their jobs against; this will affect their priority when submitting future jobs in order to maintain a fair balance of resources between users running jobs on a single cluster. Multiple factors play a role in determining a user's job priority, but in general, the amount of resources used vs. the resource limits initially allocated will either lower or heighten a user's job priority. 
-
-Priority will be calculated by calling another Python file, `fairshare.py`, which will retrieve user account information amd job record history and perform a "fairshare" calculation to determine a user's job priority on a cluster. 
+The accounting table in this database stores information like user name and ID, the account to submit jobs against, an optional parent account, the shares allocated to the user, as well as static limits, including max jobs submitted per user at a given time and max wall time per job per user.

--- a/accounting/test/docker/centos8/Dockerfile.centos8
+++ b/accounting/test/docker/centos8/Dockerfile.centos8
@@ -1,0 +1,20 @@
+# Docker file for a slim Ubuntu-based Python3 image
+
+FROM centos:8
+
+LABEL maintainer="Christopher Moussa <moussa1@llnl.gov>"
+
+# add flux-accounting/ to src/ in container
+ADD . src/
+
+RUN yum -y update \
+  && yum install -y python3-pip python3-devel git \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 install --user --upgrade pip \
+  && pip3 install tox
+
+# go into flux-accounting, install dependencies, and run unit tests
+RUN cd src/ \
+  && pip3 install --user -r requirements.txt \
+  && tox

--- a/accounting/test/docker/ubuntu/Dockerfile.ubuntu
+++ b/accounting/test/docker/ubuntu/Dockerfile.ubuntu
@@ -1,0 +1,20 @@
+# Docker file for a slim Ubuntu-based Python3 image
+
+FROM ubuntu:latest
+
+LABEL maintainer="Christopher Moussa <moussa1@llnl.gov>"
+
+# add flux-accounting/ to src/ in container
+ADD . src/
+
+RUN apt-get update \
+  && apt-get install -y python3-pip python3-dev git \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 install --upgrade pip \
+  && pip3 install tox
+
+# go into flux-accounting, install dependencies, and run unit tests
+RUN cd src/ \
+  && pip3 install -r requirements.txt \
+  && tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = python3.6
+
+[testenv]
+deps =
+    pandas
+commands =
+    python -m unittest discover


### PR DESCRIPTION
Noted by @dongahn in #6 and #12, the install and unit test instructions in the **README.md** were not clear/non-existent. This PR adds a **Makefile** that installs the dependencies listed in **requirements.txt** as well as runs the unit tests, so both can be run with `make check`.

```
$ make check
pip3 install -r requirements.txt
Collecting pandas==0.25.3
Installing collected packages: pandas
Successfully installed pandas-0.25.3
python3 -m unittest discover
....
----------------------------------------------------------------------
Ran 4 tests in 0.021s

OK
```

**README.md** has also been updated to reflect these instructions. 

Fixes #12 