### PR TITLE
Mergify: configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,9 @@ pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=master
-      - status-success="validate commits"
-      - status-success="Lint with flake8"
-      - status-success="Test with unittest"
+      - status-success="validate commits (3.6)"
+      - status-success="validate commits (3.7)"
+      - status-success="validate commits (3.8)"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"


### PR DESCRIPTION
**Problem**: mergify previously wasn't performing all of the checks when a PR was submitted; adding the `merge-when-passing` label didn't actually merge the PR.

This PR edits **.mergify.yml** so that all of the checks are performed when a new PR is submitted. Namely, the `validate commits (3.x)` checks are added to the file, since those checks already include the previous checks that were never run:

- `Lint with flake8`
- `Test with unittest` 