### PR TITLE
create_db.py, accounting_cli.py: add configurable database path

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -12,6 +12,7 @@
 import sqlite3
 import argparse
 import time
+import sys
 
 import pandas as pd
 
@@ -27,6 +28,10 @@ def main():
         """
     )
     subparsers = parser.add_subparsers(help="sub-command help",)
+
+    parser.add_argument(
+        "-p", "--path", dest="path", help="specify location of database file"
+    )
 
     subparser_view_user = subparsers.add_parser(
         "view-user", help="view a user's information in the accounting database"
@@ -82,7 +87,13 @@ def main():
 
     args = parser.parse_args()
 
-    conn = sqlite3.connect("FluxAccounting.db")
+    # try to open database file; will exit with -1 if database file not found
+    path = args.path if args.path else "FluxAccounting.db"
+    try:
+        conn = sqlite3.connect("file:" + path + "?mode=rw", uri=True)
+    except sqlite3.OperationalError:
+        print("Unable to open database file")
+        sys.exit(-1)
 
     try:
         if args.func == "view_user":

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -12,6 +12,8 @@
 import sqlite3
 import pandas as pd
 import logging
+import argparse
+import sys
 
 
 LOGGER = logging.basicConfig(filename="db_creation.log", level=logging.INFO)
@@ -20,7 +22,7 @@ LOGGER = logging.basicConfig(filename="db_creation.log", level=logging.INFO)
 def create_db(filepath):
     # open connection to database
     logging.info("Creating Flux Accounting DB")
-    conn = sqlite3.connect(filepath)
+    conn = sqlite3.connect("file:" + filepath + "?mode:rwc", uri=True)
     logging.info("Created Flux Accounting DB sucessfully")
 
     # Association Table
@@ -47,7 +49,26 @@ def create_db(filepath):
 
 
 def main():
-    create_db("FluxAccounting.db")
+
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Create flux-accounting database to store
+        user account information.
+        """
+    )
+
+    parser.add_argument(
+        "-p", "--path", dest="path", help="specify location of database file"
+    )
+
+    args = parser.parse_args()
+
+    path = args.path if args.path else "FluxAccounting.db"
+    try:
+        create_db(path)
+    except sqlite3.OperationalError:
+        print("Unable to create database file")
+        sys.exit(-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Problem**: Both **create_db.py** and **accounting_cli.py** make assumptions about the location of the database file **FluxAccounting.db**. When **create_db.py** gets run, the database file gets placed in the same directory as the source code:

```
|-- LICENSE -> COPYING
|-- Makefile
|-- NOTICE -> NOTICE.LLNS
|-- NOTICE.LLNS
|-- README.md
|-- accounting
|   |-- FluxAccounting.db
|   |-- accounting_cli.py
|   |-- accounting_cli_functions.py
|   |-- create_db.py
```

This forces all of the subcommands to be executed in the same directory as well.

---

This PR adds a new optional command line argument `-p`, `--path` that allows the user to specify the database location when both creating the database and executing any of the subcommands. If no `-p` is passed, both scripts will default to the current directory (which was the behavior beforehand). 

An example of creating the database with the new argument:

```
$ ./create_db.py -p some/other/location/FluxAccounting.db
```

And running the subcommands:

```
$ flux account -p ../FluxAccounting.db view-user fluxuser
   id_assoc  creation_time    mod_time  deleted user_name  admin_level account parent_acct  shares  max_jobs  max_wall_pj
0         1     1593451150  1593451150        0  fluxuser            1    acct       pacct      10       100         1440
```

The subcommands will only open **FluxAccounting.db** in read-write mode instead of read-write-create. This should prevent empty database files from being created in case it cannot find the file. 

Fixes #20 