### PR TITLE
print-hierarchy: improve output format

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from accounting import accounting_cli_functions as aclif
 from accounting import create_db as c
+from accounting import print_hierarchy as ph
 
 
 def main():
@@ -231,7 +232,7 @@ def main():
         elif args.func == "edit_bank":
             aclif.edit_bank(conn, args.bank, args.shares)
         elif args.func == "print_hierarchy":
-            aclif.print_hierarchy(conn)
+            print(ph.print_full_hierarchy(conn))
         else:
             print(parser.print_usage())
     finally:

--- a/accounting/accounting_cli_functions.py
+++ b/accounting/accounting_cli_functions.py
@@ -325,40 +325,6 @@ def edit_bank(conn, bank, shares):
         print(e_database_error)
 
 
-def print_hierarchy(conn):
-    print("Bank = RawShares\n  | User = RawShares\n")
-    select_stmt = """
-        SELECT bank_table.bank,
-        bank_table.shares,
-        bank_table.parent_bank
-        FROM bank_table;
-        """
-    dataframe = pd.read_sql_query(select_stmt, conn)
-    for index, row in dataframe.iterrows():
-        print("-" * 50)
-        print(
-            "Bank:",
-            row["bank"],
-            "| Shares =",
-            row["shares"],
-            "| Parent Bank:",
-            row["parent_bank"],
-        )
-        print("-" * 50)
-        select_stmt = """
-            SELECT association_table.user_name,
-            association_table.shares AS user_shares
-            FROM association_table
-            INNER JOIN bank_table ON association_table.account = ?;
-            """
-        dataframe = pd.read_sql_query(select_stmt, conn, params=(row["bank"],))
-        users_seen = []
-        for index, row in dataframe.iterrows():
-            if row["user_name"] not in users_seen:
-                print("  |", row["user_name"], "| Shares =", row["user_shares"])
-                users_seen.append(row["user_name"])
-
-
 def view_user(conn, user):
     try:
         # get the information pertaining to a user in the Accounting DB

--- a/accounting/print_hierarchy.py
+++ b/accounting/print_hierarchy.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import pandas as pd
+
+# this will print the full hierarchy of banks
+# and associations that are found in the
+# flux-accounting DB
+def print_full_hierarchy(conn):
+    hierarchy = "Bank|User|RawShares\n"
+
+    # get the root bank in the bank table
+    select_stmt = """
+        SELECT bank_table.bank,
+        bank_table.shares
+        FROM bank_table
+        WHERE parent_bank="";
+        """
+    dataframe = pd.read_sql_query(select_stmt, conn)
+
+    if len(dataframe) == 0:
+        raise Exception("No root bank found")
+    elif len(dataframe) > 1:
+        raise Exception("More than one root bank found")
+
+    root = dataframe.iloc[0]
+
+    # helper function to traverse the bank hierarchy tree
+    def get_sub_banks(row, indent=""):
+        nonlocal hierarchy
+        hierarchy += indent + row["bank"] + "||" + str(row["shares"]) + "\n"
+
+        # get all sub banks of the current bank
+        select_stmt = """
+            SELECT bank_table.bank,
+            bank_table.shares
+            FROM bank_table
+            WHERE parent_bank=?;
+            """
+        dataframe = pd.read_sql_query(select_stmt, conn, params=(row["bank"],))
+
+        # we've reached a bank with no sub banks, so print
+        # out all associations under this sub bank
+        if len(dataframe) == 0:
+            select_stmt = """
+                SELECT association_table.user_name,
+                association_table.shares,
+                association_table.account
+                FROM association_table
+                WHERE association_table.account=?
+                """
+            dataframe = pd.read_sql_query(select_stmt, conn, params=(row["bank"],))
+            for index, association_row in dataframe.iterrows():
+                hierarchy += (
+                    " "
+                    + indent
+                    + association_row["account"]
+                    + "|"
+                    + association_row["user_name"]
+                    + "|"
+                    + str(association_row["shares"])
+                    + "\n"
+                )
+        # this bank has sub banks, so call this helper
+        # function again with the first sub bank it found
+        else:
+            for index, sub_bank_row in dataframe.iterrows():
+                get_sub_banks(sub_bank_row, indent + " ")
+
+    get_sub_banks(root)
+
+    return hierarchy


### PR DESCRIPTION
**Problem**: The current output of `print-hierarchy()` is pretty clunky and hard to read if there are lots and lots of banks and sub banks, each which might hold lots of user accounts.

In reality, with lots of banks and accounts, we need output that is cleaner and has more of a directory tree layout. 

---

This PR moves `print_hierarchy()` to its own file, **print-hierarchy.py**, and changes its output to more closely resemble the `sshare` command. For example, take the following bank structure

```
      A
      |
   |-----|
   B     C
   |     |
 |---| |---|
 D   E F   G
```

With a call to `print-hierarchy()`, this should result in the following output:

```
Bank|User|RawShares
A||1
 B||1
  D||1
   D|user1|1
  E||1
 C||1
  F||1
   F|user2|1
   F|user3|1
  G||1
   G|user4|1
```

This PR is the first step to gathering bank/user data needed to perform usage calculations. Eventually, the output from this function would probably contain more columns like the `sshare` command, like `RawUsage` and `FairShare` values. But for now, this PR just fetches static information about banks and their associations from `flux-accounting`'s database file. 