### PR TITLE
accounting_cli.py: add default arg values for add-user subcommand

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -47,22 +47,25 @@ def main():
         "--username", help="username", metavar="USERNAME",
     )
     subparser_add_user.add_argument(
-        "--admin-level", help="admin level", metavar="ADMIN_LEVEL",
+        "--admin-level", help="admin level", default=1, metavar="ADMIN_LEVEL",
     )
     subparser_add_user.add_argument(
         "--account", help="account to charge jobs against", metavar="ACCOUNT",
     )
     subparser_add_user.add_argument(
-        "--parent-acct", help="parent account", metavar="PARENT_ACCOUNT",
+        "--parent-acct", help="parent account", default="", metavar="PARENT_ACCOUNT",
     )
     subparser_add_user.add_argument(
-        "--shares", help="shares", metavar="SHARES",
+        "--shares", help="shares", default=1, metavar="SHARES",
     )
     subparser_add_user.add_argument(
-        "--max-jobs", help="max jobs", metavar="MAX_JOBS",
+        "--max-jobs", help="max jobs", default=1, metavar="MAX_JOBS",
     )
     subparser_add_user.add_argument(
-        "--max-wall-pj", help="max wall time per job", metavar="MAX_WALL_PJ",
+        "--max-wall-pj",
+        help="max wall time per job",
+        default=60,
+        metavar="MAX_WALL_PJ",
     )
 
     subparser_delete_user = subparsers.add_parser(


### PR DESCRIPTION
**Problem**: In the `add-user` subcommand, all fields in the association_table in `flux-accounting` were required to be filled in when adding a new user. However, I learned that account names are unique in Slurm, so we generally don’t need to specify the parent account when adding a user (though we do need to specify a parent when adding a new account). I don’t think that we want the parent account to be a required field in `add-user`. More generally, it’d be nice to have default values for several of the add-user options.

This PR adds a default value to a number of the fields in `add-user`. The bare minimum fields required are now only `username` and `account`. The default values were set for the following fields:

- `admin-level=1`
- `parent-acct=`
- `shares=1`
- `max-jobs=1`
- `max-wall-pj=60`

#### An example

We should now be able to just add a user without needing to specify every field:

```
$ flux account add-user --username=moussa1 --account=some_account 
```

but all of the fields will still be passed in when adding the user, just with default values:

```
$ flux account view-user moussa1
   creation_time    mod_time  deleted user_name  admin_level       account parent_acct  shares  max_jobs  max_wall_pj
      1595519872  1595519872        0   moussa1            1  some_account                   1         1           60
```

Fixes #24