### PR TITLE
print_hierarchy.cpp: move global variables into main(), add another test

### DIFF
--- a/src/fairness/print_hierarchy/test-print-hierarchy.sh
+++ b/src/fairness/print_hierarchy/test-print-hierarchy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# TEST 1: valid flux-accounting DB with a proper hierarchy
+
+echo "test 1: valid flux-accounting DB with a proper hierarchy"
+
 python3 ../../../accounting/accounting_cli.py create-db FluxAccounting.db
 
 python3 ../../../accounting/accounting_cli.py add-bank A 1
@@ -32,6 +36,28 @@ diff py-output.txt cpp-output.txt
 
 RC=$?
 
-rm py-output.txt cpp-output.txt FluxAccounting.db db_creation.log
+if [[ $RC = 0 ]]
+then
+  echo "test 1: success"
+  rm py-output.txt cpp-output.txt FluxAccounting.db db_creation.log
+else
+  exit $RC
+fi
 
-exit $RC
+# TEST 2: valid flux-accounting DB with no entries should exit out
+
+echo "test 2: valid flux-accounting DB with no entries in bank table"
+
+python3 ../../../accounting/accounting_cli.py create-db FluxAccounting.db
+
+./print_hierarchy FluxAccounting.db > error-output.txt 2>&1
+
+file_contents=`cat error-output.txt`
+
+if [[ $file_contents = 'root bank not found, exiting' ]]
+then
+  echo "test 2: success"
+  rm FluxAccounting.db db_creation.log error-output.txt
+else
+  exit 1
+fi


### PR DESCRIPTION
**Problem**: As noted in #71, a number of the `sqlite3_stmt` variables where defined in global scope. If we wanted to call `get_sub_banks()` from other parts of the codebase, we should instead move those variables inside `main()` and pass them into `get_sub_banks()`. 

---

This small PR does just that; moves the `sqlite3_stmt` variables into `main()` and reformats the function header and calls for `get_sub_banks()`. 

I also added another test to **test-print-hierarchy.sh**: when a flux-accounting database is created with no root bank, the program should detect that and exit out. 

Fixes #71 