### PR TITLE
job-archive interface: turn current subcommands into options

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -97,38 +97,6 @@ def main():
         "--new-value", help="new value", metavar="VALUE",
     )
 
-    subparser_view_jobs_by_username = subparsers.add_parser(
-        "by-user", help="show jobs run by username"
-    )
-    subparser_view_jobs_by_username.set_defaults(func="view_jobs_run_by_username")
-    subparser_view_jobs_by_username.add_argument(
-        "username", help="username", metavar="USERNAME",
-    )
-
-    subparser_view_job_by_jobid = subparsers.add_parser(
-        "by-jobid", help="show job info from jobid"
-    )
-    subparser_view_job_by_jobid.set_defaults(func="view_jobs_with_jobid")
-    subparser_view_job_by_jobid.add_argument(
-        "jobid", help="jobid", metavar="JOBID",
-    )
-
-    subparser_view_jobs_after_start_time = subparsers.add_parser(
-        "after-start-time", help="show jobs that completed after start time"
-    )
-    subparser_view_jobs_after_start_time.set_defaults(func="view_jobs_after_start_time")
-    subparser_view_jobs_after_start_time.add_argument(
-        "start_time", help="start time", metavar="START TIME",
-    )
-
-    subparser_view_jobs_before_end_time = subparsers.add_parser(
-        "before-end-time", help="show jobs that completed before end time"
-    )
-    subparser_view_jobs_before_end_time.set_defaults(func="view_jobs_before_end_time")
-    subparser_view_jobs_before_end_time.add_argument(
-        "end_time", help="end time", metavar="END TIME",
-    )
-
     subparser_view_job_records = subparsers.add_parser(
         "view-job-records", help="view job records"
     )
@@ -232,14 +200,6 @@ def main():
             aclif.delete_user(conn, args.username)
         elif args.func == "edit_user":
             aclif.edit_user(conn, args.username, args.field, args.new_value)
-        elif args.func == "view_jobs_run_by_username":
-            aclif.view_jobs_run_by_username(conn, args.username, args.output_file)
-        elif args.func == "view_jobs_with_jobid":
-            aclif.view_jobs_with_jobid(conn, args.jobid, args.output_file)
-        elif args.func == "view_jobs_after_start_time":
-            aclif.view_jobs_after_start_time(conn, args.start_time, args.output_file)
-        elif args.func == "view_jobs_before_end_time":
-            aclif.view_jobs_before_end_time(conn, args.end_time, args.output_file)
         elif args.func == "view_job_records":
             aclif.view_job_records(conn, args.output_file, args)
         elif args.func == "add_bank":

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -129,6 +129,23 @@ def main():
         "end_time", help="end time", metavar="END TIME",
     )
 
+    subparser_view_job_records = subparsers.add_parser(
+        "view-job-records", help="view job records"
+    )
+    subparser_view_job_records.set_defaults(func="view_job_records")
+    subparser_view_job_records.add_argument(
+        "-u", "--user", help="username", metavar="USERNAME",
+    )
+    subparser_view_job_records.add_argument(
+        "-j", "--jobid", help="jobid", metavar="JOBID"
+    )
+    subparser_view_job_records.add_argument(
+        "-a", "--after-start-time", help="start time", metavar="START TIME",
+    )
+    subparser_view_job_records.add_argument(
+        "-b", "--before-end-time", help="end time", metavar="END TIME",
+    )
+
     subparser_create_db = subparsers.add_parser(
         "create-db", help="create the flux-accounting database"
     )
@@ -223,6 +240,8 @@ def main():
             aclif.view_jobs_after_start_time(conn, args.start_time, args.output_file)
         elif args.func == "view_jobs_before_end_time":
             aclif.view_jobs_before_end_time(conn, args.end_time, args.output_file)
+        elif args.func == "view_job_records":
+            aclif.view_job_records(conn, args.output_file, args)
         elif args.func == "add_bank":
             aclif.add_bank(conn, args.bank, args.shares, args.parent_bank)
         elif args.func == "view_bank":

--- a/test/test_job_archive_interface.py
+++ b/test/test_job_archive_interface.py
@@ -108,63 +108,105 @@ class TestAccountingCLI(unittest.TestCase):
     # passing a valid jobid should return
     # its job information
     def test_01_with_jobid_valid(self):
-        job_records = aclif.view_jobs_with_jobid(jobs_conn, 102, op)
+        my_dict = {"jobid": 102}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 1)
 
     # passing a bad jobid should return a
     # failure message
     def test_02_with_jobid_failure(self):
-        job_records = aclif.view_jobs_with_jobid(jobs_conn, 000, op)
-        self.assertEqual(job_records, "Job not found in jobs table")
+        my_dict = {"jobid": 000}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 0)
 
     # passing a timestamp before the first job to
     # start should return all of the jobs
     def test_03_after_start_time_all(self):
-        job_records = aclif.view_jobs_after_start_time(jobs_conn, 0, op)
+        my_dict = {"after_start_time": 0}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 4)
 
     # passing a timestamp in the middle should return
     # only some of the jobs
     def test_04_after_start_time_some(self):
-        job_records = aclif.view_jobs_after_start_time(jobs_conn, 2500, op)
+        my_dict = {"after_start_time": 2500}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 2)
 
     # passing a timestamp after all of the start time
     # of all the completed jobs should return a failure message
     def test_05_after_start_time_none(self):
-        job_records = aclif.view_jobs_after_start_time(jobs_conn, 10000, op)
-        self.assertEqual(job_records, "No jobs found after time specified")
+        my_dict = {"after_start_time": 5000}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 0)
 
     # passing a timestamp after the end time of the
     # last job should return all of the jobs
     def test_06_before_end_time_all(self):
-        job_records = aclif.view_jobs_before_end_time(jobs_conn, 5000, op)
+        my_dict = {"before_end_time": 5000}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 4)
 
     # passing a timestamp in the middle should return
     # only some of the jobs
     def test_07_before_end_time_some(self):
-        job_records = aclif.view_jobs_before_end_time(jobs_conn, 3000, op)
+        my_dict = {"before_end_time": 3000}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 2)
 
     # passing a timestamp before the end time of
     # all the completed jobs should return a failure message
     def test_08_before_end_time_none(self):
-        job_records = aclif.view_jobs_before_end_time(jobs_conn, 0, op)
-        self.assertEqual(job_records, "No jobs found before time specified")
+        my_dict = {"before_end_time": 0}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 0)
 
     # passing a user not in the jobs table
     # should return a failure message
     def test_09_by_user_failure(self):
-        job_records = aclif.view_jobs_run_by_username(jobs_conn, "9999", op)
-        self.assertEqual(job_records, "User not found in jobs table")
+        my_dict = {"user": "9999"}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 0)
 
     # view_jobs_run_by_username() interacts with a
     # passwd file; for the purpose of these tests,
     # just pass the userid
     def test_10_by_user_success(self):
-        job_records = aclif.view_jobs_run_by_username(jobs_conn, "1234", op)
+        my_dict = {"user": "1234"}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 1)
+
+    # passing a combination of params should further
+    # refine the query
+    def test_11_multiple_params_1(self):
+        my_dict = {"user": "1234", "after_start_time": 1009}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 1)
+
+    def test_12_multiple_params_2(self):
+        my_dict = {"user": "1234", "before_end_time": 1021}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 1)
+
+    # order of the parameters shouldn't matter
+    def test_13_multiple_params_3(self):
+        my_dict = {"before_end_time": 5000, "user": "1234"}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 1)
+
+    # passing multiple parameters will result in precedence;
+    # the first parameter will be used to filter results
+    def test_14_multiple_params_4(self):
+        my_dict = {"jobid": 102, "after_start_time": 0}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 1)
+
+    # passing no parameters will result in a generic query
+    # returning all results
+    def test_15_no_options_passed(self):
+        my_dict = {}
+        job_records = aclif.view_job_records(jobs_conn, op, **my_dict)
+        self.assertEqual(len(job_records), 4)
 
     # remove database and log file
     @classmethod


### PR DESCRIPTION
**Problem**: As described in #46, the current way to interact with the job-archive interface is through a series of subcommands. These, however, limit the user to only being able to run one of these filters at a time.

---

This PR turns the existing subcommands into optional arguments under a new subcommand, `view-job-records`. The filter options are the same:

```
optional arguments:
  -h, --help            show this help message and exit
  -u USERNAME, --user USERNAME
                        username
  -j JOBID, --jobid JOBID
                        jobid
  -a START TIME, --after-start-time START TIME
                        start time
  -b END TIME, --before-end-time END TIME
                        end time
```

except now they can be combined (e.g. I want to see all jobs run by a user _u_ before some timestamp _t_).

The current implementation grabs the optional args passed in and performs a series of `if-else` checks to determine which `SELECT` statement to use on the job-archive DB. If a combination of parameters are passed in that are not one of the combinations checked by the `if-else` branches, the `SELECT` statement should default to the first parameter that was passed in (e.g. I pass in a jobid _j_ but also some timestamp _t_ - this will just use the jobid _j_). 

With the new `view_job_records()` function in **accounting_cli_functions.py**, I went ahead and removed the individual job-archive interface subcommands and functions, and changed their unit tests to instead interact with the new function, `view_job_records()`.  

Fixes #46