### PR TITLE
tests: integrate unittest.mock() with sample job-archive DB

### DIFF
--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -162,7 +162,7 @@ class TestAccountingCLI(unittest.TestCase):
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
-    # passing a timestamp after the end time of the
+    # passing a timestamp before the end time of the
     # last job should return all of the jobs
     def test_05_before_end_time_all(self):
         my_dict = {"before_end_time": time.time() + 10000}
@@ -170,14 +170,14 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(len(job_records), 18)
 
     # passing a timestamp before the end time of
-    # all the completed jobs should return a failure message
+    # the first completed jobs should return no jobs
     def test_06_before_end_time_none(self):
         my_dict = {"before_end_time": 0}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # passing a user not in the jobs table
-    # should return a failure message
+    # should return no jobs
     def test_07_by_user_failure(self):
         my_dict = {"user": "9999"}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)

--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -103,11 +103,11 @@ class TestAccountingCLI(unittest.TestCase):
                             userid,
                             username,
                             ranks,
-                            time.time() - 2000,
-                            time.time() - 1000,
-                            time.time(),
-                            time.time() + 1000,
-                            time.time() + t_inactive_delta,
+                            (time.time() + interval) - 2000,
+                            (time.time() + interval) - 1000,
+                            (time.time() + interval),
+                            (time.time() + interval) + 1000,
+                            (time.time() + interval) + t_inactive_delta,
                             "eventlog",
                             "jobspec",
                             '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
@@ -157,6 +157,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # passing a timestamp after all of the start time
     # of all the completed jobs should return a failure message
+    @mock.patch("time.time", mock.MagicMock(return_value=11000000))
     def test_04_after_start_time_none(self):
         my_dict = {"after_start_time": time.time()}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
@@ -164,8 +165,9 @@ class TestAccountingCLI(unittest.TestCase):
 
     # passing a timestamp before the end time of the
     # last job should return all of the jobs
+    @mock.patch("time.time", mock.MagicMock(return_value=11000000))
     def test_05_before_end_time_all(self):
-        my_dict = {"before_end_time": time.time() + 10000}
+        my_dict = {"before_end_time": time.time()}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 18)
 
@@ -193,10 +195,11 @@ class TestAccountingCLI(unittest.TestCase):
 
     # passing a combination of params should further
     # refine the query
+    @mock.patch("time.time", mock.MagicMock(return_value=10000500))
     def test_09_multiple_params(self):
-        my_dict = {"user": "1001", "after_start_time": time.time() - 1000}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 2)
+        my_dict = {"user": "1001", "after_start_time": time.time()}
+        job_records = jobs.view_job_records(jobs_conn, "records.csv", **my_dict)
+        self.assertEqual(len(job_records), 1)
 
     # passing no parameters will result in a generic query
     # returning all results

--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -33,8 +33,6 @@ class TestAccountingCLI(unittest.TestCase):
         global op
         op = "job_records.csv"
 
-        id = 100
-
         jobs_conn = sqlite3.connect("file:jobs.db?mode:rwc", uri=True)
         jobs_conn.execute(
             """
@@ -71,8 +69,13 @@ class TestAccountingCLI(unittest.TestCase):
         aclif.add_user(acct_conn, username="1003", bank="D")
         aclif.add_user(acct_conn, username="1004", bank="D")
 
+        jobid = 100
+        interval = 0  # add to job timestamps to diversify job-archive records
+
+        @mock.patch("time.time", mock.MagicMock(return_value=10000000))
         def populate_job_archive_db(jobs_conn, userid, username, ranks, num_entries):
-            nonlocal id
+            nonlocal jobid
+            nonlocal interval
             t_inactive_delta = 2000
 
             for i in range(num_entries):
@@ -96,7 +99,7 @@ class TestAccountingCLI(unittest.TestCase):
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
-                            id,
+                            jobid,
                             userid,
                             username,
                             ranks,
@@ -116,7 +119,8 @@ class TestAccountingCLI(unittest.TestCase):
                 except sqlite3.IntegrityError as integrity_error:
                     print(integrity_error)
 
-                id += 1
+                jobid += 1
+                interval += 10000
                 t_inactive_delta += 100
 
         # populate the job-archive DB with fake job entries


### PR DESCRIPTION
_note: this PR is built on top of #92, and should probably only be reviewed after that has landed._

**Problem**: 

Problem: The fake job-archive DB uses `time.time()` to generate the timestamps for the job records, which can sometimes create problems with testing.

---

Use `unittest.mock()` to generate the same timestamps for the job records every time the unit tests are run:

```
UserID|Username|JobID|T_Submit|T_Run|T_Inactive|Nodes|R
1001|1001|100|9998000.0 |10000000.0|10002000.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1001|1001|101|10008000.0|10010000.0|10012100.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1002|1002|102|10018000.0|10020000.0|10022000.0|2|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1002|1002|103|10028000.0|10030000.0|10032100.0|2|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1002|1002|104|10038000.0|10040000.0|10042200.0|2|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1002|1002|105|10048000.0|10050000.0|10052000.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1002|1002|106|10058000.0|10060000.0|10062100.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1003|1003|107|10068000.0|10070000.0|10072000.0|3|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1003|1003|108|10078000.0|10080000.0|10082100.0|3|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1003|1003|109|10088000.0|10090000.0|10092200.0|3|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|110|10098000.0|10100000.0|10102000.0|4|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|111|10108000.0|10110000.0|10112100.0|4|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|112|10118000.0|10120000.0|10122200.0|4|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|113|10128000.0|10130000.0|10132300.0|4|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|114|10138000.0|10140000.0|10142000.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|115|10148000.0|10150000.0|10152100.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|116|10158000.0|10160000.0|10162200.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
1004|1004|117|10168000.0|10170000.0|10172300.0|1|{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}
```

The reason I did not use `unittest.mock()` with `test_14_append_jobs_in_diff_half_life_period` is because `calc_usage_factor()` makes a call to `time.time()` in its function to determine if we are in the same half-life period or not, so I left that test be.

Fixes #86 