### PR TITLE
repo: add Travis CI, Codecov to flux-accounting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install:
+  - pip install pandas
+  - pip install codecov
+# command to run tests
+script:
+  - coverage run -m unittest discover
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/flux-framework/flux-accounting.svg?branch=master)](https://travis-ci.org/flux-framework/flux-accounting)
+[![codecov](https://codecov.io/gh/flux-framework/flux-accounting/branch/master/graph/badge.svg)](https://codecov.io/gh/flux-framework/flux-accounting)
+
 _NOTE: The interfaces of flux-accounting are being actively developed and are not yet stable. The Github issue tracker is the primary way to communicate with the developers._
 
 ## flux-accounting

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+ round: down
+ range: "65...100"
+
+ # Allow coverage to drop up to 0.5%
+ status:
+  project:
+   default:
+    threshold: .5
+
+comment:
+ layout: "header, diff, changes, tree"
+ behavior: new


### PR DESCRIPTION
This PR adds Travis CI and Codecov to `flux-accounting`, as well as the badges indicating successful builds and the coverage percentage to the top of the **README**. 