### PR TITLE
add flux-accounting v0.2.0 release notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+flux-accounting version 0.2.0 - 2020-08-31
+------------------------------------------
+
+This release adds a new table to the flux-accounting database and a front end to flux-core's job-archive.
+
+#### Features
+
+* Add a new table `bank_table` that stores bank information for users to charge jobs against.
+
+* Add a front-end interface to flux-core's job-archive to fetch job record information and sort it with customizable parameters, such as by username, before or after a specific time, or with a specific job ID.
+
 flux-accounting version 0.1.0 - 2020-07-29
 ------------------------------------------
 
@@ -8,4 +19,4 @@ Initial release.
 * Create an accounting database which stores user account information. Can interact with database through SQLite shell or
 through a command line interface to add and remove users, edit account values, and view account information.
 
-* Add **Makefile** to allow flux-accounting to be installed alongside flux-core so that flux-accounting commands can be picked up by Flux's command driver. 
+* Add **Makefile** to allow flux-accounting to be installed alongside flux-core so that flux-accounting commands can be picked up by Flux's command driver.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Successfully built f29dd2ca5958
 
 ### User Account Information
 
-The accounting table in this database stores information like user name and ID, the account to submit jobs against, an optional parent account, the shares allocated to the user, as well as static limits, including max jobs submitted per user at a given time and max wall time per job per user.
+The accounting table in this database stores information like user name and ID, the account to submit jobs against, the shares allocated to the user, as well as static limits, including max jobs submitted per user at a given time and max wall time per job per user.
 
 ### Interacting With the Accounting DB
 
@@ -119,7 +119,7 @@ Connected to a transient in-memory database.
 Use ".open FILENAME" to reopen on a persistent database.
 
 sqlite> .tables
-association_table
+association_table bank_table
 ```
 
 To get nicely formatted output from queries (like headers for the tables and proper spacing), you can also set the following options in your shell:
@@ -133,9 +133,9 @@ This will output queries like the following:
 
 ```
 sqlite> SELECT * FROM association_table;
-creation_time  mod_time    deleted     user_name   admin_level  account     parent_acct  shares      max_jobs    max_wall_pj
--------------  ----------  ----------  ----------  -----------  ----------  -----------  ----------  ----------  -----------
-1589225734     1589225734  0           fluxuser    1            acct        pacct        10          100         60  
+creation_time  mod_time    deleted     user_name   admin_level  account     shares      max_jobs    max_wall_pj
+-------------  ----------  ----------  ----------  -----------  ----------  ----------  ----------  -----------
+1589225734     1589225734  0           fluxuser    1            acct        10          100         60  
 ```
 
 The second way is to use flux-accounting's command line arguments. You can pass in a path to the database file, or be in the same directory where the database file (**FluxAccounting.db**) is located:


### PR DESCRIPTION
This PR adds the release notes for flux-accounting v0.2.0. This PR should go in after #33, #34, and #36 land. 