### PR TITLE
delete_user/delete_bank: keep job usage history after deletion of user 

### DIFF
--- a/src/bindings/python/flux/accounting/README.md
+++ b/src/bindings/python/flux/accounting/README.md
@@ -26,8 +26,6 @@ def apply_decay_factor(decay_factor, acct_conn, user=None, bank=None):
 
 After the current usage factor is calculated, it is written to the first usage bin in **job_usage_factor_table** along with the other, older factors. The oldest factor gets removed from the table since it is no longer needed.
 
-Then, a similar process is repeated to calculate the raw usage factor for all of the user's siblings' jobs in that same time period.
-
 ---
 
 ### An example of calculating the job usage factor

--- a/src/bindings/python/flux/accounting/create_db.py
+++ b/src/bindings/python/flux/accounting/create_db.py
@@ -128,7 +128,6 @@ def create_db(
                 FOREIGN KEY (username, bank)
                     REFERENCES association_table (username, bank)
                         ON UPDATE CASCADE
-                        ON DELETE CASCADE
         );"""
     )
     add_usage_columns_to_table(

--- a/src/bindings/python/flux/accounting/create_db.py
+++ b/src/bindings/python/flux/accounting/create_db.py
@@ -107,7 +107,7 @@ def create_db(
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS bank_table (
-                bank_id     integer PRIMARY KEY,
+                bank_id     integer PRIMARY KEY AUTOINCREMENT,
                 bank        text                NOT NULL,
                 parent_bank text    DEFAULT '',
                 shares      int                 NOT NULL

--- a/src/bindings/python/flux/accounting/test/test_create_db.py
+++ b/src/bindings/python/flux/accounting/test/test_create_db.py
@@ -40,9 +40,12 @@ class TestDB(unittest.TestCase):
             list_of_tables.append(table_name)
             table = pd.read_sql_query("SELECT * from %s" % table_name, conn)
 
+        # sqlite_sequence is an internal table that SQLite
+        # uses to keep track of the largest ROWID
         expected = [
             "association_table",
             "bank_table",
+            "sqlite_sequence",
             "job_usage_factor_table",
             "t_half_life_period_table",
         ]

--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -343,6 +343,21 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertGreater(float(new_end_half_life), float(old_end_half_life))
 
+    # removing a user from the flux-accounting DB should NOT remove their job
+    # usage history from the job_usage_factor_table
+    def test_17_keep_job_usage_records_upon_delete(self):
+        aclif.delete_user(acct_conn, user="1001", bank="C")
+
+        select_stmt = """
+            SELECT * FROM
+            job_usage_factor_table
+            WHERE username='1001'
+            AND bank='C'
+            """
+
+        dataframe = pd.read_sql_query(select_stmt, acct_conn)
+        self.assertEqual(len(dataframe), 1)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
**Problem**: As noted in #84, the `job_usage_factor_table` references both the `association_table` and `bank_table`; when a bank (and its subsequent users) get removed, their job usage history will also be removed from this table. Speaking with Ryan, we should probably keep this data in case we need it at a later date.

---

This PR removes the `ON DELETE CASCADE` option from the creation of `job_usage_factor_table` so a user's job usage history is kept even when they are removed from the flux-accounting DB. I added a test that checks to see a user's entry in the `job_usage_factor_table` is still present even when they are removed from the `association_table`. 

Fixes #84