### PR TITLE
accounting_cli.py: add create-db subcommand

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -17,6 +17,7 @@ import sys
 import pandas as pd
 
 from accounting import accounting_cli_functions as aclif
+from accounting import create_db as c
 
 
 def main():
@@ -127,7 +128,21 @@ def main():
         "end_time", help="end time", metavar="END TIME",
     )
 
+    subparser_create_db = subparsers.add_parser(
+        "create-db", help="create the flux-accounting database"
+    )
+    subparser_create_db.set_defaults(func="create_db")
+    subparser_create_db.add_argument(
+        "dbpath", help="specify location of database file", metavar=("DATABASE PATH")
+    )
+
     args = parser.parse_args()
+
+    # if we are creating the DB for the first time, we need
+    # to ONLY create the DB and then exit out successfully
+    if args.func == "create_db":
+        c.create_db(args.dbpath)
+        sys.exit(0)
 
     # try to open database file; will exit with -1 if database file not found
     path = args.path if args.path else "FluxAccounting.db"

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -46,30 +46,3 @@ def create_db(filepath):
     logging.info("Created association_table successfully")
 
     conn.close()
-
-
-def main():
-
-    parser = argparse.ArgumentParser(
-        description="""
-        Description: Create flux-accounting database to store
-        user account information.
-        """
-    )
-
-    parser.add_argument(
-        "-p", "--path", dest="path", help="specify location of database file"
-    )
-
-    args = parser.parse_args()
-
-    path = args.path if args.path else "FluxAccounting.db"
-    try:
-        create_db(path)
-    except sqlite3.OperationalError as e:
-        print("Unable to create database file:", e)
-        sys.exit(-1)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This PR would probably be nice to land before our end-of-August release deadline as well. :-)

**Problem**: As mentioned in #35, in order to initially create the flux-accounting database, you have to go into the `flux-accounting` directory and call the `create_db.py` script directly:

```
[flux-framework/flux-accounting/accounting] $ ./create_db.py -p path/to/FluxAccounting.db
```

---

This PR removes `main()` from **create_db.py** and instead adds a new subcommand to **accounting_cli.py**:  `create-db`, which creates **FluxAccounting.db**. It takes one argument, the path to the database file.

```
$ flux account create-db path/to/FluxAccounting.db
```

Keeping the same behavior as before, ownership of the directory that the database file is placed in is required for the database to be created.

Fixes #35