### PR TITLE
create_db: change table structure to allow duplicate usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ This will output queries like the following:
 
 ```
 sqlite> SELECT * FROM association_table;
-id_assoc    creation_time  mod_time    deleted     user_name   admin_level  account     parent_acct  shares      max_jobs    max_wall_pj
-----------  -------------  ----------  ----------  ----------  -----------  ----------  -----------  ----------  ----------  -----------
-1           1589225734     1589225734  0           fluxuser    1            acct        pacct        10          100         60  
+creation_time  mod_time    deleted     user_name   admin_level  account     parent_acct  shares      max_jobs    max_wall_pj
+-------------  ----------  ----------  ----------  -----------  ----------  -----------  ----------  ----------  -----------
+1589225734     1589225734  0           fluxuser    1            acct        pacct        10          100         60  
 ```
 
 The second way is to use flux-accounting's command line arguments. Then, from the same directory where the database file (**FluxAccounting.db**) is located, you can use flux-accounting's command line interface:
@@ -166,6 +166,6 @@ With flux-accounting's command line tools, you can view a user's account informa
 ```
 $ flux account view-user fluxuser
 
-id_assoc  creation_time    mod_time  deleted user_name  admin_level account parent_acct  shares  max_jobs  max_wall_pj
-       1     1589225734  1589225734        0  fluxuser            1    acct       pacct      10       100           60
+creation_time    mod_time  deleted user_name  admin_level     account parent_acct  shares  max_jobs  max_wall_pj
+   1595438356  1595438356        0  fluxuser            1        acct       pacct       1       100           60
 ```

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -30,17 +30,17 @@ def create_db(filepath):
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS association_table (
-                id_assoc      integer                           PRIMARY KEY,
                 creation_time bigint(20)            NOT NULL,
                 mod_time      bigint(20)  DEFAULT 0 NOT NULL,
                 deleted       tinyint(4)  DEFAULT 0 NOT NULL,
-                user_name     tinytext    UNIQUE    NOT NULL,
+                user_name     tinytext              NOT NULL,
                 admin_level   smallint(6) DEFAULT 1 NOT NULL,
                 account       tinytext              NOT NULL,
                 parent_acct   tinytext              NOT NULL,
                 shares        int(11)     DEFAULT 1 NOT NULL,
                 max_jobs      int(11)               NOT NULL,
-                max_wall_pj   int(11)               NOT NULL
+                max_wall_pj   int(11)               NOT NULL,
+                PRIMARY KEY   (user_name, account)
         );"""
     )
     logging.info("Created association_table successfully")
@@ -66,8 +66,8 @@ def main():
     path = args.path if args.path else "FluxAccounting.db"
     try:
         create_db(path)
-    except sqlite3.OperationalError:
-        print("Unable to create database file")
+    except sqlite3.OperationalError as e:
+        print("Unable to create database file:", e)
         sys.exit(-1)
 
 

--- a/test/test_create_db.py
+++ b/test/test_create_db.py
@@ -46,10 +46,10 @@ class TestDB(unittest.TestCase):
             db.execute(
                 """
             INSERT INTO association_table
-            (creation_time, mod_time, deleted, id_assoc, user_name, admin_level,
+            (creation_time, mod_time, deleted, user_name, admin_level,
             account, parent_acct, shares, max_jobs, max_wall_pj)
             VALUES
-            (0, 0, 0, 1, "test user", 1, "test account", "parent account", 0, 0,
+            (0, 0, 0, "test user", 1, "test account", "parent account", 0, 0,
             0)
             """
             )


### PR DESCRIPTION
**Problem**: as discussed in #23, the current table structure of `association_table` has a **UNIQUE** constraint on the `username` field. However, there is a need for multiple entries to be created with the same username, but different accounts. 

This PR changes the structure of `association_table` to instead have a primary key of a combination of both `username` and `account`. It also removes the `assoc_id` field from the table, which will be replaced by SQLite's native `ROWID` field [[1]](https://www.sqlite.org/autoinc.html). This should allow multiple entries to be created with the same username, as long as they are under different accounts. 

### An example

Trying to add the same user under the same account should raise an `IntegrityError`:

```
$ flux account add-user --username=fluxuser --admin-level=1 --account=acct --parent-acct=pacct --shares=1 --max-jobs=100 --max-wall-pj=60
$ flux account add-user --username=fluxuser --admin-level=1 --account=acct --parent-acct=pacct --shares=1 --max-jobs=100 --max-wall-pj=60
UNIQUE constraint failed: association_table.user_name, association_table.account
```

But changing the account name results in a successful addition:

```
$ flux account -p accounting/FluxAccounting.db view-user fluxuser
   creation_time    mod_time  deleted user_name  admin_level     account parent_acct  shares  max_jobs  max_wall_pj
0     1595438356  1595438356        0  fluxuser            1        acct       pacct       1       100           60
1     1595438491  1595438491        0  fluxuser            1  other_acct       pacct       1       100           60
```

Some of the unit tests also needed to be changed to reflect the update in `association_table`, as well as the example output from the SQLite queries in the top level **README**. 