### PR TITLE
NEWS.md: add release notes for v0.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+flux-accounting version 0.4.0 - 2020-11-06
+------------------------------------------
+
+#### Fixes
+
+* `view-job-records` subcommand parameters adjusted to be unpacked as a dictionary (#55)
+
+* Move `view_job_records()` and its helper functions into its own Python module (#57)
+
+#### Features
+
+* Add a library that provides a weighted tree-based fairness (#65)
+
+* Add autogen, automake tools to flux-accounting repo (#65)
+
 flux-accounting version 0.3.0 - 2020-09-30
 ------------------------------------------
 


### PR DESCRIPTION
Release notes for `v0.4.0`!

The big additions include the parameter fix from #55, the move of `view_job_records()` into its own module in #57, the addition of a library that provides a weighted tree-based fairness, and automake tools to the flux-accounting repo. 