### PR TITLE
job-archive: add front-end to job-archive

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -33,6 +33,13 @@ def main():
         "-p", "--path", dest="path", help="specify location of database file"
     )
 
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        dest="output_file",
+        help="specify location of output file",
+    )
+
     subparser_view_user = subparsers.add_parser(
         "view-user", help="view a user's information in the accounting database"
     )
@@ -88,6 +95,38 @@ def main():
         "--new-value", help="new value", metavar="VALUE",
     )
 
+    subparser_view_jobs_by_username = subparsers.add_parser(
+        "by-user", help="show jobs run by username"
+    )
+    subparser_view_jobs_by_username.set_defaults(func="view_jobs_run_by_username")
+    subparser_view_jobs_by_username.add_argument(
+        "username", help="username", metavar="USERNAME",
+    )
+
+    subparser_view_job_by_jobid = subparsers.add_parser(
+        "by-jobid", help="show job info from jobid"
+    )
+    subparser_view_job_by_jobid.set_defaults(func="view_jobs_with_jobid")
+    subparser_view_job_by_jobid.add_argument(
+        "jobid", help="jobid", metavar="JOBID",
+    )
+
+    subparser_view_jobs_after_start_time = subparsers.add_parser(
+        "after-start-time", help="show jobs that completed after start time"
+    )
+    subparser_view_jobs_after_start_time.set_defaults(func="view_jobs_after_start_time")
+    subparser_view_jobs_after_start_time.add_argument(
+        "start_time", help="start time", metavar="START TIME",
+    )
+
+    subparser_view_jobs_before_end_time = subparsers.add_parser(
+        "before-end-time", help="show jobs that completed before end time"
+    )
+    subparser_view_jobs_before_end_time.set_defaults(func="view_jobs_before_end_time")
+    subparser_view_jobs_before_end_time.add_argument(
+        "end_time", help="end time", metavar="END TIME",
+    )
+
     args = parser.parse_args()
 
     # try to open database file; will exit with -1 if database file not found
@@ -97,6 +136,9 @@ def main():
     except sqlite3.OperationalError:
         print("Unable to open database file")
         sys.exit(-1)
+
+    # set path for output file
+    output_file = args.output_file if args.output_file else None
 
     try:
         if args.func == "view_user":
@@ -116,6 +158,14 @@ def main():
             aclif.delete_user(conn, args.username)
         elif args.func == "edit_user":
             aclif.edit_user(conn, args.username, args.field, args.new_value)
+        elif args.func == "view_jobs_run_by_username":
+            aclif.view_jobs_run_by_username(conn, args.username, args.output_file)
+        elif args.func == "view_jobs_with_jobid":
+            aclif.view_jobs_with_jobid(conn, args.jobid, args.output_file)
+        elif args.func == "view_jobs_after_start_time":
+            aclif.view_jobs_after_start_time(conn, args.start_time, args.output_file)
+        elif args.func == "view_jobs_before_end_time":
+            aclif.view_jobs_before_end_time(conn, args.end_time, args.output_file)
         else:
             print(parser.print_usage())
     finally:

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -13,8 +13,239 @@ import sqlite3
 import argparse
 import time
 import sys
+import pwd
+import csv
 
 import pandas as pd
+
+
+def count_ranks(ranks):
+    if "-" in ranks:
+        ranks_count = ranks.replace("-", ",").split(",")
+        return int(ranks_count[1]) - int(ranks_count[0]) + 1
+    else:
+        return int(ranks) + 1
+
+
+def get_username(userid):
+    try:
+        return pwd.getpwuid(userid).pw_name
+    except KeyError:
+        return str(userid)
+
+
+def get_uid(username):
+    try:
+        return pwd.getpwnam(username).pw_uid
+    except KeyError:
+        return str(username)
+
+
+def write_records_to_file(job_records, output_file):
+    with open(output_file, "w", newline="") as csvfile:
+        spamwriter = csv.writer(
+            csvfile, delimiter="|", quotechar="", escapechar="'", quoting=csv.QUOTE_NONE
+        )
+        spamwriter.writerow(
+            (
+                "UserID",
+                "Username",
+                "JobID",
+                "T_Submit",
+                "T_Run",
+                "T_Inactive",
+                "Nodes",
+                "R",
+            )
+        )
+        for record in job_records:
+            spamwriter.writerow(
+                (
+                    str(record.userid),
+                    str(record.username),
+                    str(record.jobid),
+                    str(record.t_submit),
+                    str(record.t_run),
+                    str(record.t_inactive),
+                    str(record.nnodes),
+                    str(record.R),
+                )
+            )
+
+
+def print_job_records(job_records):
+    records = {}
+    userid_arr = []
+    username_arr = []
+    jobid_arr = []
+    t_submit_arr = []
+    t_run_arr = []
+    t_inactive_arr = []
+    nnodes_arr = []
+    R_arr = []
+    hostname_arr = []
+
+    for record in job_records:
+        userid_arr.append(record.userid)
+        username_arr.append(record.username),
+        jobid_arr.append(record.jobid),
+        t_submit_arr.append(record.t_submit),
+        t_run_arr.append(record.t_run),
+        t_inactive_arr.append(record.t_inactive),
+        nnodes_arr.append(record.nnodes),
+        R_arr.append(record.R),
+
+    records = {
+        "UserID": userid_arr,
+        "Username": username_arr,
+        "JobID": jobid_arr,
+        "T_Submit": t_submit_arr,
+        "T_Run": t_run_arr,
+        "T_Inactive": t_inactive_arr,
+        "Nodes": nnodes_arr,
+        "R": R_arr,
+    }
+
+    dataframe = pd.DataFrame(
+        records,
+        columns=[
+            "UserID",
+            "Username",
+            "JobID",
+            "T_Submit",
+            "T_Run",
+            "T_Inactive",
+            "Nodes",
+            "R",
+        ],
+    )
+    pd.set_option("max_colwidth", 100)
+    pd.set_option("display.float_format", lambda x: "%.5f" % x)
+    print(dataframe)
+
+
+class JobRecord(object):
+    """
+    A record of an individual job.
+    """
+
+    def __init__(self, userid, username, jobid, t_submit, t_run, t_inactive, nnodes, R):
+        self.userid = userid
+        self.username = get_username(userid)
+        self.jobid = jobid
+        self.t_submit = t_submit
+        self.t_run = t_run
+        self.t_inactive = t_inactive
+        self.nnodes = nnodes
+        self.R = R
+        return None
+
+    @property
+    def elapsed(self):
+        return time.mktime(self.t_inactive) - time.mktime(self.t_run)
+
+    @property
+    def queued(self):
+        return time.mktime(self.t_run) - time.mktime(self.t_submit)
+
+
+def add_job_records(dataframe):
+    job_records = []
+
+    for index, row in dataframe.iterrows():
+        job_record = JobRecord(
+            row["userid"],
+            get_username(row["userid"]),
+            row["id"],
+            row["t_submit"],
+            row["t_run"],
+            row["t_inactive"],
+            count_ranks(row["ranks"]),
+            row["R"],
+        )
+        job_records.append(job_record)
+
+    return job_records
+
+
+def view_jobs_run_by_username(conn, username, output_file):
+    # look up userid with username
+    userid = get_uid(username)
+    # get the information pertaining to a user in the jobs DB
+    select_stmt = (
+        "SELECT userid,id,t_submit,t_run,t_inactive,ranks,R FROM jobs where userid=?"
+    )
+    dataframe = pd.read_sql_query(select_stmt, conn, params=(userid,))
+    # if the length of dataframe is 0, that means
+    # the user specified was not found in the table
+    if len(dataframe.index) == 0:
+        return "User not found in jobs table"
+    else:
+        job_records = add_job_records(dataframe)
+        if output_file is None:
+            print_job_records(job_records)
+        else:
+            write_records_to_file(job_records, output_file)
+
+    return job_records
+
+
+def view_jobs_with_jobid(conn, jobid, output_file):
+    # get the information pertaining to a job in the jobs DB
+    select_stmt = (
+        "SELECT userid,id,t_submit,t_run,t_inactive,ranks,R FROM jobs where id=?"
+    )
+    dataframe = pd.read_sql_query(select_stmt, conn, params=(jobid,))
+    # if the length of dataframe is 0, that means
+    # the jobid specified was not found in the table
+    if len(dataframe.index) == 0:
+        return "Job not found in jobs table"
+    else:
+        job_records = add_job_records(dataframe)
+        if output_file is None:
+            print_job_records(job_records)
+        else:
+            write_records_to_file(job_records, output_file)
+
+    return job_records
+
+
+def view_jobs_after_start_time(conn, time_after, output_file):
+    # get jobs that have completed after a certain time
+    select_stmt = (
+        "SELECT userid,id,t_submit,t_run,t_inactive,ranks,R FROM jobs WHERE t_run > ?"
+    )
+    dataframe = pd.read_sql_query(select_stmt, conn, params=(time_after,))
+    # if the length of dataframe is 0, that means
+    # the time specified resulted in no jobs found
+    if len(dataframe.index) == 0:
+        return "No jobs found after time specified"
+    else:
+        job_records = add_job_records(dataframe)
+        if output_file is None:
+            print_job_records(job_records)
+        else:
+            write_records_to_file(job_records, output_file)
+
+    return job_records
+
+
+def view_jobs_before_end_time(conn, time_before, output_file):
+    # get jobs that have completed before a certain time
+    select_stmt = "SELECT userid,id,t_submit,t_run,t_inactive,ranks,R FROM jobs WHERE t_inactive < ?"
+    dataframe = pd.read_sql_query(select_stmt, conn, params=(time_before,))
+    # if the length of dataframe is 0, that means
+    # the time specified resulted in no jobs found
+    if len(dataframe.index) == 0:
+        return "No jobs found before time specified"
+    else:
+        job_records = add_job_records(dataframe)
+        if output_file is None:
+            print_job_records(job_records)
+        else:
+            write_records_to_file(job_records, output_file)
+
+    return job_records
 
 
 def view_user(conn, user):

--- a/test/test_accounting_cli.py
+++ b/test/test_accounting_cli.py
@@ -19,36 +19,121 @@ from accounting import create_db as c
 
 
 class TestAccountingCLI(unittest.TestCase):
-    # create database
+    # create accounting, job-archive databases
     @classmethod
     def setUpClass(self):
+        # create example accounting database
         c.create_db("FluxAccounting.db")
-        global conn
-        conn = sqlite3.connect("FluxAccounting.db")
+        global acct_conn
+        global jobs_conn
+        acct_conn = sqlite3.connect("FluxAccounting.db")
+
+        # create example job-archive database, output file
+        global op
+        op = "job_records.csv"
+        jobs_conn = sqlite3.connect("file:jobs.db?mode:rwc", uri=True)
+        jobs_conn.execute(
+            """
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id            int       NOT NULL,
+                    userid        int       NOT NULL,
+                    username      text      NOT NULL,
+                    ranks         text      NOT NULL,
+                    t_submit      real      NOT NULL,
+                    t_sched       real      NOT NULL,
+                    t_run         real      NOT NULL,
+                    t_cleanup     real      NOT NULL,
+                    t_inactive    real      NOT NULL,
+                    eventlog      text      NOT NULL,
+                    jobspec       text      NOT NULL,
+                    R             text      NOT NULL,
+                    PRIMARY KEY   (id)
+            );"""
+        )
+
+        # add sample jobs to job-archive database
+        id = 100
+        userid = 1234
+        username = "user" + str(userid)
+        t_submit = 1000
+        t_sched = 1005
+        t_run = 1010
+        t_cleanup = 1015
+        t_inactive = 1020
+        for i in range(4):
+            try:
+                jobs_conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        id,
+                        userid,
+                        username,
+                        ranks,
+                        t_submit,
+                        t_sched,
+                        t_run,
+                        t_cleanup,
+                        t_inactive,
+                        eventlog,
+                        jobspec,
+                        R
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        id,
+                        userid,
+                        username,
+                        "0",
+                        t_submit,
+                        t_sched,
+                        t_run,
+                        t_cleanup,
+                        t_inactive,
+                        "eventlog",
+                        "jobspec",
+                        '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
+                    ),
+                )
+                # commit changes
+                jobs_conn.commit()
+            # make sure entry is unique
+            except sqlite3.IntegrityError as integrity_error:
+                print(integrity_error)
+            id += 1
+            userid += 1000
+            username = "user" + str(userid)
+            t_submit += 1000
+            t_sched += 1000
+            t_run += 1000
+            t_cleanup += 1000
+            t_inactive += 1000
 
     # add a valid user to association_table
     def test_01_add_valid_user(self):
-        aclif.add_user(conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
 
-        cursor = conn.cursor()
+        cursor = acct_conn.cursor()
         num_rows = cursor.execute("DELETE FROM association_table").rowcount
         self.assertEqual(num_rows, 1)
 
     # adding a user with the same primary key (user_name, account) should
     # return an IntegrityError
     def test_02_add_duplicate_primary_key(self):
-        aclif.add_user(conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
 
-        aclif.add_user(conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
 
         self.assertRaises(sqlite3.IntegrityError)
 
     # adding a user with the same username BUT a different account should
     # succeed
     def test_03_add_duplicate_user(self):
-        aclif.add_user(conn, "dup_user", "1", "acct", "pacct", "10", "100", "60")
-        aclif.add_user(conn, "dup_user", "1", "other_acct", "pacct", "10", "100", "60")
-        cursor = conn.cursor()
+        aclif.add_user(acct_conn, "dup_user", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(
+            acct_conn, "dup_user", "1", "other_acct", "pacct", "10", "100", "60"
+        )
+        cursor = acct_conn.cursor()
         cursor.execute("SELECT * from association_table where user_name='dup_user'")
         num_rows = cursor.execute(
             "DELETE FROM association_table where user_name='dup_user'"
@@ -57,8 +142,8 @@ class TestAccountingCLI(unittest.TestCase):
 
     # edit a value for a user in the association table
     def test_04_edit_user_value(self):
-        aclif.edit_user(conn, "fluxuser", "max_jobs", "10000")
-        cursor = conn.cursor()
+        aclif.edit_user(acct_conn, "fluxuser", "max_jobs", "10000")
+        cursor = acct_conn.cursor()
         cursor.execute(
             "SELECT max_jobs FROM association_table where user_name='fluxuser'"
         )
@@ -69,16 +154,80 @@ class TestAccountingCLI(unittest.TestCase):
     # exist should return an OperationalError
     def test_05_edit_bad_field(self):
         with self.assertRaises(SystemExit) as cm:
-            aclif.edit_user(conn, "fluxuser", "foo", "bar")
+            aclif.edit_user(acct_conn, "fluxuser", "foo", "bar")
 
         self.assertEqual(cm.exception.code, 1)
 
-    # remove database and log file
+    # passing a valid jobid should return
+    # its job information
+    def test_06_with_jobid_valid(self):
+        job_records = aclif.view_jobs_with_jobid(jobs_conn, 102, op)
+        self.assertEqual(len(job_records), 1)
+
+    # passing a bad jobid should return a
+    # failure message
+    def test_07_with_jobid_failure(self):
+        job_records = aclif.view_jobs_with_jobid(jobs_conn, 000, op)
+        self.assertEqual(job_records, "Job not found in jobs table")
+
+    # passing a timestamp before the first job to
+    # start should return all of the jobs
+    def test_08_after_start_time_all(self):
+        job_records = aclif.view_jobs_after_start_time(jobs_conn, 0, op)
+        self.assertEqual(len(job_records), 4)
+
+    # passing a timestamp in the middle should return
+    # only some of the jobs
+    def test_09_after_start_time_some(self):
+        job_records = aclif.view_jobs_after_start_time(jobs_conn, 2500, op)
+        self.assertEqual(len(job_records), 2)
+
+    # passing a timestamp after all of the start time
+    # of all the completed jobs should return a failure message
+    def test_10_after_start_time_none(self):
+        job_records = aclif.view_jobs_after_start_time(jobs_conn, 10000, op)
+        self.assertEqual(job_records, "No jobs found after time specified")
+
+    # passing a timestamp after the end time of the
+    # last job should return all of the jobs
+    def test_11_before_end_time_all(self):
+        job_records = aclif.view_jobs_before_end_time(jobs_conn, 5000, op)
+        self.assertEqual(len(job_records), 4)
+
+    # passing a timestamp in the middle should return
+    # only some of the jobs
+    def test_12_before_end_time_some(self):
+        job_records = aclif.view_jobs_before_end_time(jobs_conn, 3000, op)
+        self.assertEqual(len(job_records), 2)
+
+    # passing a timestamp before the end time of
+    # all the completed jobs should return a failure message
+    def test_13_before_end_time_none(self):
+        job_records = aclif.view_jobs_before_end_time(jobs_conn, 0, op)
+        self.assertEqual(job_records, "No jobs found before time specified")
+
+    # passing a user not in the jobs table
+    # should return a failure message
+    def test_14_by_user_failure(self):
+        job_records = aclif.view_jobs_run_by_username(jobs_conn, "9999", op)
+        self.assertEqual(job_records, "User not found in jobs table")
+
+    # view_jobs_run_by_username() interacts with a
+    # passwd file; for the purpose of these tests,
+    # just pass the userid
+    def test_15_by_user_success(self):
+        job_records = aclif.view_jobs_run_by_username(jobs_conn, "1234", op)
+        self.assertEqual(len(job_records), 1)
+
+    # remove databases, log file, and output file
     @classmethod
     def tearDownClass(self):
-        conn.close()
+        acct_conn.close()
+        jobs_conn.close()
         os.remove("FluxAccounting.db")
         os.remove("db_creation.log")
+        os.remove("jobs.db")
+        os.remove("job_records.csv")
 
 
 def suite():
@@ -88,6 +237,16 @@ def suite():
     suite.addTest(TestAccountingCLI("test_03_add_duplicate_user"))
     suite.addTest(TestAccountingCLI("test_04_edit_user_value"))
     suite.addTest(TestAccountingCLI("test_05_edit_bad_field"))
+    suite.addTest(TestAccountingCLI("test_06_with_jobid_valid"))
+    suite.addTest(TestAccountingCLI("test_07_with_jobid_failure"))
+    suite.addTest(TestAccountingCLI("test_08_after_start_time_all"))
+    suite.addTest(TestAccountingCLI("test_09_after_start_time_some"))
+    suite.addTest(TestAccountingCLI("test_10_after_start_time_none"))
+    suite.addTest(TestAccountingCLI("test_11_before_end_time_all"))
+    suite.addTest(TestAccountingCLI("test_12_before_end_time_some"))
+    suite.addTest(TestAccountingCLI("test_13_before_end_time_none"))
+    suite.addTest(TestAccountingCLI("test_14_by_user_failure"))
+    suite.addTest(TestAccountingCLI("test_15_by_user_success"))
 
     return suite
 


### PR DESCRIPTION
The power finally came back on at my place! I can continue where I left off before mother nature so rudely interrupted me 😅

**Problem**: flux-core's job-archive currently stores job records in a SQLite database that can be viewed and queried with SQLite commands: 

```
sqlite> select userid,id,t_submit,t_run,t_inactive,ranks,R from jobs;
userid      id            t_submit         t_run            t_inactive        ranks       R                                                                            
----------  ------------  ---------------  ---------------  ----------------  ----------  -----------------------------------------------------------------------------
2001        429932937216  1597722545.7235  1597722545.7498  1597722545.83819  0           {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0-2"}}]}}
2001        408659427328  1597722544.4558  1597722544.4830  1597722544.58507  0           {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0-2"}}]}}
2001        340007059456  1597722540.3639  1597722540.3879  1597722540.46995  0           {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0-1"}}]}}
2001        319857623040  1597722539.1629  1597722539.1850  1597722539.27435  0           {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0-1"}}]}}
2001        256154533888  1597722535.3659  1597722535.3874  1597722535.4645   0           {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0"}}]}}  
2001        241961009152  1597722534.5195  1597722534.5461  1597722534.63193  0           {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0"}}]}} 
```

From talks with Ryan Day, it would be preferable to have some sort of front-end interface to this database to extract job records and group them by various options.  

---

This PR looks to add a front end to the job-archive so that job records can be queried without having to go into a SQLite shell and write SQL queries. The following subcommands have been added:

- **by-user**: allows a user to fetch all job records from a certain username
- **by-jobid**: allows user to fetch job information from a certain jobid
- **after-start-time**: allows a user to fetch job records after a certain start time
- **before-end-time**: allows a user to fetch job records before a certain end time

Each of the subcommands query the job-archive and add matching entries to a list of `JobRecord`s, which have the following structure:

```python
class JobRecord(object):
    """
    A record of an individual job.
    """

    def __init__(self, userid, username, jobid, t_submit, t_run, t_inactive, nnodes, R):
        self.userid = userid
        self.username = get_username(userid)
        self.jobid = jobid
        self.t_submit = t_submit
        self.t_run = t_run
        self.t_inactive = t_inactive
        self.nnodes = nnodes
        self.R = R
        return None

    @property
    def elapsed(self):
        return time.mktime(self.t_inactive) - time.mktime(self.t_run)

    @property
    def queued(self):
        return time.mktime(self.t_run) - time.mktime(self.t_submit)
```

These job records get written to a .csv file that can be specified on the command line; if no path is passed, the records get printed out to the screen in a `Dataframe` format:

```
$ flux account -p /var/lib/flux/jobs.db -o /var/lib/flux/job_records.csv by-user fluxuser
```

OR 

```
$ flux account -p /var/lib/flux/jobs.db by-user fluxuser
   UserID  Username         JobID         T_Submit            T_Run       T_Inactive  Nodes                                                                            R
0    2001  fluxuser  410739802112 1598469186.39630 1598469186.41970 1598469186.49578      1  {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0"}}]}}
1    2001  fluxuser  379114749952 1598469184.51090 1598469184.53045 1598469184.60123      1  {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0"}}]}}
2    2001  fluxuser  353646936064 1598469182.99277 1598469183.01287 1598469183.08738      1  {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0"}}]}}
3    2001  fluxuser  292040998912 1598469179.32122 1598469179.34539 1598469179.43041      1  {"version":1,"execution":{"R_lite":[{"rank":"0","children":{"core":"0"}}]}}
```

Some notes:

The **nnodes** field is counted by reading the `ranks` field from the job-archive. It makes the assumption that each rank is associated with one node. We discussed in a coffee time (thanks @SteVwonder, @grondo, and @garlick for your input) that it is okay to make this assumption for now. 

Fixes #30 