### PR TITLE
association_table: add job usage column to association_table

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])
 
-AM_INIT_AUTOMAKE([subdir-objects tar-ustar filename-length-max=256])
+AM_INIT_AUTOMAKE([subdir-objects tar-ustar filename-length-max=256 foreign])
 AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER([config.h])
 AM_MAINTAINER_MODE([enable])

--- a/src/bindings/python/flux/accounting/create_db.py
+++ b/src/bindings/python/flux/accounting/create_db.py
@@ -87,15 +87,16 @@ def create_db(
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS association_table (
-                creation_time bigint(20)            NOT NULL,
-                mod_time      bigint(20)  DEFAULT 0 NOT NULL,
-                deleted       tinyint(4)  DEFAULT 0 NOT NULL,
-                username      tinytext              NOT NULL,
-                admin_level   smallint(6) DEFAULT 1 NOT NULL,
-                bank          tinytext              NOT NULL,
-                shares        int(11)     DEFAULT 1 NOT NULL,
-                max_jobs      int(11)               NOT NULL,
-                max_wall_pj   int(11)               NOT NULL,
+                creation_time bigint(20)              NOT NULL,
+                mod_time      bigint(20)  DEFAULT 0   NOT NULL,
+                deleted       tinyint(4)  DEFAULT 0   NOT NULL,
+                username      tinytext                NOT NULL,
+                admin_level   smallint(6) DEFAULT 1   NOT NULL,
+                bank          tinytext                NOT NULL,
+                shares        int(11)     DEFAULT 1   NOT NULL,
+                max_jobs      int(11)                 NOT NULL,
+                max_wall_pj   int(11)                 NOT NULL,
+                job_usage     real        DEFAULT 0.0 NOT NULL,
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/bindings/python/flux/accounting/job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/job_archive_interface.py
@@ -427,6 +427,23 @@ def calc_usage_factor(
     )
     acct_conn.commit()
 
+    # update job_usage column in association_table
+    update_usage_stmt = """
+        UPDATE association_table
+        SET job_usage=?
+        WHERE username=?
+        AND bank=?
+        """
+    acct_conn.execute(
+        update_usage_stmt,
+        (
+            usage_user_historical,
+            user,
+            bank,
+        ),
+    )
+    acct_conn.commit()
+
     return usage_user_historical
 
 

--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -248,11 +248,19 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(usage_factor, 8500.0)
 
     # make sure usage factor was written to job_usage_factor_table
+    # and association_table
     def test_13_check_usage_factor_in_table(self):
         select_stmt = "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='1002' AND bank='C'"
         dataframe = pd.read_sql_query(select_stmt, acct_conn)
         usage_factor = dataframe.iloc[0]
         self.assertEqual(usage_factor["usage_factor_period_0"], 17044.0)
+
+        select_stmt = (
+            "SELECT job_usage FROM association_table WHERE username='1002' AND bank='C'"
+        )
+        dataframe = pd.read_sql_query(select_stmt, acct_conn)
+        job_usage = dataframe.iloc[0]
+        self.assertEqual(job_usage["job_usage"], 17044.0)
 
     # re-calculating a job usage factor after the end of the last half-life
     # period should create a new usage bin and update t_half_life_period_table


### PR DESCRIPTION
~Now that #79 has landed, we can add the job usage value returned by `calc_usage_factor()` to the output of `print-hierarchy`. The output should now look like the following:~

_please see comments at the bottom of this PR thread regarding changing the structure of this PR._ 

_note: this PR also includes the re-addition of `AUTHORS`; I removed the file in #90 not realizing that it was required to build flux-accounting: so sorry about that!_