### PR TITLE
tests: break up test_accounting_cli.py into multiple test files

### DIFF
--- a/test/test_accounting_cli.py
+++ b/test/test_accounting_cli.py
@@ -109,53 +109,6 @@ class TestAccountingCLI(unittest.TestCase):
             t_cleanup += 1000
             t_inactive += 1000
 
-    # add a valid user to association_table
-    def test_01_add_valid_user(self):
-        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
-
-        cursor = acct_conn.cursor()
-        num_rows = cursor.execute("DELETE FROM association_table").rowcount
-        self.assertEqual(num_rows, 1)
-
-    # adding a user with the same primary key (user_name, account) should
-    # return an IntegrityError
-    def test_02_add_duplicate_primary_key(self):
-        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
-
-        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
-
-        self.assertRaises(sqlite3.IntegrityError)
-
-    # adding a user with the same username BUT a different account should
-    # succeed
-    def test_03_add_duplicate_user(self):
-        aclif.add_user(acct_conn, "dup_user", "1", "acct", "10", "100", "60")
-        aclif.add_user(acct_conn, "dup_user", "1", "other_acct", "10", "100", "60")
-        cursor = acct_conn.cursor()
-        cursor.execute("SELECT * from association_table where user_name='dup_user'")
-        num_rows = cursor.execute(
-            "DELETE FROM association_table where user_name='dup_user'"
-        ).rowcount
-        self.assertEqual(num_rows, 2)
-
-    # edit a value for a user in the association table
-    def test_04_edit_user_value(self):
-        aclif.edit_user(acct_conn, "fluxuser", "max_jobs", "10000")
-        cursor = acct_conn.cursor()
-        cursor.execute(
-            "SELECT max_jobs FROM association_table where user_name='fluxuser'"
-        )
-
-        self.assertEqual(cursor.fetchone()[0], 10000)
-
-    # trying to edit a field in a column that doesn't
-    # exist should return an OperationalError
-    def test_05_edit_bad_field(self):
-        with self.assertRaises(SystemExit) as cm:
-            aclif.edit_user(acct_conn, "fluxuser", "foo", "bar")
-
-        self.assertEqual(cm.exception.code, 1)
-
     # passing a valid jobid should return
     # its job information
     def test_06_with_jobid_valid(self):

--- a/test/test_accounting_cli.py
+++ b/test/test_accounting_cli.py
@@ -25,150 +25,7 @@ class TestAccountingCLI(unittest.TestCase):
         # create example accounting database
         c.create_db("FluxAccounting.db")
         global acct_conn
-        global jobs_conn
         acct_conn = sqlite3.connect("FluxAccounting.db")
-
-        # create example job-archive database, output file
-        global op
-        op = "job_records.csv"
-        jobs_conn = sqlite3.connect("file:jobs.db?mode:rwc", uri=True)
-        jobs_conn.execute(
-            """
-                CREATE TABLE IF NOT EXISTS jobs (
-                    id            int       NOT NULL,
-                    userid        int       NOT NULL,
-                    username      text      NOT NULL,
-                    ranks         text      NOT NULL,
-                    t_submit      real      NOT NULL,
-                    t_sched       real      NOT NULL,
-                    t_run         real      NOT NULL,
-                    t_cleanup     real      NOT NULL,
-                    t_inactive    real      NOT NULL,
-                    eventlog      text      NOT NULL,
-                    jobspec       text      NOT NULL,
-                    R             text      NOT NULL,
-                    PRIMARY KEY   (id)
-            );"""
-        )
-
-        # add sample jobs to job-archive database
-        id = 100
-        userid = 1234
-        username = "user" + str(userid)
-        t_submit = 1000
-        t_sched = 1005
-        t_run = 1010
-        t_cleanup = 1015
-        t_inactive = 1020
-        for i in range(4):
-            try:
-                jobs_conn.execute(
-                    """
-                    INSERT INTO jobs (
-                        id,
-                        userid,
-                        username,
-                        ranks,
-                        t_submit,
-                        t_sched,
-                        t_run,
-                        t_cleanup,
-                        t_inactive,
-                        eventlog,
-                        jobspec,
-                        R
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        id,
-                        userid,
-                        username,
-                        "0",
-                        t_submit,
-                        t_sched,
-                        t_run,
-                        t_cleanup,
-                        t_inactive,
-                        "eventlog",
-                        "jobspec",
-                        '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
-                    ),
-                )
-                # commit changes
-                jobs_conn.commit()
-            # make sure entry is unique
-            except sqlite3.IntegrityError as integrity_error:
-                print(integrity_error)
-            id += 1
-            userid += 1000
-            username = "user" + str(userid)
-            t_submit += 1000
-            t_sched += 1000
-            t_run += 1000
-            t_cleanup += 1000
-            t_inactive += 1000
-
-    # passing a valid jobid should return
-    # its job information
-    def test_06_with_jobid_valid(self):
-        job_records = aclif.view_jobs_with_jobid(jobs_conn, 102, op)
-        self.assertEqual(len(job_records), 1)
-
-    # passing a bad jobid should return a
-    # failure message
-    def test_07_with_jobid_failure(self):
-        job_records = aclif.view_jobs_with_jobid(jobs_conn, 000, op)
-        self.assertEqual(job_records, "Job not found in jobs table")
-
-    # passing a timestamp before the first job to
-    # start should return all of the jobs
-    def test_08_after_start_time_all(self):
-        job_records = aclif.view_jobs_after_start_time(jobs_conn, 0, op)
-        self.assertEqual(len(job_records), 4)
-
-    # passing a timestamp in the middle should return
-    # only some of the jobs
-    def test_09_after_start_time_some(self):
-        job_records = aclif.view_jobs_after_start_time(jobs_conn, 2500, op)
-        self.assertEqual(len(job_records), 2)
-
-    # passing a timestamp after all of the start time
-    # of all the completed jobs should return a failure message
-    def test_10_after_start_time_none(self):
-        job_records = aclif.view_jobs_after_start_time(jobs_conn, 10000, op)
-        self.assertEqual(job_records, "No jobs found after time specified")
-
-    # passing a timestamp after the end time of the
-    # last job should return all of the jobs
-    def test_11_before_end_time_all(self):
-        job_records = aclif.view_jobs_before_end_time(jobs_conn, 5000, op)
-        self.assertEqual(len(job_records), 4)
-
-    # passing a timestamp in the middle should return
-    # only some of the jobs
-    def test_12_before_end_time_some(self):
-        job_records = aclif.view_jobs_before_end_time(jobs_conn, 3000, op)
-        self.assertEqual(len(job_records), 2)
-
-    # passing a timestamp before the end time of
-    # all the completed jobs should return a failure message
-    def test_13_before_end_time_none(self):
-        job_records = aclif.view_jobs_before_end_time(jobs_conn, 0, op)
-        self.assertEqual(job_records, "No jobs found before time specified")
-
-    # passing a user not in the jobs table
-    # should return a failure message
-    def test_14_by_user_failure(self):
-        job_records = aclif.view_jobs_run_by_username(jobs_conn, "9999", op)
-        self.assertEqual(job_records, "User not found in jobs table")
-
-    # view_jobs_run_by_username() interacts with a
-    # passwd file; for the purpose of these tests,
-    # just pass the userid
-    def test_15_by_user_success(self):
-        job_records = aclif.view_jobs_run_by_username(jobs_conn, "1234", op)
-        self.assertEqual(len(job_records), 1)
 
     # remove databases, log file, and output file
     # let's add a top-level account using the add-bank
@@ -277,11 +134,8 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         acct_conn.close()
-        jobs_conn.close()
         os.remove("FluxAccounting.db")
         os.remove("db_creation.log")
-        os.remove("jobs.db")
-        os.remove("job_records.csv")
 
 
 def suite():

--- a/test/test_bank_subcommands.py
+++ b/test/test_bank_subcommands.py
@@ -27,10 +27,9 @@ class TestAccountingCLI(unittest.TestCase):
         global acct_conn
         acct_conn = sqlite3.connect("FluxAccounting.db")
 
-    # remove databases, log file, and output file
     # let's add a top-level account using the add-bank
     # subcommand
-    def test_16_add_bank_success(self):
+    def test_01_add_bank_success(self):
         aclif.add_bank(acct_conn, bank="root", shares=100)
         select_stmt = "SELECT * FROM bank_table WHERE bank='root'"
         dataframe = pd.read_sql_query(select_stmt, acct_conn)
@@ -38,13 +37,13 @@ class TestAccountingCLI(unittest.TestCase):
 
     # let's make sure if we try to add it a second time,
     # it fails gracefully
-    def test_17_add_dup_bank(self):
+    def test_02_add_dup_bank(self):
         aclif.add_bank(acct_conn, bank="root", shares=100)
         self.assertRaises(sqlite3.IntegrityError)
 
     # trying to add a sub account with an invalid parent bank
     # name should result in a failure
-    def test_18_add_with_invalid_parent_bank(self):
+    def test_03_add_with_invalid_parent_bank(self):
         with self.assertRaises(SystemExit) as cm:
             aclif.add_bank(
                 acct_conn,
@@ -57,7 +56,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # now let's add a couple sub accounts whose parent is 'root'
     # and whose total shares equal root's allocation (100 shares)
-    def test_19_add_subaccounts(self):
+    def test_04_add_subaccounts(self):
         aclif.add_bank(acct_conn, bank="sub_account_1", parent_bank="root", shares=50)
         select_stmt = "SELECT * FROM bank_table WHERE bank='sub_account_1'"
         dataframe = pd.read_sql_query(select_stmt, acct_conn)
@@ -68,14 +67,14 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(len(dataframe.index), 1)
 
     # removing a bank currently in the bank_table
-    def test_20_delete_bank_success(self):
+    def test_05_delete_bank_success(self):
         aclif.delete_bank(acct_conn, bank="sub_account_1")
         select_stmt = "SELECT * FROM bank_table WHERE bank='sub_account_1'"
         dataframe = pd.read_sql_query(select_stmt, acct_conn)
         self.assertEqual(len(dataframe.index), 0)
 
     # edit a bank value
-    def test_21_edit_bank_value(self):
+    def test_06_edit_bank_value(self):
         aclif.add_bank(acct_conn, bank="root", shares=100)
         aclif.edit_bank(acct_conn, bank="root", shares=50)
         cursor = acct_conn.cursor()
@@ -86,7 +85,7 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to edit a parent bank's value to be
     # less than the total amount allocated to all of its
     # sub banks should result in a failure message and exit
-    def test_22_edit_parent_bank_failure(self):
+    def test_07_edit_parent_bank_failure(self):
         with self.assertRaises(SystemExit) as cm:
             aclif.add_bank(acct_conn, bank="sub_bank_1", parent_bank="root", shares=25)
             aclif.add_bank(acct_conn, bank="sub_bank_2", parent_bank="root", shares=25)
@@ -95,7 +94,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(cm.exception.code, -1)
 
     # edit a parent bank that has sub banks successfully
-    def test_23_edit_parent_bank_success(self):
+    def test_08_edit_parent_bank_success(self):
         aclif.add_bank(acct_conn, bank="sub_bank_1", shares=25)
         aclif.add_bank(
             acct_conn, bank="sub_bank_1_1", parent_bank="sub_bank_1", shares=5
@@ -112,7 +111,7 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to edit a sub bank's shares to be greater
     # than its parent bank's allocation should result
     # in a failure message and exit
-    def test_24_edit_sub_bank_greater_than_parent_bank(self):
+    def test_09_edit_sub_bank_greater_than_parent_bank(self):
         with self.assertRaises(SystemExit) as cm:
             aclif.add_bank(
                 acct_conn, bank="sub_bank_2_1", parent_bank="sub_bank_2", shares=5
@@ -122,7 +121,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(cm.exception.code, -1)
 
     # edit the sub bank successfully
-    def test_25_edit_sub_bank_successfully(self):
+    def test_10_edit_sub_bank_successfully(self):
         aclif.add_bank(acct_conn, bank="sub_bank_2_1", shares=26)
         aclif.edit_bank(acct_conn, bank="sub_bank_2_1", shares=24)
         cursor = acct_conn.cursor()

--- a/test/test_job_archive_interface.py
+++ b/test/test_job_archive_interface.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import pandas as pd
+
+from accounting import accounting_cli_functions as aclif
+from accounting import create_db as c
+
+
+class TestAccountingCLI(unittest.TestCase):
+    # create accounting, job-archive databases
+    @classmethod
+    def setUpClass(self):
+        global jobs_conn
+
+        # create example job-archive database, output file
+        global op
+        op = "job_records.csv"
+        jobs_conn = sqlite3.connect("file:jobs.db?mode:rwc", uri=True)
+        jobs_conn.execute(
+            """
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id            int       NOT NULL,
+                    userid        int       NOT NULL,
+                    username      text      NOT NULL,
+                    ranks         text      NOT NULL,
+                    t_submit      real      NOT NULL,
+                    t_sched       real      NOT NULL,
+                    t_run         real      NOT NULL,
+                    t_cleanup     real      NOT NULL,
+                    t_inactive    real      NOT NULL,
+                    eventlog      text      NOT NULL,
+                    jobspec       text      NOT NULL,
+                    R             text      NOT NULL,
+                    PRIMARY KEY   (id)
+            );"""
+        )
+
+        # add sample jobs to job-archive database
+        id = 100
+        userid = 1234
+        username = "user" + str(userid)
+        t_submit = 1000
+        t_sched = 1005
+        t_run = 1010
+        t_cleanup = 1015
+        t_inactive = 1020
+        for i in range(4):
+            try:
+                jobs_conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        id,
+                        userid,
+                        username,
+                        ranks,
+                        t_submit,
+                        t_sched,
+                        t_run,
+                        t_cleanup,
+                        t_inactive,
+                        eventlog,
+                        jobspec,
+                        R
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        id,
+                        userid,
+                        username,
+                        "0",
+                        t_submit,
+                        t_sched,
+                        t_run,
+                        t_cleanup,
+                        t_inactive,
+                        "eventlog",
+                        "jobspec",
+                        '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
+                    ),
+                )
+                # commit changes
+                jobs_conn.commit()
+            # make sure entry is unique
+            except sqlite3.IntegrityError as integrity_error:
+                print(integrity_error)
+            id += 1
+            userid += 1000
+            username = "user" + str(userid)
+            t_submit += 1000
+            t_sched += 1000
+            t_run += 1000
+            t_cleanup += 1000
+            t_inactive += 1000
+
+    # passing a valid jobid should return
+    # its job information
+    def test_01_with_jobid_valid(self):
+        job_records = aclif.view_jobs_with_jobid(jobs_conn, 102, op)
+        self.assertEqual(len(job_records), 1)
+
+    # passing a bad jobid should return a
+    # failure message
+    def test_02_with_jobid_failure(self):
+        job_records = aclif.view_jobs_with_jobid(jobs_conn, 000, op)
+        self.assertEqual(job_records, "Job not found in jobs table")
+
+    # passing a timestamp before the first job to
+    # start should return all of the jobs
+    def test_03_after_start_time_all(self):
+        job_records = aclif.view_jobs_after_start_time(jobs_conn, 0, op)
+        self.assertEqual(len(job_records), 4)
+
+    # passing a timestamp in the middle should return
+    # only some of the jobs
+    def test_04_after_start_time_some(self):
+        job_records = aclif.view_jobs_after_start_time(jobs_conn, 2500, op)
+        self.assertEqual(len(job_records), 2)
+
+    # passing a timestamp after all of the start time
+    # of all the completed jobs should return a failure message
+    def test_05_after_start_time_none(self):
+        job_records = aclif.view_jobs_after_start_time(jobs_conn, 10000, op)
+        self.assertEqual(job_records, "No jobs found after time specified")
+
+    # passing a timestamp after the end time of the
+    # last job should return all of the jobs
+    def test_06_before_end_time_all(self):
+        job_records = aclif.view_jobs_before_end_time(jobs_conn, 5000, op)
+        self.assertEqual(len(job_records), 4)
+
+    # passing a timestamp in the middle should return
+    # only some of the jobs
+    def test_07_before_end_time_some(self):
+        job_records = aclif.view_jobs_before_end_time(jobs_conn, 3000, op)
+        self.assertEqual(len(job_records), 2)
+
+    # passing a timestamp before the end time of
+    # all the completed jobs should return a failure message
+    def test_08_before_end_time_none(self):
+        job_records = aclif.view_jobs_before_end_time(jobs_conn, 0, op)
+        self.assertEqual(job_records, "No jobs found before time specified")
+
+    # passing a user not in the jobs table
+    # should return a failure message
+    def test_09_by_user_failure(self):
+        job_records = aclif.view_jobs_run_by_username(jobs_conn, "9999", op)
+        self.assertEqual(job_records, "User not found in jobs table")
+
+    # view_jobs_run_by_username() interacts with a
+    # passwd file; for the purpose of these tests,
+    # just pass the userid
+    def test_10_by_user_success(self):
+        job_records = aclif.view_jobs_run_by_username(jobs_conn, "1234", op)
+        self.assertEqual(len(job_records), 1)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        jobs_conn.close()
+        os.remove("jobs.db")
+        os.remove("job_records.csv")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/test/test_user_subcommands.py
+++ b/test/test_user_subcommands.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+from accounting import accounting_cli_functions as aclif
+from accounting import create_db as c
+
+
+class TestAccountingCLI(unittest.TestCase):
+    # create accounting, job-archive databases
+    @classmethod
+    def setUpClass(self):
+        # create example accounting database
+        c.create_db("FluxAccounting.db")
+        global acct_conn
+        global jobs_conn
+        acct_conn = sqlite3.connect("FluxAccounting.db")
+
+    # add a valid user to association_table
+    def test_01_add_valid_user(self):
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
+        cursor = acct_conn.cursor()
+        num_rows = cursor.execute("DELETE FROM association_table").rowcount
+
+        self.assertEqual(num_rows, 1)
+
+    # adding a user with the same primary key (user_name, account) should
+    # return an IntegrityError
+    def test_02_add_duplicate_primary_key(self):
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
+        aclif.add_user(acct_conn, "fluxuser", "1", "acct", "10", "100", "60")
+
+        self.assertRaises(sqlite3.IntegrityError)
+
+    # adding a user with the same username BUT a different account should
+    # succeed
+    def test_03_add_duplicate_user(self):
+        aclif.add_user(acct_conn, "dup_user", "1", "acct", "10", "100", "60")
+        aclif.add_user(acct_conn, "dup_user", "1", "other_acct", "10", "100", "60")
+        cursor = acct_conn.cursor()
+        cursor.execute("SELECT * from association_table where user_name='dup_user'")
+        num_rows = cursor.execute(
+            "DELETE FROM association_table where user_name='dup_user'"
+        ).rowcount
+
+        self.assertEqual(num_rows, 2)
+
+    # edit a value for a user in the association table
+    def test_04_edit_user_value(self):
+        aclif.edit_user(acct_conn, "fluxuser", "max_jobs", "10000")
+        cursor = acct_conn.cursor()
+        cursor.execute(
+            "SELECT max_jobs FROM association_table where user_name='fluxuser'"
+        )
+
+        self.assertEqual(cursor.fetchone()[0], 10000)
+
+    # trying to edit a field in a column that doesn't
+    # exist should return an OperationalError
+    def test_05_edit_bad_field(self):
+        with self.assertRaises(SystemExit) as cm:
+            aclif.edit_user(acct_conn, "fluxuser", "foo", "bar")
+
+        self.assertEqual(cm.exception.code, 1)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        acct_conn.close()
+        os.remove("FluxAccounting.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
**Problem**: The main unit test file in `flux-accounting`, **test_accounting_cli.py** is getting quite long with all of the unit tests; there are a bunch in there and they cover three different areas of `flux-accounting`: the **user table subcommands**, the **job archive interface subcommands**, and the **bank table subcommands**. 

---

This PR breaks up **test_accounting_cli.py** into three different test files:

* **test_user_subcommands.py**

* **test_job_archive_interface.py**

* **test_bank_subcommands.py**

All four test files (I say 4 because **test_create_db.py** is also there in the `test/` directory) can still be run with `tox`, which is what I've been using to run these tests:

```
$ tox
GLOB sdist-make: /Users/moussa1/src/flux-framework/flux-accounting/setup.py
python3.6 inst-nodeps: /Users/moussa1/src/flux-framework/flux-accounting/.tox/.tmp/package/1/flux-accounting-0.1.0.zip
python3.6 installed: flux-accounting @ file:///Users/moussa1/src/flux-framework/flux-accounting/.tox/.tmp/package/1/flux-accounting-0.1.0.zip,numpy==1.18.4,pandas==1.0.3,python-dateutil==2.8.1,pytz==2020.1,six==1.14.0
python3.6 run-test-pre: PYTHONHASHSEED='1186837928'
python3.6 run-test: commands[0] | python -m unittest discover -b
...............................
----------------------------------------------------------------------
Ran 31 tests in 0.158s

OK
__________________________________________________________________________________________ summary __________________________________________________________________________________________
  python3.6: commands succeeded
  congratulations :)
```

And now, I can run specific test files individually that cover one of those four areas:

```
$ python3 -m unittest -q test/test_bank_subcommands.py -b
----------------------------------------------------------------------
Ran 10 tests in 0.049s

OK
```