### PR TITLE
bank_table: change primary key to a fixed data type

### DIFF
--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -45,15 +45,15 @@ def create_db(filepath):
     logging.info("Created association_table successfully")
 
     # Bank Table
+    # bank_id gets auto-incremented with every new entry
     logging.info("Creating bank_table in DB...")
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS bank_table (
-                bank            text    NOT NULL,
-                parent_bank     text,
-                shares          int     NOT NULL,
-                PRIMARY KEY     (bank)
-
+                bank_id     integer PRIMARY KEY,
+                bank        text    NOT NULL,
+                parent_bank text,
+                shares      int     NOT NULL
         );"""
     )
     logging.info("Created bank_table successfully")

--- a/test/test_create_db.py
+++ b/test/test_create_db.py
@@ -90,6 +90,13 @@ class TestDB(unittest.TestCase):
         dataframe = pd.read_sql_query(select_stmt, conn)
         self.assertEqual(len(dataframe.index), 2)
 
+    # let's make sure the bank id's get autoincremented
+    def test_05_check_bank_ids(self):
+        select_stmt = "SELECT bank_id FROM bank_table;"
+        dataframe = pd.read_sql_query(select_stmt, conn)
+        self.assertEqual(dataframe["bank_id"][0], 1)
+        self.assertEqual(dataframe["bank_id"][1], 2)
+
     # remove database file
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
As mentioned in #39, the current primary key for the `bank_table` is the name of the bank, whose data type is `text`, a variable data type. Instead, it is considered best practice to use a fixed data type for a primary key (ref: [this StackOverflow post](https://stackoverflow.com/questions/15477005/what-are-the-pros-and-cons-for-choosing-a-character-varying-data-type-for-primar) that @dongahn pointed me to). 

---

This PR adds a new field to the `bank_table` called _bank_id_ which will serve as the new primary key. It is of type `int`. It will auto increment as more banks are added to this table. 

Fixes #39 