### PR TITLE
docker: change module/dependency installation in bionic image, add a README

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - status-success="validate commits"
       - status-success="python format"
       - status-success="centos8 - py3.6"
-      - status-success="bionic - py3.7"
+      - status-success="bionic - py3.6"
       - status-success="python lint"
       - status-success="coverage"
       - label="merge-when-passing"

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,13 @@ AC_SUBST(fluxrc1dir)
 AS_VAR_SET(fluxrc3dir, $sysconfdir/flux/rc3.d)
 AC_SUBST(fluxrc3dir)
 
+# Target of PYTHONPATH set by flux(1) cmddriver, so flux(1)
+# doesn't inadvertently insert system python paths (or any
+# other python path for that matter) first in PYTHONPATH.
+#
+AS_VAR_SET(fluxpylinkdir, $fluxlibdir/python$PYTHON_VERSION)
+AC_SUBST(fluxpylinkdir)
+
 AS_VAR_SET(fluxpydir, $pyexecdir/fluxacct)
 AC_SUBST(fluxpydir)
 AS_VAR_SET(acctpydir, $fluxpydir/accounting)

--- a/src/bindings/python/fluxacct/Makefile.am
+++ b/src/bindings/python/fluxacct/Makefile.am
@@ -1,1 +1,15 @@
 SUBDIRS = accounting
+
+install-data-hook:
+	$(AM_V_at)echo Linking python modules in non-standard location... && \
+	  $(INSTALL) -d -m 0755 "$(DESTDIR)$(fluxpylinkdir)" && \
+	  target=$(fluxpydir) && \
+	  f=$${target##*/} && \
+	  cd "$(DESTDIR)$(fluxpylinkdir)" && \
+	  rm -f $$f && \
+	  $(LN_S) $$target .
+
+uninstall-local:
+	$(AM_V_at)target=$(fluxpydir) && f=$${target##*/} && \
+	  echo "Removing $(fluxpylinkdir)/$$f" && \
+	  rm -rf $(fluxpylinkdir)/$$f

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -1,0 +1,28 @@
+## Docker images for flux-accounting
+
+The Dockerfiles, resulting docker images, and the `docker-run-checks.sh` script contained herein are used as part of the strategy for CI testing of flux-accounting.
+
+Docker is used under CI to speed up deployment of an environment with correct build dependencies. flux-accounting builds against the latest or a tagged version of flux-core by including `FROM fluxrm/flux-core:` at the top of each Dockerfile.
+
+### Local Testing
+
+Developers can test the docker images themselves. If new dependencies are needed, they can update the `$image` Dockerfiles manually (where `$image` is one of `bionic` or `centos8`). To run inside a local Docker image, run the command:
+
+```console
+docker-run-checks.sh -i $image [options] -- [arguments]
+```
+
+### Interactive Testing
+
+While running in an interactive Docker container, you can build, test, and interact with flux-accounting. The `bionic` image has multiple versions of Python installed, which you can configure and build against (the default version for both images is Python version `3.6`).
+
+Remember to install the required dependencies before you build and add the appropriate install location to your `PYTHONPATH`. Below is an example of configuring and building against Python version `3.7` while running inside the Docker container.
+
+```console
+sudo python3.7 -m pip install pandas==0.24.1
+./autogen.sh
+PYTHON_VERSION=3.7 ./configure
+make
+make check
+export PYTHONPATH=$PYTHONPATH:/usr/lib/python3.7/site-packages/
+```

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -18,7 +18,7 @@ RUN \
  fi
 
 RUN \
- sudo python3.7 -m pip install pandas==0.24.1
+ sudo pip3 install pandas==0.24.1
 
 USER $USER
 WORKDIR /home/$USER

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -137,7 +137,6 @@ matrix = BuildMatrix()
 # Ubuntu: coverage
 matrix.add_build(
     name="coverage",
-    env=dict(PYTHON_VERSION="3.7"),
     coverage=True,
     jobs=2,
 )
@@ -146,15 +145,13 @@ matrix.add_build(
 matrix.add_build(
     name="centos8 - py3.6",
     image="centos8",
-    env=dict(PYTHON_VERSION="3.6"),
     docker_tag=True,
 )
 
 # Bionic
 matrix.add_build(
-    name="bionic - py3.7",
+    name="bionic - py3.6",
     image="bionic",
-    env=dict(PYTHON_VERSION="3.7"),
     docker_tag=True,
 )
 


### PR DESCRIPTION
While working inside of the `bionic` Docker image the other day/this morning, I ran into some trouble trying to install flux-accounting and use it. More specifically, I continued to run into dependency issues both with the `accounting` module and the `pandas` dependency itself:

```console
moussa1@docker-desktop:/usr/src$ flux account -h
Traceback (most recent call last):
  File "/usr/libexec/flux/cmd/flux-account.py", line 15, in <module>
    import fluxacct.accounting
ModuleNotFoundError: No module named 'fluxacct'
```

After some fiddling around, I think I found that the answer included not adding the location of `/usr/lib/python3.7/site-packages/` to my `PYTHONPATH`. I think the `bionic` image could be improved by not having to perform these steps manually after the user starts up an interactive session.

---

This PR changes the `pandas` installation to install to the default Flux Python version on the bionic image, which is Python `3.6`. This matches the version on the other Docker image in flux-accounting, `centos8`. It also adds a new line in the `bionic` Dockerfile which adds `/usr/lib/python3.6/site-packages/` (the location of the `fluxacct.accounting` module) to `PYTHONPATH` so that the user does not have to add it themselves when running inside the container.

It also changes the Python version of the `coverage` build when running CI; the three builds, `bionic`, `centos8`, and `coverage` should now all configure and build with Python `3.6` by default.

The last thing I added was a `README` to the `docker` directory inside flux-accounting with instructions on how to build the images and run an interactive session, along with specific instructions on how to configure and build with a different version of Python if they so choose. 