### PR TITLE
accounting_cli.py: add command line interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@
 
 check:
 	pip3 install -r requirements.txt
-	python3 -m unittest discover
+	python3 -m unittest discover -b

--- a/README.md
+++ b/README.md
@@ -39,6 +39,117 @@ _______________________________summary _______________________________
   congratulations :)
 ```
 
-##### user account information
+To run the unit tests in a Docker container, you can use `docker build -f <path/to/Dockerfile> .` from the flux-accounting directory:
+
+```
+$ docker build -f accounting/test/docker/ubuntu/Dockerfile.ubuntu .
+Sending build context to Docker daemon  299.9MB
+Step 1/5 : FROM ubuntu:latest
+ ---> 1d622ef86b13
+Step 2/5 : LABEL maintainer="Christopher Moussa <moussa1@llnl.gov>"
+ ---> Using cache
+ ---> bdbc2ff632a5
+Step 3/5 : ADD . src/
+ ---> 7da92dbd8852
+ .
+ .
+ .
+ Step 5/5 : RUN cd src/   && pip3 install -r requirements.txt   && tox
+ .
+ .
+ .
+ python3.6 run-test: commands[0] | python -m unittest discover
+.........
+----------------------------------------------------------------------
+Ran 9 tests in 0.035s
+
+OK
+missing fields for account.
+
+FIELDS=user_name admin_level account parent_acct shares max_jobs max_wall_pj
+UNIQUE constraint failed: association_table.user_name
+no such column: bar
+___________________________________ summary ____________________________________
+  python3.6: commands succeeded
+  congratulations :)
+Removing intermediate container 45479512d947
+ ---> f29dd2ca5958
+Successfully built f29dd2ca5958
+```
+
+### User Account Information
 
 The accounting table in this database stores information like user name and ID, the account to submit jobs against, an optional parent account, the shares allocated to the user, as well as static limits, including max jobs submitted per user at a given time and max wall time per job per user.
+
+### Interacting With the Accounting DB
+
+There are two ways you can interact with the tables contained in the Accounting DB. Both of these require you to be in the same directory where the database file (**FluxAccounting.db**) is located. The first way is to launch into an interactive SQLite shell. From there, you can open the database file and interface with any of the tables using SQLite commands:
+
+```
+$ sqlite3
+SQLite version 3.24.0 2018-06-04 14:10:15
+Enter ".help" for usage hints.
+Connected to a transient in-memory database.
+Use ".open FILENAME" to reopen on a persistent database.
+
+sqlite> .open FluxAccounting.db
+sqlite> .tables
+association_table
+```
+
+To get nicely formatted output from queries (like headers for the tables and proper spacing), you can also set the following options in your shell:
+
+```
+sqlite> .mode columns
+sqlite> .headers on
+```
+
+This will output queries like the following:
+
+```
+sqlite> SELECT * FROM association_table;
+id_assoc    creation_time  mod_time    deleted     user_name   admin_level  account     parent_acct  shares      max_jobs    max_wall_pj
+----------  -------------  ----------  ----------  ----------  -----------  ----------  -----------  ----------  ----------  -----------
+1           1589225734     1589225734  0           fluxuser    1            acct        pacct        10          100         60  
+```
+
+The second way is to use flux-accounting's command line arguments. You can install them by running the following command from the `flux-accounting` directory:
+
+```
+$ pip3 install .
+
+Installing collected packages: flux-accounting
+  Running setup.py develop for flux-accounting
+Successfully installed flux-accounting
+```
+
+Then, from the same directory where the database file (**FluxAccounting.db**) is located, you can use flux-accounting's command line interface:
+
+```
+$ flux-accounting -h
+
+usage: flux-accounting [-h] {view-user,add-user,delete-user,edit-user} ...
+
+Description: Translate command line arguments into SQLite instructions for the
+Flux Accounting Database.
+
+positional arguments:
+  {view-user,add-user,delete-user,edit-user}
+                        sub-command help
+    view-user           view a user's information in the accounting database
+    add-user            add a user to the accounting database
+    delete-user         remove a user from the accounting database
+    edit-user           edit a user's value
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+With flux-accounting's command line tools, you can view a user's account information, add and remove users to the accounting database, and edit an existing user's account information. Just make sure you are in the same directory where the database file is located when you run the commands:
+
+```
+$ flux-account view-user fluxuser
+
+id_assoc  creation_time    mod_time  deleted user_name  admin_level account parent_acct  shares  max_jobs  max_wall_pj
+       1     1589225734  1589225734        0  fluxuser            1    acct       pacct      10       100           60
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run the unit tests with `tox` to ensure the correctness of this package on your 
 
 ```
 $ tox
-python3.6 run-test: commands[0] | python -m unittest discover
+python3.6 run-test: commands[0] | python -m unittest discover -b
 ....
 ----------------------------------------------------------------------
 Ran 4 tests in 0.008s
@@ -58,17 +58,12 @@ Step 3/5 : ADD . src/
  .
  .
  .
- python3.6 run-test: commands[0] | python -m unittest discover
+ python3.6 run-test: commands[0] | python -m unittest discover -b
 .........
 ----------------------------------------------------------------------
 Ran 9 tests in 0.035s
 
 OK
-missing fields for account.
-
-FIELDS=user_name admin_level account parent_acct shares max_jobs max_wall_pj
-UNIQUE constraint failed: association_table.user_name
-no such column: bar
 ___________________________________ summary ____________________________________
   python3.6: commands succeeded
   congratulations :)

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import argparse
+import time
+
+import pandas as pd
+
+from accounting import accounting_cli_functions as aclif
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Translate command line arguments into
+        SQLite instructions for the Flux Accounting Database.
+        """
+    )
+    subparsers = parser.add_subparsers(help="sub-command help",)
+
+    subparser_view_user = subparsers.add_parser(
+        "view-user", help="view a user's information in the accounting database"
+    )
+    subparser_view_user.set_defaults(func="view_user")
+    subparser_view_user.add_argument("username", help="username", metavar=("USERNAME"))
+
+    subparser_add_user = subparsers.add_parser(
+        "add-user", help="add a user to the accounting database"
+    )
+    subparser_add_user.set_defaults(func="add_user")
+    subparser_add_user.add_argument(
+        "--username", help="username", metavar="USERNAME",
+    )
+    subparser_add_user.add_argument(
+        "--admin-level", help="admin level", metavar="ADMIN_LEVEL",
+    )
+    subparser_add_user.add_argument(
+        "--account", help="account to charge jobs against", metavar="ACCOUNT",
+    )
+    subparser_add_user.add_argument(
+        "--parent-acct", help="parent account", metavar="PARENT_ACCOUNT",
+    )
+    subparser_add_user.add_argument(
+        "--shares", help="shares", metavar="SHARES",
+    )
+    subparser_add_user.add_argument(
+        "--max-jobs", help="max jobs", metavar="MAX_JOBS",
+    )
+    subparser_add_user.add_argument(
+        "--max-wall-pj", help="max wall time per job", metavar="MAX_WALL_PJ",
+    )
+
+    subparser_delete_user = subparsers.add_parser(
+        "delete-user", help="remove a user from the accounting database"
+    )
+    subparser_delete_user.set_defaults(func="delete_user")
+    subparser_delete_user.add_argument(
+        "username", help="username", metavar=("USERNAME")
+    )
+
+    subparser_edit_user = subparsers.add_parser("edit-user", help="edit a user's value")
+    subparser_edit_user.set_defaults(func="edit_user")
+    subparser_edit_user.add_argument(
+        "--username", help="username", metavar="USERNAME",
+    )
+    subparser_edit_user.add_argument(
+        "--field", help="column name", metavar="FIELD",
+    )
+    subparser_edit_user.add_argument(
+        "--new-value", help="new value", metavar="VALUE",
+    )
+
+    args = parser.parse_args()
+
+    conn = sqlite3.connect("FluxAccounting.db")
+
+    try:
+        if args.func == "view_user":
+            aclif.view_user(conn, args.username)
+        elif args.func == "add_user":
+            aclif.add_user(
+                conn,
+                args.username,
+                args.admin_level,
+                args.account,
+                args.parent_acct,
+                args.shares,
+                args.max_jobs,
+                args.max_wall_pj,
+            )
+        elif args.func == "delete_user":
+            aclif.delete_user(conn, args.username)
+        elif args.func == "edit_user":
+            aclif.edit_user(conn, args.username, args.field, args.new_value)
+        else:
+            print(parser.print_usage())
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import argparse
+import time
+import sys
+
+import pandas as pd
+
+
+def view_user(conn, user):
+    try:
+        # get the information pertaining to a user in the Accounting DB
+        select_stmt = "SELECT * FROM association_table where user_name=?"
+        dataframe = pd.read_sql_query(select_stmt, conn, params=(user,))
+        # if the length of dataframe is 0, that means
+        # the user specified was not found in the table
+        if len(dataframe.index) == 0:
+            print("User not found in association_table")
+        else:
+            print(dataframe)
+    except pd.io.sql.DatabaseError as e_database_error:
+        print(e_database_error)
+
+
+def add_user(
+    conn, username, admin_level, account, parent_acct, shares, max_jobs, max_wall_pj
+):
+
+    # insert the user values into the database
+    try:
+        conn.execute(
+            """
+            INSERT INTO association_table (
+                creation_time,
+                mod_time,
+                deleted,
+                user_name,
+                admin_level,
+                account,
+                parent_acct,
+                shares,
+                max_jobs,
+                max_wall_pj
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                int(time.time()),
+                int(time.time()),
+                0,
+                username,
+                admin_level,
+                account,
+                parent_acct,
+                shares,
+                max_jobs,
+                max_wall_pj,
+            ),
+        )
+        # commit changes
+        conn.commit()
+    # make sure entry is unique
+    except sqlite3.IntegrityError as integrity_error:
+        print(integrity_error)
+
+
+def delete_user(conn, user):
+    # delete user account from association_table
+    delete_stmt = "DELETE FROM association_table WHERE user_name=?"
+    cursor = conn.cursor()
+    cursor.execute(delete_stmt, (user,))
+    # commit changes
+    conn.commit()
+
+
+def edit_user(conn, username, field, new_value):
+    fields = [
+        "user_name",
+        "admin_level",
+        "account",
+        "parent_acct",
+        "shares",
+        "max_jobs",
+        "max_wall_pj",
+    ]
+    if field in fields:
+        the_field = field
+    else:
+        print("Field not found in association table")
+        sys.exit(1)
+
+    # edit value in accounting database
+    conn.execute(
+        "UPDATE association_table SET " + the_field + "=? WHERE user_name=?",
+        (new_value, username,),
+    )
+    # commit changes
+    conn.commit()

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -28,17 +28,17 @@ def create_db(filepath):
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS association_table (
+                id_assoc      integer                           PRIMARY KEY,
                 creation_time bigint(20)            NOT NULL,
                 mod_time      bigint(20)  DEFAULT 0 NOT NULL,
                 deleted       tinyint(4)  DEFAULT 0 NOT NULL,
-                id_assoc      integer                         PRIMARY KEY AUTOINCREMENT,
-                user_name     tinytext              NOT NULL,
+                user_name     tinytext    UNIQUE    NOT NULL,
                 admin_level   smallint(6) DEFAULT 1 NOT NULL,
                 account       tinytext              NOT NULL,
-                parent_acct   tinytext,
+                parent_acct   tinytext              NOT NULL,
                 shares        int(11)     DEFAULT 1 NOT NULL,
-                max_jobs      int(11),
-                max_wall_pj   int(11)
+                max_jobs      int(11)               NOT NULL,
+                max_wall_pj   int(11)               NOT NULL
         );"""
     )
     logging.info("Created association_table successfully")

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -14,7 +14,7 @@ import pandas as pd
 import logging
 
 
-LOGGER = logging.basicConfig(filename="accounting/db_creation.log", level=logging.INFO)
+LOGGER = logging.basicConfig(filename="db_creation.log", level=logging.INFO)
 
 
 def create_db(filepath):
@@ -47,7 +47,7 @@ def create_db(filepath):
 
 
 def main():
-    create_db("accounting/FluxAccounting.db")
+    create_db("FluxAccounting.db")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/flux-framework/flux-accounting",
     packages=setuptools.find_packages(),
+    entry_points={
+        'console_scripts': [
+            'flux-account = accounting.accounting_cli:main',
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License",

--- a/test/test_accounting_cli.py
+++ b/test/test_accounting_cli.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import pandas as pd
+
+from accounting import accounting_cli_functions as aclif
+from accounting import create_db as c
+
+
+class TestAccountingCLI(unittest.TestCase):
+    # create database
+    @classmethod
+    def setUpClass(self):
+        c.create_db("FluxAccounting.db")
+        global conn
+        conn = sqlite3.connect("FluxAccounting.db")
+
+    # add a valid user to association_table
+    def test_01_add_valid_user(self):
+        aclif.add_user(conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+
+        cursor = conn.cursor()
+        num_rows = cursor.execute("DELETE FROM association_table").rowcount
+        self.assertEqual(num_rows, 1)
+
+    # adding a user with the same user_name as an existing user should
+    # return an IntegrityError
+    def test_02_add_duplicate_user(self):
+        aclif.add_user(conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+
+        aclif.add_user(conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+
+        self.assertRaises(sqlite3.IntegrityError)
+
+    # edit a value for a user in the association table
+    def test_03_edit_user_value(self):
+        aclif.edit_user(conn, "fluxuser", "max_jobs", "10000")
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT max_jobs FROM association_table where user_name='fluxuser'"
+        )
+
+        self.assertEqual(cursor.fetchone()[0], 10000)
+
+    # trying to edit a field in a column that doesn't
+    # exist should return an OperationalError
+    def test_04_edit_bad_field(self):
+        with self.assertRaises(SystemExit) as cm:
+            aclif.edit_user(conn, "fluxuser", "foo", "bar")
+
+        self.assertEqual(cm.exception.code, 1)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove("FluxAccounting.db")
+        os.remove("db_creation.log")
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(TestAccountingCLI("test_01_add_valid_user"))
+    suite.addTest(TestAccountingCLI("test_02_add_bad_user"))
+    suite.addTest(TestAccountingCLI("test_03_add_duplicate_user"))
+    suite.addTest(TestAccountingCLI("test_04_edit_user_value"))
+    suite.addTest(TestAccountingCLI("test_05_edit_bad_field"))
+
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/test/test_create_db.py
+++ b/test/test_create_db.py
@@ -13,19 +13,20 @@ import unittest
 import os
 import sqlite3
 import pandas as pd
+
 from accounting import create_db as c
 
 
 class TestDB(unittest.TestCase):
     # create database and make sure it exists
     def test_00_test_create_db(self):
-        c.create_db("test/FluxAccounting.db")
+        c.create_db("FluxAccounting.db")
 
-        assert os.path.exists("test/FluxAccounting.db")
+        assert os.path.exists("FluxAccounting.db")
 
     # make sure association table exists
     def test_01_user_table_exists(self):
-        with sqlite3.connect("test/FluxAccounting.db") as db:
+        with sqlite3.connect("FluxAccounting.db") as db:
             cursor = db.cursor()
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
             tables = cursor.fetchall()
@@ -41,7 +42,7 @@ class TestDB(unittest.TestCase):
 
     # add an association to the association_table
     def test_02_create_association(self):
-        with sqlite3.connect("test/FluxAccounting.db") as db:
+        with sqlite3.connect("FluxAccounting.db") as db:
             db.execute(
                 """
             INSERT INTO association_table
@@ -56,6 +57,21 @@ class TestDB(unittest.TestCase):
             num_rows = cursor.execute("DELETE FROM association_table").rowcount
             self.assertEqual(num_rows, 1)
 
+    # remove database file
+    @classmethod
+    def tearDownClass(self):
+        os.remove("FluxAccounting.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(TestDB("test_00_test_create_db"))
+    suite.addTest(TestDB("test_01_user_table_exists"))
+    suite.addTest(TestDB("test_02_create_association"))
+
+    return suite
+
 
 if __name__ == "__main__":
-    unittest.main()
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist = python3.6
 deps =
     pandas
 commands =
-    python -m unittest discover
+    python -m unittest discover -b


### PR DESCRIPTION
**Problem**: currently, the only way to access data within the accounting database file (**FluxAccounting.db**) is to open a sqlite3 shell from the same directory where the database file is located and run SQLite commands:

```
$ sqlite3

moussa1@trinity1 $ sqlite3
SQLite version 3.24.0 2018-06-04 14:10:15
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> .open FluxAccounting.db
sqlite> .headers on
sqlite> .mode column
sqlite> select * from association_table;
id_assoc    creation_time  mod_time    deleted     user_name   admin_level  account     parent_acct  shares      max_jobs    max_wall_pj
----------  -------------  ----------  ----------  ----------  -----------  ----------  -----------  ----------  ----------  -----------
1           1589225734     1589225734  0           fluxuser    1            acct        pacct        10          100         60  
``` 

**Proposal**: This PR looks to add a command line interface to flux-accounting so that instead of launching into a sqlite shell, we can use commands to:

- add a user to the accounting database: 

```
$ flux-accounting -a testuser 1 acct pacct 10 100 60
```

- view a user's information:

```
$ flux-accounting -u testuser
id_assoc  creation_time    mod_time  deleted user_name  admin_level account parent_acct  shares  max_jobs  max_wall_pj
       3     1589384678  1589384678        0  testuser            1    acct       pacct      10       100           60
```

- edit a user's value:

```
$ flux-accounting -e testuser max_jobs 500 
```

- remove a user from the accounting database

```
$ flux-accounting -d testuser 
```

Instructions on how to install the command line interface and run the flux-accounting commands were added to the top level README as well. 

The unit tests for the added files `accounting_cli.py` and `accounting_cli_functions.py` can be run from the `flux-accounting` directory with: 

- `tox`,
- `python -m unittest discover`,
or
- `docker build -f accounting/test/docker/ubuntu/Dockerfile.ubuntu .`

I have this tagged as a [WIP] and I think it would be helpful for me to get some feedback on the labels I gave the command line arguments (e.g. is `-u` the best char to use for viewing a user's information?) and the way the command line syntax works:

1. Is the syntax for adding a user to the database perhaps too difficult to use? There are a lot of arguments (fields in the association_table) and the way the command works right now basically requires the admin to remember the order in which the fields should be entered. Would it be more convenient to add the fields one at a time, each labeled? 

An example:

```
enter a user_name: testuser
enter an admin_level: 1
.
.
.
```

2. Is `-u` a good flag for viewing a user's information? I first had thought of using `-v` but figured that would be confused with a `--verbose`.