### PR TITLE
fairshare implementation part 1: add effective job usage factor calculation  

### DIFF
--- a/src/bindings/python/flux/accounting/README.md
+++ b/src/bindings/python/flux/accounting/README.md
@@ -1,0 +1,85 @@
+### Job Usage Factor Calculation Documentation
+
+`calc_usage_factor()` is the function responsible for calculating a user's job usage factor as it relates to fairshare. The raw job usage factor is defined as the sum of products of number of nodes used (`nnodes`) and time elapsed (`t_elapsed`).
+
+```
+RawUsage = sum(nnodes * t_elapsed)
+```
+
+`create_db()` creates a new table **job_usage_factor_table** that is dynamically sized based on two options passed in when initially creating the database: **PriorityDecayHalfLife** and **PriorityUsageResetPeriod**. Each of these parameters represent a number of weeks by which to hold usage factors up to the time period where jobs no longer play a factor in calculating a usage factor. If these options aren't specified, the table defaults to 4 usage columns, each which represent one week's worth of jobs.
+
+The **job_usage_factor_table** stores past job usage factors per user/bank combination in the `association_table`. When a user is first added to **association_table**, they are also added to to **job_usage_factor_table**.
+
+```python
+def calc_usage_factor(jobs_conn, acct_conn, user, bank, priority_decay_half_life=None, priority_usage_reset_period=None,)
+```
+
+The value of **PriorityDecayHalfLife** determines the amount of time that represents one "usage period" of jobs. It then uses `view_job_records()` to filter out the job archive and retrieve a user's jobs that have completed in the time period specified. It saves the last seen `t_inactive` timestamp in the `job_usage_factor_table` for the next query that it runs, which will look for jobs that have completed after the saved timestamp.
+
+Past usage factors have a decay factor D (0.5) applied to them before they are added to the user's current usage factor.
+
+```python
+def apply_decay_factor(decay_factor, acct_conn, user=None, bank=None):
+```
+
+**usage_user_past** = `( D * Ulast_period) + (D * D * Uperiod-2) + ...`
+
+After the current usage factor is calculated, it is written to the first usage bin in **job_usage_factor_table** along with the other, older factors. The oldest factor gets removed from the table since it is no longer needed.
+
+Then, a similar process is repeated to calculate the raw usage factor for all of the user's siblings' jobs in that same time period.
+
+---
+
+### An example of calculating the job usage factor
+
+
+Let's say a user has the following job records from the most recent **PriorityDecayHalfLife**:
+
+```
+   UserID Username  JobID         T_Submit            T_Run       T_Inactive  Nodes                                                                               R
+0    1002     1002    102 1605633403.22141 1605635403.22141 1605637403.22141      2  {"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
+1    1002     1002    103 1605633403.22206 1605635403.22206 1605637403.22206      2  {"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
+2    1002     1002    104 1605633403.22285 1605635403.22286 1605637403.22286      2  {"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
+3    1002     1002    105 1605633403.22347 1605635403.22348 1605637403.22348      1  {"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
+4    1002     1002    106 1605633403.22416 1605635403.22416 1605637403.22416      1  {"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
+```
+
+**total nodes used**:  8
+
+**total time elapsed**:  10000.0
+
+**usage_user_current**:
+
+```
+sum(nnodes * t_elapsed) = (2 * 2000) + (2 * 2000) + (2 * 2000) + (1 * 2000) + (1 * 2000)
+                        = 4000 + 4000 + 4000 + 2000 + 2000
+                        = 16000
+```
+
+And the user's past job usage factors (each one represents a **PriorityDecayHalfLife** period up to the **PriorityUsageResetPeriod**) consist of the following:
+
+```
+  username bank  usage_factor_period_0  usage_factor_period_1  usage_factor_period_2  usage_factor_period_3
+0     1002    C               128.0000               64.00000               64.0000               16.00000
+```
+
+The past usage factors have the decay factor applied to them: `[64.0, 16.0, 8.0, 1.0]`
+
+**usage_user_past**:  `64.0 + 16.0 + 8.0 + 1.0 = 89`
+
+**usage_user_historical**: (usage\_user\_current) + (usage\_user\_past) = 16000 + 89 = 16089
+
+---
+
+### A typical workflow using calc_usage_factor() and update_end_half_life_period()
+
+Ultimately, a Python script (through a `cron` job or the like) would end up utilizing both `calc_usage_factor()` and `update_end_half_life_period()` in the following manner.
+
+
+Every **PriorityCalcPeriod**, the script would go through the following steps:
+
+- A list of user/bank combinations would be fetched from the `association_table` in the flux-accounting database.
+
+- For every user/bank combination, `calc_usage_factor()` is called; any new job records are fetched from the job-archive DB and a historical usage factor is generated. The appropriate values throughout the flux-accounting database would be updated to reflect this new usage factor.
+
+- After the list of user/bank usage values are calculated, `update_end_half_life_period()` is called to determine if we are in a new half-life period. If we are, we update the flux-accounting database with the new timestamp that represents the end of the new half-life period.

--- a/src/bindings/python/flux/accounting/accounting_cli_functions.py
+++ b/src/bindings/python/flux/accounting/accounting_cli_functions.py
@@ -94,7 +94,7 @@ def delete_bank(conn, bank):
             # we've reached a bank with no sub banks
             if len(dataframe) == 0:
                 select_associations_stmt = """
-                    SELECT user_name, bank
+                    SELECT username, bank
                     FROM association_table
                     WHERE bank=?
                     """
@@ -136,7 +136,7 @@ def edit_bank(conn, bank, shares):
 def view_user(conn, user):
     try:
         # get the information pertaining to a user in the Accounting DB
-        select_stmt = "SELECT * FROM association_table where user_name=?"
+        select_stmt = "SELECT * FROM association_table where username=?"
         dataframe = pd.read_sql_query(select_stmt, conn, params=(user,))
         # if the length of dataframe is 0, that means
         # the user specified was not found in the table
@@ -158,7 +158,7 @@ def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall
                 creation_time,
                 mod_time,
                 deleted,
-                user_name,
+                username,
                 admin_level,
                 bank,
                 shares,
@@ -188,14 +188,14 @@ def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall
 
 def delete_user(conn, user, bank):
     # delete user account from association_table
-    delete_stmt = "DELETE FROM association_table WHERE user_name=? AND bank=?"
+    delete_stmt = "DELETE FROM association_table WHERE username=? AND bank=?"
     cursor = conn.cursor()
     cursor.execute(delete_stmt, (user, bank,))
 
 
 def edit_user(conn, username, field, new_value):
     fields = [
-        "user_name",
+        "username",
         "admin_level",
         "bank",
         "shares",
@@ -208,7 +208,7 @@ def edit_user(conn, username, field, new_value):
 
             # edit value in accounting database
             conn.execute(
-                "UPDATE association_table SET " + the_field + "=? WHERE user_name=?",
+                "UPDATE association_table SET " + the_field + "=? WHERE username=?",
                 (new_value, username,),
             )
             # commit changes

--- a/src/bindings/python/flux/accounting/accounting_cli_functions.py
+++ b/src/bindings/python/flux/accounting/accounting_cli_functions.py
@@ -150,8 +150,8 @@ def view_user(conn, user):
 
 def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall_pj=60):
 
-    # insert the user values into the database
     try:
+        # insert the user values into association_table
         conn.execute(
             """
             INSERT INTO association_table (
@@ -180,6 +180,18 @@ def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall
             ),
         )
         # commit changes
+        conn.commit()
+        # insert the user values into job_usage_factor_table
+        conn.execute(
+            """
+            INSERT INTO job_usage_factor_table (
+                username,
+                bank
+            )
+            VALUES (?, ?)
+            """,
+            (username, bank,),
+        )
         conn.commit()
     # make sure entry is unique
     except sqlite3.IntegrityError as integrity_error:

--- a/src/bindings/python/flux/accounting/create_db.py
+++ b/src/bindings/python/flux/accounting/create_db.py
@@ -36,13 +36,13 @@ def create_db(filepath):
                 creation_time bigint(20)            NOT NULL,
                 mod_time      bigint(20)  DEFAULT 0 NOT NULL,
                 deleted       tinyint(4)  DEFAULT 0 NOT NULL,
-                user_name     tinytext              NOT NULL,
+                username      tinytext              NOT NULL,
                 admin_level   smallint(6) DEFAULT 1 NOT NULL,
                 bank          tinytext              NOT NULL,
                 shares        int(11)     DEFAULT 1 NOT NULL,
                 max_jobs      int(11)               NOT NULL,
                 max_wall_pj   int(11)               NOT NULL,
-                PRIMARY KEY   (user_name, bank)
+                PRIMARY KEY   (username, bank)
         );"""
     )
     logging.info("Created association_table successfully")

--- a/src/bindings/python/flux/accounting/flux-account.py
+++ b/src/bindings/python/flux/accounting/flux-account.py
@@ -64,7 +64,7 @@ def main():
         "--admin-level", help="admin level", default=1, metavar="ADMIN_LEVEL",
     )
     subparser_add_user.add_argument(
-        "--account", help="account to charge jobs against", metavar="ACCOUNT",
+        "--bank", help="bank to charge jobs against", metavar="BANK",
     )
     subparser_add_user.add_argument(
         "--parent-acct", help="parent account", default="", metavar="PARENT_ACCOUNT",
@@ -197,7 +197,7 @@ def main():
             aclif.add_user(
                 conn,
                 args.username,
-                args.account,
+                args.bank,
                 args.admin_level,
                 args.shares,
                 args.max_jobs,

--- a/src/bindings/python/flux/accounting/job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/job_archive_interface.py
@@ -13,6 +13,8 @@ import sqlite3
 import time
 import pwd
 import csv
+import os
+import math
 
 import pandas as pd
 
@@ -218,3 +220,202 @@ def view_job_records(conn, output_file, **kwargs):
             write_records_to_file(job_records, output_file)
 
     return job_records
+
+
+def fetch_old_usage_factors(acct_conn, user=None, bank=None):
+    past_usage_factors = []
+
+    select_stmt = "SELECT * from job_usage_factor_table WHERE username=? AND bank=?"
+    dataframe = pd.read_sql_query(select_stmt, acct_conn, params=(user, bank,))
+
+    for val in dataframe.iloc[0].values[3:]:
+        if isinstance(val, float):
+            past_usage_factors.append(val)
+
+    return past_usage_factors
+
+
+def apply_decay_factor(decay_factor, acct_conn, user=None, bank=None):
+    past_usage_factors = []
+    past_usage_factors_w_decay = []
+
+    past_usage_factors = fetch_old_usage_factors(acct_conn, user, bank)
+
+    # apply decay factor to past usage periods of a user's jobs
+    for power, usage_factor in enumerate(past_usage_factors, start=1):
+        past_usage_factors_w_decay.append(usage_factor * math.pow(decay_factor, power))
+
+    # update job_usage_factor_table with new values, starting with period-2;
+    # the last usage factor in the table will get discarded after the update
+    period = 1
+    for usage_factor in past_usage_factors_w_decay[
+        1 : len(past_usage_factors_w_decay) - 1
+    ]:
+        update_stmt = (
+            "UPDATE job_usage_factor_table SET usage_factor_period_"
+            + str(period)
+            + "=? WHERE username=? AND bank=?"
+        )
+        acct_conn.execute(update_stmt, (str(usage_factor), user, bank,))
+        acct_conn.commit()
+        period += 1
+
+    return sum(past_usage_factors_w_decay)
+
+
+def calc_usage_factor(
+    jobs_conn, acct_conn, priority_decay_half_life, user, bank,
+):
+
+    # half_life_period represents the number of weeks (converted to
+    # seconds) that represents one usage bin
+    half_life_period = priority_decay_half_life * 604800
+
+    # fetch timestamp of last seen job (will fetch jobs that
+    # have run after this time)
+    fetch_timestamp_query = """
+        SELECT last_job_timestamp
+        FROM job_usage_factor_table
+        WHERE username=? AND bank=?
+        """
+    dataframe = pd.read_sql_query(
+        fetch_timestamp_query, acct_conn, params=(user, bank,)
+    )
+    last_job_timestamp = dataframe.iloc[0]
+
+    # fetch timestamp of the end of the current half-life period
+    fetch_half_life_timestamp_query = """
+        SELECT end_half_life_period
+        FROM t_half_life_period_table
+        """
+    dataframe = pd.read_sql_query(fetch_half_life_timestamp_query, acct_conn)
+    t_end_half_life_period = dataframe.iloc[0]
+
+    # get the total number of nodes and time elapsed across
+    # all of a user's jobs that completed since the last completed
+    # job that was retrieved
+    job_totals_user = view_job_records(
+        jobs_conn,
+        output_file=None,
+        user=user,
+        after_start_time=float(last_job_timestamp),
+    )
+
+    last_t_inactive = 0.0
+    usage_user_current = 0.0
+
+    if len(job_totals_user) > 0:
+        # sort jobs by job.t_inactive
+        job_totals_user.sort(key=lambda job: job.t_inactive)
+
+        # one per job factor = nnodes * t_elapsed
+        # usage factors = total(nnodes * t_elapsed)
+        per_job_factors = []
+        for job in job_totals_user:
+            per_job_factors.append(round((job.nnodes * job.elapsed), 5))
+
+        last_t_inactive = job_totals_user[-1].t_inactive
+        usage_user_current = sum(per_job_factors)
+
+    # if no new jobs were found and we are still in the same half-life
+    # period, then the current usage remains the same
+    if len(job_totals_user) == 0 and (
+        float(t_end_half_life_period) > (time.time() - half_life_period)
+    ):
+        # fetch past usage factors
+        past_usage_factors = fetch_old_usage_factors(acct_conn, user, bank)
+
+        usage_user_historical = sum(past_usage_factors)
+    # if no new jobs were found but we are past the most recent half-life
+    # period, then the current usage needs to have a decay factor applied
+    # to it
+    elif len(job_totals_user) == 0 and (
+        float(t_end_half_life_period) < (time.time() - half_life_period)
+    ):
+        # fetch past usage factors
+        past_usage_factors = fetch_old_usage_factors(acct_conn, user, bank)
+
+        usage_user_historical = apply_decay_factor(0.5, acct_conn, user, bank)
+    # if last_t_inactive - t_end_half_life_period < half_life_period,
+    # append newly found jobs to the most recent usage factor
+    elif (last_t_inactive - float(t_end_half_life_period)) < half_life_period:
+        # append current usage to first usage factor bin
+        fetch_current_usage_factor = """
+            SELECT usage_factor_period_0
+            FROM job_usage_factor_table
+            WHERE username=?
+            AND bank=?
+            """
+        dataframe = pd.read_sql_query(
+            fetch_current_usage_factor, acct_conn, params=(user, bank,)
+        )
+        usage_factor_period_0 = dataframe.iloc[0]
+
+        usage_user_current += float(usage_factor_period_0)
+
+        # usage_user_past will just be the sum of the older factors since
+        # they will already had their decay factor applied to them in this
+        # current half-life period
+        usage_user_past = fetch_old_usage_factors(acct_conn, user, bank)
+
+        # calculate historical usage factor for user
+        usage_user_historical = usage_user_current + sum(usage_user_past[1:])
+    # else, create a new bin, move the older factors (and throw out the oldest
+    # one), and set a new end timestamp for the next half-life period
+    else:
+        # apply decay factor to past usage periods of a user's jobs
+        usage_user_past = apply_decay_factor(0.5, acct_conn, user, bank)
+
+        # calculate historical usage factor for user
+        usage_user_historical = usage_user_current + usage_user_past
+
+    # write last t_inactive to last_job_timestamp for user
+    update_timestamp_stmt = """
+        UPDATE job_usage_factor_table SET last_job_timestamp=?
+        WHERE username=?
+        AND bank=?
+        """
+    acct_conn.execute(update_timestamp_stmt, (last_t_inactive, user, bank,))
+    acct_conn.commit()
+
+    # write historical usage to first column in job_usage_factor_table
+    update_stmt = """
+        UPDATE job_usage_factor_table
+        SET usage_factor_period_0=?
+        WHERE username=?
+        AND bank=?
+        """
+    acct_conn.execute(update_stmt, (usage_user_historical, user, bank,))
+    acct_conn.commit()
+
+    return usage_user_historical
+
+
+def update_end_half_life_period(acct_conn, priority_decay_half_life):
+    # half_life_period represents the number of weeks (converted to
+    # seconds) that represents one usage bin
+    half_life_period = priority_decay_half_life * 604800
+
+    # fetch timestamp of the end of the current half-life period
+    fetch_half_life_timestamp_query = """
+        SELECT end_half_life_period
+        FROM t_half_life_period_table
+        WHERE cluster='cluster'
+        """
+    dataframe = pd.read_sql_query(fetch_half_life_timestamp_query, acct_conn)
+    t_end_half_life_period = dataframe.iloc[0]
+
+    # check to see if we are still in the same half-life period;
+    # if not, we need to update the end_half_life_period timestamp
+    # with a new timestamp value
+    if float(t_end_half_life_period) < (time.time() - half_life_period):
+        # update new end of half-life period timestamp
+        update_timestamp_stmt = """
+            UPDATE t_half_life_period_table
+            SET end_half_life_period=?
+            WHERE cluster='cluster'
+            """
+        acct_conn.execute(
+            update_timestamp_stmt, ((float(t_end_half_life_period) + half_life_period),)
+        )
+        acct_conn.commit()

--- a/src/bindings/python/flux/accounting/job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/job_archive_interface.py
@@ -140,11 +140,11 @@ class JobRecord(object):
 
     @property
     def elapsed(self):
-        return time.mktime(self.t_inactive) - time.mktime(self.t_run)
+        return self.t_inactive - self.t_run
 
     @property
     def queued(self):
-        return time.mktime(self.t_run) - time.mktime(self.t_submit)
+        return self.t_run - self.t_submit
 
 
 def add_job_records(dataframe):

--- a/src/bindings/python/flux/accounting/print_hierarchy.py
+++ b/src/bindings/python/flux/accounting/print_hierarchy.py
@@ -57,7 +57,7 @@ def print_full_hierarchy(conn):
         # out all associations under this sub bank
         if len(dataframe) == 0:
             select_stmt = """
-                SELECT association_table.user_name,
+                SELECT association_table.username,
                 association_table.shares,
                 association_table.bank
                 FROM association_table
@@ -70,7 +70,7 @@ def print_full_hierarchy(conn):
                     + indent
                     + association_row["bank"]
                     + "|"
-                    + association_row["user_name"]
+                    + association_row["username"]
                     + "|"
                     + str(association_row["shares"])
                     + "\n"

--- a/src/bindings/python/flux/accounting/test/test_create_db.py
+++ b/src/bindings/python/flux/accounting/test/test_create_db.py
@@ -49,7 +49,7 @@ class TestDB(unittest.TestCase):
         conn.execute(
             """
             INSERT INTO association_table
-            (creation_time, mod_time, deleted, user_name, admin_level,
+            (creation_time, mod_time, deleted, username, admin_level,
             bank, shares, max_jobs, max_wall_pj)
             VALUES
             (0, 0, 0, "test user", 1, "test account", 0, 0,

--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -16,8 +16,11 @@ import time
 
 import pandas as pd
 
+from unittest import mock
+
 from flux.accounting import job_archive_interface as jobs
 from flux.accounting import create_db as c
+from flux.accounting import accounting_cli_functions as aclif
 
 
 class TestAccountingCLI(unittest.TestCase):
@@ -52,13 +55,25 @@ class TestAccountingCLI(unittest.TestCase):
             );"""
         )
 
+        c.create_db("FluxAccountingUsers.db")
+        global acct_conn
+        acct_conn = sqlite3.connect("FluxAccountingUsers.db")
+
+        # add bank hierarchy
+        aclif.add_bank(acct_conn, bank="A", shares=1)
+        aclif.add_bank(acct_conn, bank="B", parent_bank="A", shares=1)
+        aclif.add_bank(acct_conn, bank="C", parent_bank="B", shares=1)
+        aclif.add_bank(acct_conn, bank="D", parent_bank="B", shares=1)
+
+        # add users
+        aclif.add_user(acct_conn, username="1001", bank="C")
+        aclif.add_user(acct_conn, username="1002", bank="C")
+        aclif.add_user(acct_conn, username="1003", bank="D")
+        aclif.add_user(acct_conn, username="1004", bank="D")
+
         def populate_job_archive_db(jobs_conn, userid, username, ranks, num_entries):
             nonlocal id
-            nonlocal t_submit
-            nonlocal t_sched
-            nonlocal t_run
-            nonlocal t_cleanup
-            nonlocal t_inactive
+            t_inactive_delta = 2000
 
             for i in range(num_entries):
                 try:
@@ -89,7 +104,7 @@ class TestAccountingCLI(unittest.TestCase):
                             time.time() - 1000,
                             time.time(),
                             time.time() + 1000,
-                            time.time() + 2000,
+                            time.time() + t_inactive_delta,
                             "eventlog",
                             "jobspec",
                             '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
@@ -102,11 +117,7 @@ class TestAccountingCLI(unittest.TestCase):
                     print(integrity_error)
 
                 id += 1
-                t_submit += 1000
-                t_sched += 1000
-                t_run += 1000
-                t_cleanup += 1000
-                t_inactive += 1000
+                t_inactive_delta += 100
 
         # populate the job-archive DB with fake job entries
         populate_job_archive_db(jobs_conn, 1001, "1001", "0", 2)
@@ -142,28 +153,28 @@ class TestAccountingCLI(unittest.TestCase):
 
     # passing a timestamp after all of the start time
     # of all the completed jobs should return a failure message
-    def test_05_after_start_time_none(self):
+    def test_04_after_start_time_none(self):
         my_dict = {"after_start_time": time.time()}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # passing a timestamp after the end time of the
     # last job should return all of the jobs
-    def test_06_before_end_time_all(self):
+    def test_05_before_end_time_all(self):
         my_dict = {"before_end_time": time.time() + 10000}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 18)
 
     # passing a timestamp before the end time of
     # all the completed jobs should return a failure message
-    def test_08_before_end_time_none(self):
+    def test_06_before_end_time_none(self):
         my_dict = {"before_end_time": 0}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # passing a user not in the jobs table
     # should return a failure message
-    def test_09_by_user_failure(self):
+    def test_07_by_user_failure(self):
         my_dict = {"user": "9999"}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
@@ -171,24 +182,166 @@ class TestAccountingCLI(unittest.TestCase):
     # view_jobs_run_by_username() interacts with a
     # passwd file; for the purpose of these tests,
     # just pass the userid
-    def test_10_by_user_success(self):
+    def test_08_by_user_success(self):
         my_dict = {"user": "1001"}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 2)
 
     # passing a combination of params should further
     # refine the query
-    def test_11_multiple_params(self):
+    def test_09_multiple_params(self):
         my_dict = {"user": "1001", "after_start_time": time.time() - 1000}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 2)
 
     # passing no parameters will result in a generic query
     # returning all results
-    def test_15_no_options_passed(self):
+    def test_10_no_options_passed(self):
         my_dict = {}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 18)
+
+    # users that have run a lot of jobs should have a larger usage factor
+    def test_11_calc_usage_factor_many_jobs(self):
+        user = "1002"
+        bank = "C"
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_0=256 WHERE username='1002' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_1=64 WHERE username='1002' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_2=16 WHERE username='1002' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_3=8 WHERE username='1002' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        acct_conn.commit()
+
+        usage_factor = jobs.calc_usage_factor(
+            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+        )
+        self.assertEqual(usage_factor, 17044.0)
+
+    # on the contrary, users that have not run a lot of jobs should have
+    # a smaller usage factor
+    def test_12_calc_usage_factor_few_jobs(self):
+        user = "1001"
+        bank = "C"
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_0=4096 WHERE username='1001' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_1=256 WHERE username='1001' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_2=32 WHERE username='1001' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_3=16 WHERE username='1001' AND bank='C'"
+        acct_conn.execute(update_stmt)
+        acct_conn.commit()
+
+        usage_factor = jobs.calc_usage_factor(
+            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+        )
+        self.assertEqual(usage_factor, 8500.0)
+
+    # make sure usage factor was written to job_usage_factor_table
+    def test_13_check_usage_factor_in_table(self):
+        select_stmt = "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='1002' AND bank='C'"
+        dataframe = pd.read_sql_query(select_stmt, acct_conn)
+        usage_factor = dataframe.iloc[0]
+        self.assertEqual(usage_factor["usage_factor_period_0"], 17044.0)
+
+    # re-calculating a job usage factor after the end of the last half-life
+    # period should create a new usage bin and update t_half_life_period_table
+    # with the new end time of the current half-life period
+    def test_14_append_jobs_in_diff_half_life_period(self):
+        user = "1001"
+        bank = "C"
+
+        try:
+            jobs_conn.execute(
+                """
+                INSERT INTO jobs (
+                    id,
+                    userid,
+                    username,
+                    ranks,
+                    t_submit,
+                    t_sched,
+                    t_run,
+                    t_cleanup,
+                    t_inactive,
+                    eventlog,
+                    jobspec,
+                    R
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "200",
+                    "1001",
+                    "1001",
+                    "0",
+                    time.time() + 11604800,
+                    time.time() + 11604900,
+                    time.time() + 11605000,
+                    time.time() + 11605100,
+                    time.time() + 11605200,
+                    "eventlog",
+                    "jobspec",
+                    '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
+                ),
+            )
+            # commit changes
+            jobs_conn.commit()
+        # make sure entry is unique
+        except sqlite3.IntegrityError as integrity_error:
+            print(integrity_error)
+
+        # re-calculate usage factor for user1001
+        usage_factor = jobs.calc_usage_factor(
+            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+        )
+        self.assertEqual(usage_factor, 4519.0)
+
+    # simulate a half-life period further; re-calculate
+    # usage for user1001 to make sure its value goes down
+    @mock.patch(
+        "time.time", mock.MagicMock(return_value=(time.time() + (604800 * 2.1)))
+    )
+    def test_15_recalculate_usage_after_half_life_period(self):
+        user = "1001"
+        bank = "C"
+
+        usage_factor = jobs.calc_usage_factor(
+            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+        )
+
+        self.assertEqual(usage_factor, 2277.00)
+
+    # simulate a half-life period further; assure the new end of the
+    # current half-life period gets updated
+    @mock.patch(
+        "time.time", mock.MagicMock(return_value=(time.time() + (604800 * 2.1)))
+    )
+    def test_16_update_end_half_life_period(self):
+        # fetch timestamp of the end of the current half-life period
+        fetch_half_life_timestamp_query = """
+            SELECT end_half_life_period
+            FROM t_half_life_period_table
+            WHERE cluster='cluster'
+            """
+        dataframe = pd.read_sql_query(fetch_half_life_timestamp_query, acct_conn)
+        old_end_half_life = dataframe.iloc[0]
+
+        jobs.update_end_half_life_period(acct_conn, priority_decay_half_life=1)
+
+        # fetch timestamp of the end of the new half-life period
+        fetch_half_life_timestamp_query = """
+            SELECT end_half_life_period
+            FROM t_half_life_period_table
+            WHERE cluster='cluster'
+            """
+        dataframe = pd.read_sql_query(fetch_half_life_timestamp_query, acct_conn)
+        new_end_half_life = dataframe.iloc[0]
+
+        self.assertGreater(float(new_end_half_life), float(old_end_half_life))
 
     # remove database and log file
     @classmethod
@@ -196,6 +349,7 @@ class TestAccountingCLI(unittest.TestCase):
         jobs_conn.close()
         os.remove("jobs.db")
         os.remove("job_records.csv")
+        os.remove("FluxAccountingUsers.db")
 
 
 def suite():
@@ -206,4 +360,5 @@ def suite():
 
 if __name__ == "__main__":
     from pycotap import TAPTestRunner
+
     unittest.main(testRunner=TAPTestRunner())

--- a/src/bindings/python/flux/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/flux/accounting/test/test_user_subcommands.py
@@ -89,9 +89,9 @@ class TestAccountingCLI(unittest.TestCase):
             max_wall_pj="60",
         )
         cursor = acct_conn.cursor()
-        cursor.execute("SELECT * from association_table where user_name='dup_user'")
+        cursor.execute("SELECT * from association_table where username='dup_user'")
         num_rows = cursor.execute(
-            "DELETE FROM association_table where user_name='dup_user'"
+            "DELETE FROM association_table where username='dup_user'"
         ).rowcount
 
         self.assertEqual(num_rows, 2)
@@ -101,7 +101,7 @@ class TestAccountingCLI(unittest.TestCase):
         aclif.edit_user(acct_conn, "fluxuser", "max_jobs", "10000")
         cursor = acct_conn.cursor()
         cursor.execute(
-            "SELECT max_jobs FROM association_table where user_name='fluxuser'"
+            "SELECT max_jobs FROM association_table where username='fluxuser'"
         )
 
         self.assertEqual(cursor.fetchone()[0], 10000)

--- a/src/bindings/python/flux/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/flux/accounting/test/test_user_subcommands.py
@@ -39,9 +39,12 @@ class TestAccountingCLI(unittest.TestCase):
             max_wall_pj="60",
         )
         cursor = acct_conn.cursor()
-        num_rows = cursor.execute("DELETE FROM association_table").rowcount
+        num_rows_assoc_table = cursor.execute("DELETE FROM association_table").rowcount
+        num_rows_job_usage_factor_table = cursor.execute(
+            "DELETE FROM job_usage_factor_table"
+        ).rowcount
 
-        self.assertEqual(num_rows, 1)
+        self.assertEqual(num_rows_assoc_table, num_rows_job_usage_factor_table)
 
     # adding a user with the same primary key (user_name, account) should
     # return an IntegrityError

--- a/src/fairness/print_hierarchy/print_hierarchy.cpp
+++ b/src/fairness/print_hierarchy/print_hierarchy.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv) {
   exit = sqlite3_prepare_v2(DB, select_sub_banks_stmt.c_str(), -1, &b_select_sub_banks_stmt, 0);
 
   // SELECT statement to get all associations from a bank
-  std::string select_associations_stmt = "SELECT association_table.user_name, "
+  std::string select_associations_stmt = "SELECT association_table.username, "
                       "association_table.shares, "
                       "association_table.bank "
                       " FROM association_table "

--- a/t/t1000-print-hierarchy.t
+++ b/t/t1000-print-hierarchy.t
@@ -14,10 +14,10 @@ test_expect_success 'create valid flux-accounting DB with a proper hierarchy' '
 	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-bank --parent-bank=A C 1 &&
 	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-bank --parent-bank=C F 1 &&
 	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-bank --parent-bank=C G 1 &&
-	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user1 --account=D &&
-	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user2 --account=F &&
-	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user3 --account=F &&
-	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user4 --account=G
+	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user1 --bank=D &&
+	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user2 --bank=F &&
+	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user3 --bank=F &&
+	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-user --username=user4 --bank=G
 '
 
 test_expect_success 'create hierarchy output from Python' '
@@ -33,7 +33,7 @@ test_expect_success 'compare hierarchy outputs' '
 '
 
 test_expect_success 'create valid flux-accounting DB with no entries in bank table' '
-	python3 ${ACCT_CLI} -p ./FluxAccounting-2.db create-db 
+	python3 ${ACCT_CLI} -p ./FluxAccounting-2.db create-db
 '
 
 test_expect_success 'print flux-accounting DB with no entries in bank table' '

--- a/t/t1000-print-hierarchy.t
+++ b/t/t1000-print-hierarchy.t
@@ -6,7 +6,7 @@ ACCT_CLI=${FLUX_SOURCE_DIR}/src/bindings/python/flux/accounting/flux-account.py
 PRINT_HIERARCHY=${FLUX_BUILD_DIR}/src/fairness/print_hierarchy/print_hierarchy
 
 test_expect_success 'create valid flux-accounting DB with a proper hierarchy' '
-	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db create-db &&
+	${PYTHON} ${ACCT_CLI} create-db ./FluxAccounting.db &&
 	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-bank A 1 &&
 	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-bank --parent-bank=A B 1 &&
 	${PYTHON} ${ACCT_CLI} -p ./FluxAccounting.db add-bank --parent-bank=B D 1 &&
@@ -33,7 +33,7 @@ test_expect_success 'compare hierarchy outputs' '
 '
 
 test_expect_success 'create valid flux-accounting DB with no entries in bank table' '
-	python3 ${ACCT_CLI} -p ./FluxAccounting-2.db create-db
+	python3 ${ACCT_CLI} create-db ./FluxAccounting-2.db
 '
 
 test_expect_success 'print flux-accounting DB with no entries in bank table' '


### PR DESCRIPTION
_note: this PR should probably be reviewed after #73 gets approved and landed since that is a higher priority at the moment, so I'll leave it as a Draft PR for now._ 

_note 2: there are a couple of smaller fixes that I included as a part of this PR as well - more specifically issues #67 and #70. If it is more appropriate to cut those out and post as separate PRs, I would be happy to do so._

This PR is part 1 of implementing a [Level Fairshare](https://slurm.schedmd.com/fair_tree.html) calculation into flux-accounting - calculating an effective usage factor for a given user in the flux-accounting database. It looks at a user's given jobs in the job-archive, calculates a raw usage factor (while also applying a half-life decay to that user's past job usage factors), and then divides that by a job usage factor calculated by the user's siblings' jobs. This returns an effective usage factor. Users who run many jobs will have a larger usage factor than those who do not run as many jobs. 

More specific details for how the FluxAccounting database stores past job usage factors, how the job usage factor calculation is performed, and a walkthrough of an example can be found on [this](https://github.com/flux-framework/flux-accounting/wiki/Job-Usage-Factor-Calculation-Notes) Wiki page. 

Essentially, the table that stores past job usage factors (the ones that have the half-life factor applied to them) is dynamically sized when the database is first created via two parameters, **PriorityDecayHalfLife** (how long we want one period of time to represent one job usage factor) and **PriorityUsageResetPeriod** (the amount of time before jobs no longer play a role in calculating a job usage factor). For now, both of these parameters represent a time period in weeks - however, I could see how we might want to make these bins shorter (in days, for example). 

I see the main function `calc_usage_factor()` as a function that gets called via a `cron` job, one that runs every _x_ period of time or so and updates all of the job usage factors for users in the `association_table`.

Fixes #58 