### PR TITLE
flux-account.py: remove shebang line from top of file

### DIFF
--- a/src/bindings/python/flux/accounting/flux-account.py
+++ b/src/bindings/python/flux/accounting/flux-account.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 ###############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)


### PR DESCRIPTION
Problem: As noted in #89, the shebang line at the top of **flux-account.py** might lead to a Python version mismatch.

This PR removes the shebang line at the top of the file to follow flux-core's Python convention.