### PR TITLE
add print_hierarchy() C++ implementation to weighted tree lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ accounting/db_creation.log
 test/FluxAccounting.db
 build/
 .tox
+src/fairness/print_hierarchy/print_hierarchy

--- a/accounting/accounting_cli.py
+++ b/accounting/accounting_cli.py
@@ -191,8 +191,8 @@ def main():
             aclif.add_user(
                 conn,
                 args.username,
-                args.admin_level,
                 args.account,
+                args.admin_level,
                 args.shares,
                 args.max_jobs,
                 args.max_wall_pj,

--- a/accounting/create_db.py
+++ b/accounting/create_db.py
@@ -55,9 +55,9 @@ def create_db(filepath):
         """
             CREATE TABLE IF NOT EXISTS bank_table (
                 bank_id     integer PRIMARY KEY,
-                bank        text    NOT NULL,
-                parent_bank text,
-                shares      int     NOT NULL
+                bank        text                NOT NULL,
+                parent_bank text    DEFAULT '',
+                shares      int                 NOT NULL
         );"""
     )
     logging.info("Created bank_table successfully")

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,11 @@ LT_INIT([dlopen])
 
 AC_PREFIX_PROGRAM([flux])
 
+##
+# Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
+##
+PKG_PROG_PKG_CONFIG
+
 # Checks for programs.
 AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])
@@ -27,6 +32,7 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AM_PROG_CC_C_O
 AX_CODE_COVERAGE
+PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 
 if test "$GCC" = yes; then
   WARNING_CFLAGS="-Wall -Werror -Werror=missing-field-initializers -Wno-error=deprecated-declarations"
@@ -69,7 +75,8 @@ AC_CONFIG_FILES([Makefile
   src/common/libtap/Makefile
   src/fairness/Makefile
   src/fairness/weighted_tree/Makefile
-  src/fairness/weighted_tree/test/Makefile])
+  src/fairness/weighted_tree/test/Makefile
+  src/fairness/print_hierarchy/Makefile])
 AC_OUTPUT
 
 echo "

--- a/src/fairness/Makefile.am
+++ b/src/fairness/Makefile.am
@@ -1,2 +1,1 @@
-SUBDIRS = weighted_tree
-
+SUBDIRS = weighted_tree print_hierarchy

--- a/src/fairness/print_hierarchy/Makefile.am
+++ b/src/fairness/print_hierarchy/Makefile.am
@@ -1,0 +1,25 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = $(FLUX_CORE_CFLAGS)
+
+SUBDIRS = .
+
+noinst_PROGRAMS = print_hierarchy
+
+print_hierarchy_SOURCES = \
+    print_hierarchy.cpp
+
+print_hierarchy_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CFLAGS) \
+    $(AM_CXXFLAGS) \
+                $(SQLITE_CFLAGS)
+
+print_hierarchy_LDFLAGS = \
+                $(SQLITE_LIBS)
+
+TESTS = test-print-hierarchy.sh

--- a/src/fairness/print_hierarchy/print_hierarchy.cpp
+++ b/src/fairness/print_hierarchy/print_hierarchy.cpp
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 Lawrence Livermore National Security, LLC
+(c.f. AUTHORS, NOTICE.LLNS, COPYING)
+
+This file is part of the Flux resource manager framework.
+For details, see https://github.com/flux-framework.
+
+SPDX-License-Identifier: LGPL-3.0
+*/
+#include <iostream>
+#include <sqlite3.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <tuple>
+
+std::string hierarchy = "Bank|User|RawShares\n";
+char* messageError;
+
+sqlite3_stmt *b_select_root_bank_stmt;
+sqlite3_stmt *b_select_shares_stmt;
+sqlite3_stmt *b_select_sub_banks_stmt;
+sqlite3_stmt *b_select_associations_stmt;
+
+int get_sub_banks(sqlite3* DB, const std::string& bank_name, const std::string& indent) {
+  int exit = 0;
+
+  // bind parameter to prepared SQL statement
+  exit = sqlite3_bind_text(b_select_shares_stmt, 1, bank_name.c_str(), -1, NULL);
+  if (exit != SQLITE_OK) {
+      fprintf(stderr, "Failed to fetch data: %s\n", sqlite3_errmsg(DB));
+      sqlite3_close(DB);
+
+      return 1;
+  }
+  // execute SQL statement and store result
+  exit = sqlite3_step(b_select_shares_stmt);
+  std::string bank_shares = reinterpret_cast<char const*> (sqlite3_column_text(b_select_shares_stmt, 0));
+
+  hierarchy.append(indent + bank_name + "||" + bank_shares + "\n");
+
+  exit = sqlite3_bind_text(b_select_sub_banks_stmt, 1, bank_name.c_str(), -1, NULL);
+  if (exit != SQLITE_OK) {
+      fprintf(stderr, "Failed to fetch data: %s\n", sqlite3_errmsg(DB));
+      sqlite3_close(DB);
+
+      return 1;
+  }
+  exit = sqlite3_step(b_select_sub_banks_stmt);
+
+  // vector of tuples to store usernames and their respective shares
+  std::vector<std::tuple<std::string, std::string>> users;
+
+  // vector of strings to hold sub banks
+  std::vector<std::string> banks;
+
+  // we've reached a bank with no sub banks, so print
+  // out all associations under this sub bank
+  if (exit != SQLITE_ROW) {
+    exit = sqlite3_bind_text(b_select_associations_stmt, 1, bank_name.c_str(), -1, NULL);
+    if (exit != SQLITE_OK) {
+      fprintf(stderr, "Failed to fetch data: %s\n", sqlite3_errmsg(DB));
+      sqlite3_close(DB);
+
+      return 1;
+    }
+
+    // execute SQL statement
+    exit = sqlite3_step(b_select_associations_stmt);
+    while (exit == SQLITE_ROW) {
+      std::string user = reinterpret_cast<char const*> (sqlite3_column_text(b_select_associations_stmt, 0));
+      std::string single_user_shares = reinterpret_cast<char const*> (sqlite3_column_text(b_select_associations_stmt, 1));
+      // place the user and their allocated shares into vector
+      users.emplace_back(user, single_user_shares);
+      exit = sqlite3_step(b_select_associations_stmt);
+    }
+    // iterate through associations and append them to the hierarchy string
+    for (unsigned int i=0; i < users.size(); i++) {
+      std::string username = std::get<0>(users[i]);
+      std::string user_shares = std::get<1>(users[i]);
+      hierarchy.append(indent + " " + bank_name + "|" + username + "|" + user_shares + "\n");
+    }
+  }
+  // otherwise, this bank has sub banks, so call this helper
+  // function again with the first sub bank it found
+  else {
+    while (exit == SQLITE_ROW) {
+      // execute SQL statement
+      std::string bank = reinterpret_cast<char const*> (sqlite3_column_text(b_select_sub_banks_stmt, 0));
+      banks.push_back(bank);
+      exit = sqlite3_step(b_select_sub_banks_stmt);
+    }
+    for (std::string b : banks) {
+      // reset the prepared statements back to their initial state and
+      // clear their bindings
+      sqlite3_clear_bindings(b_select_associations_stmt);
+      sqlite3_reset(b_select_associations_stmt);
+      sqlite3_clear_bindings(b_select_sub_banks_stmt);
+      sqlite3_reset(b_select_sub_banks_stmt);
+      sqlite3_clear_bindings(b_select_shares_stmt);
+      sqlite3_reset(b_select_shares_stmt);
+      get_sub_banks(DB, b, indent + " ");
+    }
+  }
+
+  return 0;
+}
+
+
+/*
+print_hierarchy.cpp takes one argument, the path to a flux-accounting DB file.
+
+It will look for a parent bank in the bank table. It will exit if it does not
+find a root bank, or if it finds more than one root bank. Once it finds a root
+bank, it will call get_sub_banks, which is a recursive function that traverses
+the bank table with a depth-first search. Once it finds a bank with no sub
+banks, it will print any associations and their corresponding shares under that
+bank.
+*/
+int main(int argc, char** argv) {
+  std::string indent = "";
+
+  // only one argument should be passed in; a filepath to the flux-accounting DB
+  if (argc != 2) {
+    std::cerr << "incorrect number of args passed; please specify one db file path" << std::endl;
+    return(-1);
+  }
+
+  sqlite3* DB;
+  int exit = 0;
+
+  // open FluxAccounting database in read-write mode; if it does not exist yet,
+  // create a new database file
+  exit = sqlite3_open_v2(argv[1], &DB, SQLITE_OPEN_READWRITE, NULL);
+  if (exit) {
+    std::cerr << "error opening DB" << sqlite3_errmsg(DB) << std::endl;
+    return 1;
+  }
+
+  // SELECT statement to get the shares of the current bank
+  std::string select_shares_stmt = "SELECT bank_table.shares "
+                      "FROM bank_table "
+                      "WHERE bank=?";
+  exit = sqlite3_prepare_v2(DB, select_shares_stmt.c_str(), -1, &b_select_shares_stmt, 0);
+
+  // SELECT statement to get all sub banks of the current bank
+  std::string select_sub_banks_stmt = "SELECT bank_table.bank "
+                      "FROM bank_table "
+                      "WHERE parent_bank=?";
+  exit = sqlite3_prepare_v2(DB, select_sub_banks_stmt.c_str(), -1, &b_select_sub_banks_stmt, 0);
+
+  // SELECT statement to get all associations from a bank
+  std::string select_associations_stmt = "SELECT association_table.user_name, "
+                      "association_table.shares, "
+                      "association_table.bank "
+                      " FROM association_table "
+                      " WHERE association_table.bank=?";
+  exit = sqlite3_prepare_v2(DB, select_associations_stmt.c_str(), -1, &b_select_associations_stmt, 0);
+
+  // get the root bank and its shares in the bank table
+  std::string select_root_bank_stmt = "SELECT bank_table.bank "
+                      "FROM bank_table "
+                      "WHERE parent_bank=''";
+  // compile SQL statement into byte code
+  exit = sqlite3_prepare_v2(DB, select_root_bank_stmt.c_str(), -1, &b_select_root_bank_stmt, 0);
+  if (exit != SQLITE_OK) {
+      fprintf(stderr, "Failed to fetch data: %s\n", sqlite3_errmsg(DB));
+      sqlite3_close(DB);
+
+      return 1;
+  }
+  exit = sqlite3_step(b_select_root_bank_stmt);
+
+  // store root bank name
+  std::string root_bank;
+  if (exit == SQLITE_ROW) {
+      root_bank = reinterpret_cast<char const*> (sqlite3_column_text(b_select_root_bank_stmt, 0));
+  }
+  // otherwise, there is either no root bank, or more than one root bank was
+  // found; the program should exit
+  else {
+    std::cerr << "root bank not found, exiting" << std::endl;
+    return 1;
+  }
+
+  // call recursive function
+  get_sub_banks(DB, root_bank, indent);
+
+  // destroy the prepared SQL statements
+  sqlite3_finalize(b_select_root_bank_stmt);
+  sqlite3_finalize(b_select_shares_stmt);
+  sqlite3_finalize(b_select_sub_banks_stmt);
+  sqlite3_finalize(b_select_associations_stmt);
+
+  // print hierarchy
+  std::cout << hierarchy << std::endl;
+
+  // close DB connection
+  sqlite3_close(DB);
+
+}

--- a/src/fairness/print_hierarchy/test-print-hierarchy.sh
+++ b/src/fairness/print_hierarchy/test-print-hierarchy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+python3 ../../../accounting/accounting_cli.py create-db FluxAccounting.db
+
+python3 ../../../accounting/accounting_cli.py add-bank A 1
+
+python3 ../../../accounting/accounting_cli.py add-bank --parent-bank=A B 1
+
+python3 ../../../accounting/accounting_cli.py add-bank --parent-bank=B D 1
+
+python3 ../../../accounting/accounting_cli.py add-bank --parent-bank=B E 1
+
+python3 ../../../accounting/accounting_cli.py add-bank --parent-bank=A C 1
+
+python3 ../../../accounting/accounting_cli.py add-bank --parent-bank=C F 1
+
+python3 ../../../accounting/accounting_cli.py add-bank --parent-bank=C G 1
+
+python3 ../../../accounting/accounting_cli.py add-user --username=user1 --account=D
+
+python3 ../../../accounting/accounting_cli.py add-user --username=user2 --account=F
+
+python3 ../../../accounting/accounting_cli.py add-user --username=user3 --account=F
+
+python3 ../../../accounting/accounting_cli.py add-user --username=user4 --account=G
+
+python3 ../../../accounting/accounting_cli.py print-hierarchy > py-output.txt
+
+./print_hierarchy FluxAccounting.db > cpp-output.txt
+
+diff py-output.txt cpp-output.txt
+
+RC=$?
+
+rm py-output.txt cpp-output.txt FluxAccounting.db db_creation.log
+
+exit $RC


### PR DESCRIPTION
This experimental PR is my C++ implementation of the `print_hierarchy()` function, which will be used to display output from the flux-accounting database.

### current implementation

The program is compiled with the following:

```console
g++ print_hierarchy.cpp -l sqlite3 --std=c++11 -o print_hierarchy 
```

And is called with one command line argument, a path to the flux-accounting database file:

```console
./print_hierarchy path/to/FluxAccounting.db
```

In `main()`, the program attempts to open the database file in read-write mode. Once it opens the file, it will look for a root bank (one that sits on top of the hierarchical 'tree'). The program should exit if the following cases are met:

- the `bank_table` does not have a root bank (i.e. there is no bank in the `bank_table` that does not have a `parent_bank`)

- the `bank_table` has _more than one_ root bank (i.e there is more than one bank in the `bank_table` that does not have a `parent_bank`). 

After it finds a root bank, it calls `get_sub_banks()`, passing in the database handle and the name of the root bank. `get_sub_banks()` performs a depth-first-search of the `bank_table`, looking for sub banks. Upon coming across a bank with no sub banks (i.e. a 'leaf' bank), it will append all user accounts and their respective shares under that leaf bank to a global string, `hierarchy`. After completing a DFS traversal of the `bank_table`, it will print out the `hierarchy` string and close its connection to the DB.

```
Bank|User|RawShares
A||1|
 B||1|
  D||1|
   D|user1|1
  E||1|
 C||1|
  F||1|
   F|user2|1
   F|user3|1
  G||1|
   G|user4|1
```

### TODO

This program needs tests to be added. As of now, I've just been testing manually by passing in four different types of `bank_table`s from the flux-accounting database:

1. a standard 'successful' `bank_table`, like the one shown above

2. a `bank_table` with no root bank

3. a `bank_table` with more than one root bank

4. a successful `bank_table` where the banks are ordered in a different order

We can probably add sharness tests to confirm the correct output of running this program to automate this process. 

---

I'm not sure if we'll want to make this program a library instead with just functions that get called instead of one with a `main()` function. I'll leave that to @dongahn to give his feedback and suggestions on what he might need.

All of the SQLite database interactions in this program used the `sqlite3` C++ interface, which was actually pretty intuitive. The big difference I noticed between this and the Python interface was that the C++ version (to my knowledge) requires manually "stepping through" each result of a SQLite query, whereas Python can store its result in one `DataFrame` object, which can be indexed and iterated through.  

---

C++ styling: I'm not sure if there is a certain styling guide we use for C++, so I am sorry if there are formatting or other code conventions that I missed! 