### PR TITLE
create_db.py: add bank table to Flux Accounting database 

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -141,6 +141,12 @@ def main():
         "bank", help="bank name", metavar="BANK",
     )
 
+    subparser_delete_bank = subparsers.add_parser("delete-bank", help="remove a bank")
+    subparser_delete_bank.set_defaults(func="delete_bank")
+    subparser_delete_bank.add_argument(
+        "bank", help="bank name", metavar="BANK",
+    )
+
     args = parser.parse_args()
 
     # if we are creating the DB for the first time, we need
@@ -187,6 +193,8 @@ def main():
             aclif.view_jobs_before_end_time(conn, args.end_time, args.output_file)
         elif args.func == "view_bank":
             aclif.view_bank(conn, args.bank)
+        elif args.func == "delete_bank":
+            aclif.delete_bank(conn, args.bank)
         else:
             print(parser.print_usage())
     finally:

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -61,9 +61,6 @@ def main():
         "--account", help="account to charge jobs against", metavar="ACCOUNT",
     )
     subparser_add_user.add_argument(
-        "--parent-acct", help="parent account", default="", metavar="PARENT_ACCOUNT",
-    )
-    subparser_add_user.add_argument(
         "--shares", help="shares", default=1, metavar="SHARES",
     )
     subparser_add_user.add_argument(
@@ -164,7 +161,6 @@ def main():
                 args.username,
                 args.admin_level,
                 args.account,
-                args.parent_acct,
                 args.shares,
                 args.max_jobs,
                 args.max_wall_pj,

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -147,6 +147,17 @@ def main():
         "bank", help="bank name", metavar="BANK",
     )
 
+    subparser_edit_bank = subparsers.add_parser(
+        "edit-bank", help="edit a bank's allocation"
+    )
+    subparser_edit_bank.set_defaults(func="edit_bank")
+    subparser_edit_bank.add_argument(
+        "bank", help="bank", metavar="BANK",
+    )
+    subparser_edit_bank.add_argument(
+        "--shares", help="new shares value", metavar="SHARES",
+    )
+
     args = parser.parse_args()
 
     # if we are creating the DB for the first time, we need
@@ -195,6 +206,8 @@ def main():
             aclif.view_bank(conn, args.bank)
         elif args.func == "delete_bank":
             aclif.delete_bank(conn, args.bank)
+        elif args.func == "edit_bank":
+            aclif.edit_bank(conn, args.bank, args.shares)
         else:
             print(parser.print_usage())
     finally:

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -133,6 +133,14 @@ def main():
         "dbpath", help="specify location of database file", metavar=("DATABASE PATH")
     )
 
+    subparser_view_bank = subparsers.add_parser(
+        "view-bank", help="view bank information"
+    )
+    subparser_view_bank.set_defaults(func="view_bank")
+    subparser_view_bank.add_argument(
+        "bank", help="bank name", metavar="BANK",
+    )
+
     args = parser.parse_args()
 
     # if we are creating the DB for the first time, we need
@@ -177,6 +185,8 @@ def main():
             aclif.view_jobs_after_start_time(conn, args.start_time, args.output_file)
         elif args.func == "view_jobs_before_end_time":
             aclif.view_jobs_before_end_time(conn, args.end_time, args.output_file)
+        elif args.func == "view_bank":
+            aclif.view_bank(conn, args.bank)
         else:
             print(parser.print_usage())
     finally:

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -61,6 +61,9 @@ def main():
         "--account", help="account to charge jobs against", metavar="ACCOUNT",
     )
     subparser_add_user.add_argument(
+        "--parent-acct", help="parent account", default="", metavar="PARENT_ACCOUNT",
+    )
+    subparser_add_user.add_argument(
         "--shares", help="shares", default=1, metavar="SHARES",
     )
     subparser_add_user.add_argument(
@@ -131,6 +134,18 @@ def main():
     subparser_create_db.set_defaults(func="create_db")
     subparser_create_db.add_argument(
         "dbpath", help="specify location of database file", metavar=("DATABASE PATH")
+    )
+
+    subparser_add_bank = subparsers.add_parser("add-bank", help="add a new bank")
+    subparser_add_bank.set_defaults(func="add_bank")
+    subparser_add_bank.add_argument(
+        "bank", help="bank name", metavar="BANK",
+    )
+    subparser_add_bank.add_argument(
+        "--parent-bank", help="parent bank name", default="", metavar="PARENT BANK"
+    )
+    subparser_add_bank.add_argument(
+        "shares", help="number of shares to allocate to bank", metavar="SHARES"
     )
 
     subparser_view_bank = subparsers.add_parser(
@@ -207,6 +222,8 @@ def main():
             aclif.view_jobs_after_start_time(conn, args.start_time, args.output_file)
         elif args.func == "view_jobs_before_end_time":
             aclif.view_jobs_before_end_time(conn, args.end_time, args.output_file)
+        elif args.func == "add_bank":
+            aclif.add_bank(conn, args.bank, args.shares, args.parent_bank)
         elif args.func == "view_bank":
             aclif.view_bank(conn, args.bank)
         elif args.func == "delete_bank":

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -158,6 +158,11 @@ def main():
         "--shares", help="new shares value", metavar="SHARES",
     )
 
+    subparser_print_hierarchy = subparsers.add_parser(
+        "print-hierarchy", help="print accounting database"
+    )
+    subparser_print_hierarchy.set_defaults(func="print_hierarchy")
+
     args = parser.parse_args()
 
     # if we are creating the DB for the first time, we need
@@ -208,6 +213,8 @@ def main():
             aclif.delete_bank(conn, args.bank)
         elif args.func == "edit_bank":
             aclif.edit_bank(conn, args.bank, args.shares)
+        elif args.func == "print_hierarchy":
+            aclif.print_hierarchy(conn)
         else:
             print(parser.print_usage())
     finally:

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -263,9 +263,7 @@ def view_user(conn, user):
         print(e_database_error)
 
 
-def add_user(
-    conn, username, admin_level, account, parent_acct, shares, max_jobs, max_wall_pj
-):
+def add_user(conn, username, admin_level, account, shares, max_jobs, max_wall_pj):
 
     # insert the user values into the database
     try:
@@ -278,12 +276,11 @@ def add_user(
                 user_name,
                 admin_level,
                 account,
-                parent_acct,
                 shares,
                 max_jobs,
                 max_wall_pj
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -292,7 +289,6 @@ def add_user(
                 username,
                 admin_level,
                 account,
-                parent_acct,
                 shares,
                 max_jobs,
                 max_wall_pj,
@@ -319,7 +315,6 @@ def edit_user(conn, username, field, new_value):
         "user_name",
         "admin_level",
         "account",
-        "parent_acct",
         "shares",
         "max_jobs",
         "max_wall_pj",

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -275,6 +275,46 @@ def delete_bank(conn, bank):
     conn.commit()
 
 
+def edit_bank(conn, bank, shares):
+    total_sub_bank_shares = 0
+    parent_bank = ""
+    parent_bank_shares = 0
+    try:
+        # if bank is a parent bank, the new value
+        # should not be less than the total shares
+        # allocated to all sub banks
+        select_stmt = "SELECT shares FROM bank_table WHERE parent_bank=?"
+        dataframe = pd.read_sql_query(select_stmt, conn, params=(bank,))
+        for index, row in dataframe.iterrows():
+            total_sub_bank_shares += row["shares"]
+        if int(shares) < total_sub_bank_shares:
+            print(
+                "New shares amount would be less than total shares allocated to subaccounts"
+            )
+            sys.exit(-1)
+        # if bank is a sub bank, the new value
+        # should not be greater than its parent bank
+        select_stmt = "SELECT parent_bank FROM bank_table WHERE bank=?"
+        dataframe = pd.read_sql_query(select_stmt, conn, params=(bank,))
+        for index, row in dataframe.iterrows():
+            parent_bank = row["parent_bank"]
+        # if bank specified does not have a parent bank, just continue
+        if parent_bank != "":
+            check_parent_bank(conn, shares, parent_bank)
+        else:
+            pass
+
+    except pd.io.sql.DatabaseError as e_database_error:
+        print(e_database_error)
+
+    # edit value in bank_table
+    conn.execute(
+        "UPDATE bank_table SET shares=? WHERE bank=?", (shares, bank,),
+    )
+    # commit changes
+    conn.commit()
+
+
 def view_user(conn, user):
     try:
         # get the information pertaining to a user in the Accounting DB

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -248,6 +248,21 @@ def view_jobs_before_end_time(conn, time_before, output_file):
     return job_records
 
 
+def view_bank(conn, bank):
+    try:
+        # get the information pertaining to a bank in the Accounting DB
+        select_stmt = "SELECT * FROM bank_table where bank=?"
+        dataframe = pd.read_sql_query(select_stmt, conn, params=(bank,))
+        # if the length of dataframe is 0, that means
+        # the bank specified was not found in the table
+        if len(dataframe.index) == 0:
+            print("Bank not found in bank_table")
+        else:
+            print(dataframe)
+    except pd.io.sql.DatabaseError as e_database_error:
+        print(e_database_error)
+
+
 def view_user(conn, user):
     try:
         # get the information pertaining to a user in the Accounting DB

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -263,6 +263,18 @@ def view_bank(conn, bank):
         print(e_database_error)
 
 
+def delete_bank(conn, bank):
+    last_parent_bank_seen = bank
+
+    # delete bank from bank_table
+    delete_stmt = "DELETE FROM bank_table WHERE bank=?"
+    cursor = conn.cursor()
+    cursor.execute(delete_stmt, (bank,))
+
+    # commit changes
+    conn.commit()
+
+
 def view_user(conn, user):
     try:
         # get the information pertaining to a user in the Accounting DB

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -248,6 +248,79 @@ def view_jobs_before_end_time(conn, time_before, output_file):
     return job_records
 
 
+def check_parent_bank(conn, shares, parent_bank):
+    select_stmt = "SELECT shares FROM bank_table where bank=?"
+    dataframe = pd.read_sql_query(select_stmt, conn, params=(parent_bank,))
+    # if length of dataframe is 0, that means the parent bank wasn't found
+    if len(dataframe.index) == 0:
+        print("Parent account not found in bank table")
+        sys.exit(-1)
+    # fetch parent account from account
+    for index, row in dataframe.iterrows():
+        parent_bank_shares = row["shares"]
+    if int(shares) > int(parent_bank_shares):
+        print("Shares must not be greater than parent account's shares")
+        sys.exit(-1)
+
+    return parent_bank_shares
+
+
+def add_bank(conn, bank, shares, parent_bank=""):
+    parent_bank_shares = 0
+    total_sub_bank_shares = 0
+
+    # if the parent bank is not "", that means the account
+    # trying to be added wants to be placed under a parent bank
+    if parent_bank != "":
+        try:
+            parent_bank_shares = check_parent_bank(conn, shares, parent_bank)
+
+            select_stmt = "SELECT shares FROM bank_table where parent_bank=?"
+            dataframe = pd.read_sql_query(select_stmt, conn, params=(parent_bank,))
+            # if length of dataframe is 0, that means there are no sub banks for
+            # this parent bank
+            if len(dataframe.index) == 0:
+                pass
+            # add up all of the shares allocated to this parent's sub banks
+            else:
+                for index, row in dataframe.iterrows():
+                    total_sub_bank_shares += row["shares"]
+            # if the total amount of shares in all the sub banks is
+            # equal to the parent bank's shares, it has already reached
+            # its max allocation, and thus the bank won't be added
+            if int(total_sub_bank_shares) >= int(parent_bank_shares):
+                print("Total shares for parent account are already maxed")
+                sys.exit(-1)
+            # if the current total amount of shares in all the sub banks
+            # PLUS the number of shares trying to be added is greater than the
+            # parent's banks shares, the parent account WILL exceed its max
+            # allocation and thus the account won't be added
+            if int(total_sub_bank_shares) + int(shares) > int(parent_bank_shares):
+                print("Total shares will exceed parent account's allocation")
+                sys.exit(-1)
+        except pd.io.sql.DatabaseError as e_database_error:
+            print(e_database_error)
+
+    # insert the bank values into the database
+    try:
+        conn.execute(
+            """
+            INSERT INTO bank_table (
+                bank,
+                parent_bank,
+                shares
+            )
+            VALUES (?, ?, ?)
+            """,
+            (bank, parent_bank, shares),
+        )
+        # commit changes
+        conn.commit()
+    # make sure entry is unique
+    except sqlite3.IntegrityError as integrity_error:
+        print(integrity_error)
+
+
 def view_bank(conn, bank):
     try:
         # get the information pertaining to a bank in the Accounting DB

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -44,4 +44,18 @@ def create_db(filepath):
     )
     logging.info("Created association_table successfully")
 
+    # Bank Table
+    logging.info("Creating bank_table in DB...")
+    conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS bank_table (
+                bank            text    NOT NULL,
+                parent_bank     text,
+                shares          int     NOT NULL,
+                PRIMARY KEY     (bank)
+
+        );"""
+    )
+    logging.info("Created bank_table successfully")
+
     conn.close()

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -36,7 +36,6 @@ def create_db(filepath):
                 user_name     tinytext              NOT NULL,
                 admin_level   smallint(6) DEFAULT 1 NOT NULL,
                 account       tinytext              NOT NULL,
-                parent_acct   tinytext              NOT NULL,
                 shares        int(11)     DEFAULT 1 NOT NULL,
                 max_jobs      int(11)               NOT NULL,
                 max_wall_pj   int(11)               NOT NULL,

--- a/test/test_accounting_cli.py
+++ b/test/test_accounting_cli.py
@@ -111,7 +111,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # add a valid user to association_table
     def test_01_add_valid_user(self):
-        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
 
         cursor = acct_conn.cursor()
         num_rows = cursor.execute("DELETE FROM association_table").rowcount
@@ -120,19 +120,17 @@ class TestAccountingCLI(unittest.TestCase):
     # adding a user with the same primary key (user_name, account) should
     # return an IntegrityError
     def test_02_add_duplicate_primary_key(self):
-        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
 
-        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "pacct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
 
         self.assertRaises(sqlite3.IntegrityError)
 
     # adding a user with the same username BUT a different account should
     # succeed
     def test_03_add_duplicate_user(self):
-        aclif.add_user(acct_conn, "dup_user", "1", "acct", "pacct", "10", "100", "60")
-        aclif.add_user(
-            acct_conn, "dup_user", "1", "other_acct", "pacct", "10", "100", "60"
-        )
+        aclif.add_user(acct_conn, "dup_user", "1", "acct", "10", "100", "60")
+        aclif.add_user(acct_conn, "dup_user", "1", "other_acct", "10", "100", "60")
         cursor = acct_conn.cursor()
         cursor.execute("SELECT * from association_table where user_name='dup_user'")
         num_rows = cursor.execute(

--- a/test/test_create_db.py
+++ b/test/test_create_db.py
@@ -18,44 +18,47 @@ from accounting import create_db as c
 
 
 class TestDB(unittest.TestCase):
+    # create database
+    @classmethod
+    def setUpClass(self):
+        c.create_db("FluxAccounting.db")
+        global conn
+        conn = sqlite3.connect("FluxAccounting.db")
+
     # create database and make sure it exists
     def test_00_test_create_db(self):
-        c.create_db("FluxAccounting.db")
-
         assert os.path.exists("FluxAccounting.db")
 
     # make sure association table exists
     def test_01_user_table_exists(self):
-        with sqlite3.connect("FluxAccounting.db") as db:
-            cursor = db.cursor()
-            cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
-            tables = cursor.fetchall()
-            list_of_tables = []
-            for table_name in tables:
-                table_name = table_name[0]
-                list_of_tables.append(table_name)
-                table = pd.read_sql_query("SELECT * from %s" % table_name, db)
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = cursor.fetchall()
+        list_of_tables = []
+        for table_name in tables:
+            table_name = table_name[0]
+            list_of_tables.append(table_name)
+            table = pd.read_sql_query("SELECT * from %s" % table_name, conn)
 
-        expected = "association_table"
-        test = list_of_tables[0]
+        expected = ["association_table"]
+        test = list_of_tables[:1]
         self.assertEqual(test, expected)
 
     # add an association to the association_table
     def test_02_create_association(self):
-        with sqlite3.connect("FluxAccounting.db") as db:
-            db.execute(
-                """
-            INSERT INTO association_table
-            (creation_time, mod_time, deleted, user_name, admin_level,
-            account, parent_acct, shares, max_jobs, max_wall_pj)
-            VALUES
-            (0, 0, 0, "test user", 1, "test account", "parent account", 0, 0,
-            0)
-            """
-            )
-            cursor = db.cursor()
-            num_rows = cursor.execute("DELETE FROM association_table").rowcount
-            self.assertEqual(num_rows, 1)
+        conn.execute(
+        """
+        INSERT INTO association_table
+        (creation_time, mod_time, deleted, user_name, admin_level,
+        account, shares, max_jobs, max_wall_pj)
+        VALUES
+        (0, 0, 0, "test user", 1, "test account", 0, 0,
+        0)
+        """
+        )
+        cursor = conn.cursor()
+        num_rows = cursor.execute("DELETE FROM association_table").rowcount
+        self.assertEqual(num_rows, 1)
 
     # remove database file
     @classmethod


### PR DESCRIPTION
This is the other PR related to the [end-of-August milestone](https://github.com/flux-framework/flux-accounting/milestone/1).

**Problem**: Currently there is only one table in the flux-accounting database, `association table`, that stores user account information. One of the fields in every record in this table is an _account_ and optional _parent account_ field, which associates a user with an account they can charge jobs against. There is no information on the the account itself, however, such as information related to how many shares it gets on a machine.

---

The first part of this PR removes the _parent_acct_ field from `association_table`, since that information would now be captured as the _parent_bank_ field in `bank_table`. 

The second part looks to add a second table to the flux-accounting database, called `bank_table`. It stores bank names and information on how many shares are allocated to each bank. There are only three fields in the bank table:

```
bank            text    NOT NULL,
parent_bank     text,
shares          int     NOT NULL,
PRIMARY KEY     (bank)
```

With the addition of this new table, a new set of subcommands were added to `flux account` to be able to interact with it:

- `add-bank`: allows the addition and definition of banks, any sub-banks, and their allocated shares.

- `view-bank`: allows user to view bank information.

- `delete-bank`: allows the deletion of a bank. If the bank specified is a parent bank, it will delete all of its sub banks as well.

- `edit-bank`: allows editing of bank allocations.

- `print-hierarchy`: prints all banks, sub banks, and users associated with those banks via a `JOIN` operation between `association_table` and `bank_table` (where the _account_ field in `association_table` is equal to the _bank_ field in `bank_table`).   

Fixes #32 