### PR TITLE
delete-user, delete-bank: add commit() to functions, add bank arg to delete-user subcommand

### DIFF
--- a/src/bindings/python/flux/accounting/accounting_cli_functions.py
+++ b/src/bindings/python/flux/accounting/accounting_cli_functions.py
@@ -97,7 +97,7 @@ def delete_bank(conn, bank):
                     WHERE bank=?
                     """
                 for row in cursor.execute(select_associations_stmt, (row["bank"],)):
-                    delete_user(conn, user=row[0], bank=row[1])
+                    delete_user(conn, username=row[0], bank=row[1])
             # else, delete all of its sub banks and continue
             # traversing
             else:
@@ -207,11 +207,17 @@ def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall
         print(integrity_error)
 
 
-def delete_user(conn, user, bank):
+def delete_user(conn, username, bank):
     # delete user account from association_table
     delete_stmt = "DELETE FROM association_table WHERE username=? AND bank=?"
     cursor = conn.cursor()
-    cursor.execute(delete_stmt, (user, bank,))
+    cursor.execute(
+        delete_stmt,
+        (
+            username,
+            bank,
+        ),
+    )
     # commit changes
     conn.commit()
 

--- a/src/bindings/python/flux/accounting/accounting_cli_functions.py
+++ b/src/bindings/python/flux/accounting/accounting_cli_functions.py
@@ -112,6 +112,10 @@ def delete_bank(conn, bank):
     except sqlite3.OperationalError as e:
         print(e)
         conn.rollback()
+        return 1
+
+    # commit changes
+    conn.commit()
 
 
 def edit_bank(conn, bank, shares):
@@ -207,13 +211,9 @@ def delete_user(conn, user, bank):
     # delete user account from association_table
     delete_stmt = "DELETE FROM association_table WHERE username=? AND bank=?"
     cursor = conn.cursor()
-    cursor.execute(
-        delete_stmt,
-        (
-            user,
-            bank,
-        ),
-    )
+    cursor.execute(delete_stmt, (user, bank,))
+    # commit changes
+    conn.commit()
 
 
 def edit_user(conn, username, field, new_value):

--- a/src/bindings/python/flux/accounting/create_db.py
+++ b/src/bindings/python/flux/accounting/create_db.py
@@ -124,10 +124,7 @@ def create_db(
                 username            tinytext                    NOT NULL,
                 bank                tinytext                    NOT NULL,
                 last_job_timestamp  real        DEFAULT 0.0,
-                PRIMARY KEY (username, bank),
-                FOREIGN KEY (username, bank)
-                    REFERENCES association_table (username, bank)
-                        ON UPDATE CASCADE
+                PRIMARY KEY (username, bank)
         );"""
     )
     add_usage_columns_to_table(

--- a/src/bindings/python/flux/accounting/flux-account.py
+++ b/src/bindings/python/flux/accounting/flux-account.py
@@ -101,6 +101,7 @@ def main():
     subparser_delete_user.add_argument(
         "username", help="username", metavar=("USERNAME")
     )
+    subparser_delete_user.add_argument("bank", help="bank", metavar=("BANK"))
 
     subparser_edit_user = subparsers.add_parser("edit-user", help="edit a user's value")
     subparser_edit_user.set_defaults(func="edit_user")
@@ -258,7 +259,7 @@ def main():
                 args.max_wall_pj,
             )
         elif args.func == "delete_user":
-            aclif.delete_user(conn, args.username)
+            aclif.delete_user(conn, args.username, args.bank)
         elif args.func == "edit_user":
             aclif.edit_user(conn, args.username, args.field, args.new_value)
         elif args.func == "view_job_records":

--- a/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/flux/accounting/test/test_job_archive_interface.py
@@ -353,7 +353,7 @@ class TestAccountingCLI(unittest.TestCase):
     # removing a user from the flux-accounting DB should NOT remove their job
     # usage history from the job_usage_factor_table
     def test_17_keep_job_usage_records_upon_delete(self):
-        aclif.delete_user(acct_conn, user="1001", bank="C")
+        aclif.delete_user(acct_conn, username="1001", bank="C")
 
         select_stmt = """
             SELECT * FROM

--- a/src/bindings/python/flux/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/flux/accounting/test/test_user_subcommands.py
@@ -126,7 +126,7 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(len(num_rows_before_delete), 1)
 
-        aclif.delete_user(acct_conn, user="fluxuser", bank="acct")
+        aclif.delete_user(acct_conn, username="fluxuser", bank="acct")
 
         cursor.execute(
             "SELECT * FROM association_table WHERE username='fluxuser' AND bank='acct'"

--- a/src/bindings/python/flux/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/flux/accounting/test/test_user_subcommands.py
@@ -116,6 +116,25 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertRaises(ValueError)
 
+    # delete a user from the association table
+    def test_06_delete_user(self):
+        cursor = acct_conn.cursor()
+        cursor.execute(
+            "SELECT * FROM association_table WHERE username='fluxuser' AND bank='acct'"
+        )
+        num_rows_before_delete = cursor.fetchall()
+
+        self.assertEqual(len(num_rows_before_delete), 1)
+
+        aclif.delete_user(acct_conn, user="fluxuser", bank="acct")
+
+        cursor.execute(
+            "SELECT * FROM association_table WHERE username='fluxuser' AND bank='acct'"
+        )
+        num_rows_after_delete = cursor.fetchall()
+
+        self.assertEqual(len(num_rows_after_delete), 0)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
As noted in #95, there were a couple of issues with the `delete-user` and `delete-bank` subcommands.

Trying to delete a user results in the following error:

```console
[fluxuser@30451d797d82 accounting-DB]$ flux account -p FluxAccounting.db delete-user user1
Traceback (most recent call last):
  File "/usr/libexec/flux/cmd/flux-account.py", line 249, in <module>
    main()
  File "/usr/libexec/flux/cmd/flux-account.py", line 220, in main
    aclif.delete_user(conn, args.username)
```

As well as the presence of a foreign key issue between the `association_table` and the `job_usage_factor_table`. Basically, when a user gets removed from the `association_table`, their entry in the `job_usage_factor_table` is no longer valid because it references the entry in the `association_table`, thus rejecting the deletion. 

The other problem was the absence of a `conn.commit()` in `both delete_user()` and `delete_bank()`. Without it, when you pass a subcommand to try and delete either a user or bank, the command succeeds, but doesn't keep the change. So I think I will need to add `conn.commit()` to both functions; one to `delete_user()` and one at the end of `delete_bank()` (See [this](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.commit) reference for `conn.commit()`). 

---

This PR adds `BANK` as another argument to the `delete-user` subcommand, adds `conn.commit()` to `delete_user()` and `delete_bank()`, and removes the foreign key on the `job_usage_factor_table`. 

Fixes #95 