### PR TITLE
accounting_cli: change params to view_job_records

### DIFF
--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -201,7 +201,14 @@ def main():
         elif args.func == "edit_user":
             aclif.edit_user(conn, args.username, args.field, args.new_value)
         elif args.func == "view_job_records":
-            aclif.view_job_records(conn, args.output_file, args)
+            aclif.view_job_records(
+                conn,
+                output_file,
+                jobid=args.jobid,
+                user=args.user,
+                before_end_time=args.before_end_time,
+                after_start_time=args.after_start_time,
+            )
         elif args.func == "add_bank":
             aclif.add_bank(conn, args.bank, args.shares, args.parent_bank)
         elif args.func == "view_bank":


### PR DESCRIPTION
**Problem**: Trying to use the `view-job-records` subcommand would result in the following error:

```
$ flux account -p /var/lib/flux/jobs.db view-job-records 

Traceback (most recent call last):
  File "/usr/libexec/flux/cmd/flux-account.py", line 11, in <module>
    load_entry_point('flux-accounting==0.1.0', 'console_scripts', 'flux-account.py')()
  File "/usr/lib64/flux/python3.6/flux_accounting-0.1.0-py3.6.egg/accounting/accounting_cli.py", line 204, in main
TypeError: view_job_records() takes 2 positional arguments but 3 were given
```

I think this is because `view_job_records()` was interpreting `args` as a `Namespace` object instead of unpacking it into a dictionary.

---

This PR updates the parameters passed to `view_job_records()` to: 
- the SQLite connection to the job-archive DB
- an optional output file, and 
- a dictionary containing the options to filter the job archive database.

Fixes #54