### PR TITLE
edit error handling in create-db(), edit-user()

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -179,7 +179,7 @@ def main():
         conn = sqlite3.connect("file:" + path + "?mode=rw", uri=True)
     except sqlite3.OperationalError:
         print("Unable to open database file")
-        sys.exit(-1)
+        sys.exit(1)
 
     # set path for output file
     output_file = args.output_file if args.output_file else None

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -167,16 +167,18 @@ def edit_user(conn, username, field, new_value):
         "max_jobs",
         "max_wall_pj",
     ]
-    if field in fields:
-        the_field = field
-    else:
-        print("Field not found in association table")
-        sys.exit(1)
+    try:
+        if field in fields:
+            the_field = field
 
-    # edit value in accounting database
-    conn.execute(
-        "UPDATE association_table SET " + the_field + "=? WHERE user_name=?",
-        (new_value, username,),
-    )
-    # commit changes
-    conn.commit()
+            # edit value in accounting database
+            conn.execute(
+                "UPDATE association_table SET " + the_field + "=? WHERE user_name=?",
+                (new_value, username,),
+            )
+            # commit changes
+            conn.commit()
+        else:
+            raise ValueError("Field not found in association table")
+    except Exception as e:
+        print(e)

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -10,9 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import sqlite3
-import argparse
 import time
-import sys
 import pwd
 import csv
 

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -20,10 +20,14 @@ LOGGER = logging.basicConfig(filename="db_creation.log", level=logging.INFO)
 
 
 def create_db(filepath):
-    # open connection to database
-    logging.info("Creating Flux Accounting DB")
-    conn = sqlite3.connect("file:" + filepath + "?mode:rwc", uri=True)
-    logging.info("Created Flux Accounting DB sucessfully")
+    try:
+        # open connection to database
+        logging.info("Creating Flux Accounting DB")
+        conn = sqlite3.connect("file:" + filepath + "?mode:rwc", uri=True)
+        logging.info("Created Flux Accounting DB successfully")
+    except sqlite3.OperationalError as e:
+        logging.error(e)
+        sys.exit(1)
 
     # Association Table
     logging.info("Creating association_table in DB...")

--- a/accounting/print_hierarchy.py
+++ b/accounting/print_hierarchy.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import sqlite3
+import sys
 import pandas as pd
 
 # this will print the full hierarchy of banks
@@ -27,10 +28,14 @@ def print_full_hierarchy(conn):
         """
     dataframe = pd.read_sql_query(select_stmt, conn)
 
-    if len(dataframe) == 0:
-        raise Exception("No root bank found")
-    elif len(dataframe) > 1:
-        raise Exception("More than one root bank found")
+    try:
+        if len(dataframe) == 0:
+            raise IndexError("No root bank found")
+        elif len(dataframe) > 1:
+            raise IndexError("More than one root bank found")
+    except IndexError as e:
+        print(e)
+        sys.exit(1)
 
     root = dataframe.iloc[0]
 

--- a/test/test_bank_subcommands.py
+++ b/test/test_bank_subcommands.py
@@ -165,12 +165,39 @@ A||1
 
         self.assertEqual(test, expected)
 
+    # having more than one root bank should result
+    # in an exception being thrown
+    def test_09_print_hierarchy_failure_1(self):
+        c.create_db("flux_accounting_failure_1.db")
+        acct_conn = sqlite3.connect("flux_accounting_failure_1.db")
+
+        aclif.add_bank(acct_conn, bank="A", shares=1)
+        aclif.add_bank(acct_conn, bank="B", shares=1)
+
+        with self.assertRaises(SystemExit) as cm:
+            p.print_full_hierarchy(acct_conn)
+
+        self.assertTrue(cm.exception.code, 1)
+
+    # having no root bank should also result in an
+    # exception being thrown
+    def test_10_print_hierarchy_failure_2(self):
+        c.create_db("flux_accounting_failure_2.db")
+        acct_conn = sqlite3.connect("flux_accounting_failure_2.db")
+
+        with self.assertRaises(SystemExit) as cm:
+            p.print_full_hierarchy(acct_conn)
+
+        self.assertTrue(cm.exception.code, 1)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):
         acct_conn.close()
         os.remove("FluxAccounting.db")
         os.remove("db_creation.log")
+        os.remove("flux_accounting_failure_1.db")
+        os.remove("flux_accounting_failure_2.db")
 
 
 def suite():

--- a/test/test_user_subcommands.py
+++ b/test/test_user_subcommands.py
@@ -107,12 +107,11 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(cursor.fetchone()[0], 10000)
 
     # trying to edit a field in a column that doesn't
-    # exist should return an OperationalError
+    # exist should return a ValueError
     def test_05_edit_bad_field(self):
-        with self.assertRaises(SystemExit) as cm:
-            aclif.edit_user(acct_conn, "fluxuser", "foo", "bar")
+        aclif.edit_user(acct_conn, "fluxuser", "foo", "bar")
 
-        self.assertEqual(cm.exception.code, 1)
+        self.assertRaises(ValueError)
 
     # remove database and log file
     @classmethod


### PR DESCRIPTION
**Problem**: Noted in #38, there was no sort of error handling if `create-db()` failed for whatever reason while creating the database. There was also an instance in `edit-user()` where if somebody tried to edit a user's account information and specified a non-existent field, the program would call `sys.exit(1)`.

---

This PR wraps `create-db()` in a `try-except` block, and will print any SQLite operational error to the screen. It also changes `edit-user()` to raise an `Exception` instead of calling `sys.exit()` if a non-existent field is specified.

I also noticed that `accounting_cli_functions.py` had a couple of unused `import` statements, so I figured I would remove those as well in this PR (if anything, I can always open another tiny PR that removes it instead of including it in this one).

I believe now there is only one instance where `sys.exit()` is called - in `accounting_cli.py`:

```python
# try to open database file; will exit with -1 if database file not found
path = args.path if args.path else "FluxAccounting.db"
try:
    conn = sqlite3.connect("file:" + path + "?mode=rw", uri=True)
except sqlite3.OperationalError:
    print("Unable to open database file")
    sys.exit(-1)
```

I figured not being able to connect to the database file would warrant a `sys.exit()` since essentially none of the subcommands would work if you can't connect to the database file... is this the right intuition to have? Should an `Exception` instead be raised? 