### PR TITLE
job_archive_interface: refactor calc_usage_factor(), add job usage calculation subcommand

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -254,7 +254,7 @@ def get_last_job_ts(acct_conn, user, bank):
     return float(timestamp.iloc[0])
 
 
-def fetch_old_usage_factors(acct_conn, user=None, bank=None):
+def fetch_usg_bins(acct_conn, user=None, bank=None):
     past_usage_factors = []
 
     select_stmt = "SELECT * from job_usage_factor_table WHERE username=? AND bank=?"
@@ -278,7 +278,7 @@ def apply_decay_factor(decay, acct_conn, user=None, bank=None):
     usg_past = []
     usg_past_decay = []
 
-    usg_past = fetch_old_usage_factors(acct_conn, user, bank)
+    usg_past = fetch_usg_bins(acct_conn, user, bank)
 
     # apply decay factor to past usage periods of a user's jobs
     for power, usage_factor in enumerate(usg_past, start=1):
@@ -362,7 +362,7 @@ def calc_usage_factor(jobs_conn, acct_conn, pdhl, user, bank):
 
     if len(user_jobs) == 0 and (float(end_hl) > (time.time() - hl_period)):
         # no new jobs in the current half-life period
-        usg_past = fetch_old_usage_factors(acct_conn, user, bank)
+        usg_past = fetch_usg_bins(acct_conn, user, bank)
 
         usg_historical = sum(usg_past)
     elif len(user_jobs) == 0 and (float(end_hl) < (time.time() - hl_period)):
@@ -375,7 +375,7 @@ def calc_usage_factor(jobs_conn, acct_conn, pdhl, user, bank):
         usg_current += get_curr_usg_bin(acct_conn, user, bank)
 
         # usage_user_past = sum of the older usage factors
-        usg_past = fetch_old_usage_factors(acct_conn, user, bank)
+        usg_past = fetch_usg_bins(acct_conn, user, bank)
 
         usg_historical = usg_current + sum(usg_past[1:])
     else:

--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -421,7 +421,7 @@ def calc_usage_factor(jobs_conn, acct_conn, pdhl, user, bank):
     return usg_historical
 
 
-def update_end_half_life_period(acct_conn, pdhl):
+def check_end_hl(acct_conn, pdhl):
     hl_period = pdhl * 604800
 
     # fetch timestamp of the end of the current half-life period

--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -449,3 +449,13 @@ def check_end_hl(acct_conn, pdhl):
             """
         acct_conn.execute(update_timestamp_stmt, ((float(end_hl) + hl_period),))
         acct_conn.commit()
+
+
+def update_job_usage(acct_conn, jobs_conn, pdhl):
+    s_assoc = "SELECT username, bank FROM association_table"
+    dataframe = pd.read_sql_query(s_assoc, acct_conn)
+
+    for _, row in dataframe.iterrows():
+        calc_usage_factor(jobs_conn, acct_conn, pdhl, row["username"], row["bank"])
+
+    check_end_hl(acct_conn, pdhl)

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -350,7 +350,7 @@ class TestAccountingCLI(unittest.TestCase):
         dataframe = pd.read_sql_query(s_end_hl, acct_conn)
         old_hl = dataframe.iloc[0]
 
-        jobs.update_end_half_life_period(acct_conn, pdhl=1)
+        jobs.check_end_hl(acct_conn, pdhl=1)
 
         dataframe = pd.read_sql_query(s_end_hl, acct_conn)
         new_hl = dataframe.iloc[0]

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -80,7 +80,7 @@ class TestAccountingCLI(unittest.TestCase):
         jobid = 100
         interval = 0  # add to job timestamps to diversify job-archive records
 
-        @mock.patch("time.time", mock.MagicMock(return_value=10000000))
+        @mock.patch("time.time", mock.MagicMock(return_value=9000000))
         def populate_job_archive_db(jobs_conn, userid, username, ranks, num_entries):
             nonlocal jobid
             nonlocal interval
@@ -203,7 +203,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # passing a combination of params should further
     # refine the query
-    @mock.patch("time.time", mock.MagicMock(return_value=10000500))
+    @mock.patch("time.time", mock.MagicMock(return_value=9000500))
     def test_09_multiple_params(self):
         my_dict = {"user": "1001", "after_start_time": time.time()}
         job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
@@ -217,6 +217,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(len(job_records), 18)
 
     # users that have run a lot of jobs should have a larger usage factor
+    @mock.patch("time.time", mock.MagicMock(return_value=9900000))
     def test_11_calc_usage_factor_many_jobs(self):
         user = "1002"
         bank = "C"
@@ -237,6 +238,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # on the contrary, users that have not run a lot of jobs should have
     # a smaller usage factor
+    @mock.patch("time.time", mock.MagicMock(return_value=9900000))
     def test_12_calc_usage_factor_few_jobs(self):
         user = "1001"
         bank = "C"
@@ -288,8 +290,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(job_usage["job_usage"], 17044.0)
 
     # re-calculating a job usage factor after the end of the last half-life
-    # period should create a new usage bin and update t_half_life_period_table
-    # with the new end time of the current half-life period
+    # period should create a new usage bin
     @mock.patch("time.time", mock.MagicMock(return_value=(100000000 + (604800 * 2.1))))
     def test_15_append_jobs_in_diff_half_life_period(self):
         user = "1001"

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -231,7 +231,7 @@ class TestAccountingCLI(unittest.TestCase):
         acct_conn.commit()
 
         usage_factor = jobs.calc_usage_factor(
-            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+            jobs_conn, acct_conn, pdhl=1, user=user, bank=bank
         )
         self.assertEqual(usage_factor, 17044.0)
 
@@ -251,7 +251,7 @@ class TestAccountingCLI(unittest.TestCase):
         acct_conn.commit()
 
         usage_factor = jobs.calc_usage_factor(
-            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+            jobs_conn, acct_conn, pdhl=1, user=user, bank=bank
         )
         self.assertEqual(usage_factor, 8500.0)
 
@@ -320,7 +320,7 @@ class TestAccountingCLI(unittest.TestCase):
 
         # re-calculate usage factor for user1001
         usage_factor = jobs.calc_usage_factor(
-            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+            jobs_conn, acct_conn, pdhl=1, user=user, bank=bank
         )
         self.assertEqual(usage_factor, 4519.0)
 
@@ -332,7 +332,7 @@ class TestAccountingCLI(unittest.TestCase):
         bank = "C"
 
         usage_factor = jobs.calc_usage_factor(
-            jobs_conn, acct_conn, priority_decay_half_life=1, user=user, bank=bank
+            jobs_conn, acct_conn, pdhl=1, user=user, bank=bank
         )
 
         self.assertEqual(usage_factor, 2277.00)
@@ -342,26 +342,20 @@ class TestAccountingCLI(unittest.TestCase):
     @mock.patch("time.time", mock.MagicMock(return_value=(10000000 + (604800 * 2.1))))
     def test_16_update_end_half_life_period(self):
         # fetch timestamp of the end of the current half-life period
-        fetch_half_life_timestamp_query = """
+        s_end_hl = """
             SELECT end_half_life_period
             FROM t_half_life_period_table
             WHERE cluster='cluster'
             """
-        dataframe = pd.read_sql_query(fetch_half_life_timestamp_query, acct_conn)
-        old_end_half_life = dataframe.iloc[0]
+        dataframe = pd.read_sql_query(s_end_hl, acct_conn)
+        old_hl = dataframe.iloc[0]
 
-        jobs.update_end_half_life_period(acct_conn, priority_decay_half_life=1)
+        jobs.update_end_half_life_period(acct_conn, pdhl=1)
 
-        # fetch timestamp of the end of the new half-life period
-        fetch_half_life_timestamp_query = """
-            SELECT end_half_life_period
-            FROM t_half_life_period_table
-            WHERE cluster='cluster'
-            """
-        dataframe = pd.read_sql_query(fetch_half_life_timestamp_query, acct_conn)
-        new_end_half_life = dataframe.iloc[0]
+        dataframe = pd.read_sql_query(s_end_hl, acct_conn)
+        new_hl = dataframe.iloc[0]
 
-        self.assertGreater(float(new_end_half_life), float(old_end_half_life))
+        self.assertGreater(float(new_hl), float(old_hl))
 
     # removing a user from the flux-accounting DB should NOT remove their job
     # usage history from the job_usage_factor_table

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -355,10 +355,26 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(usage_factor, 2199.5)
 
+    # calling update_job_usage() in the same half-life period should NOT
+    # update usage factors for users
+    @mock.patch("time.time", mock.MagicMock(return_value=(10000000 + (604799))))
+    def test_17_update_job_usage_same_half_life_period(self):
+        s_stmt = """
+            SELECT job_usage FROM association_table
+            WHERE username='1002' AND bank='C'
+            """
+        dataframe = pd.read_sql_query(s_stmt, acct_conn)
+        self.assertEqual(float(dataframe.iloc[0]), 17044.0)
+
+        jobs.update_job_usage(acct_conn, jobs_conn, pdhl=1)
+
+        dataframe = pd.read_sql_query(s_stmt, acct_conn)
+        self.assertEqual(float(dataframe.iloc[0]), 17044.0)
+
     # simulate a half-life period further; assure the new end of the
     # current half-life period gets updated
     @mock.patch("time.time", mock.MagicMock(return_value=(10000000 + (604800 * 2.1))))
-    def test_17_update_end_half_life_period(self):
+    def test_18_update_end_half_life_period(self):
         # fetch timestamp of the end of the current half-life period
         s_end_hl = """
             SELECT end_half_life_period
@@ -377,7 +393,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # removing a user from the flux-accounting DB should NOT remove their job
     # usage history from the job_usage_factor_table
-    def test_18_keep_job_usage_records_upon_delete(self):
+    def test_19_keep_job_usage_records_upon_delete(self):
         aclif.delete_user(acct_conn, username="1001", bank="C")
 
         select_stmt = """
@@ -389,6 +405,22 @@ class TestAccountingCLI(unittest.TestCase):
 
         dataframe = pd.read_sql_query(select_stmt, acct_conn)
         self.assertEqual(len(dataframe), 1)
+
+    # calling update_job_usage in the next half-life period should update usage
+    # factors for users
+    @mock.patch("time.time", mock.MagicMock(return_value=(10000000 + (604800 * 2.1))))
+    def test_20_update_job_usage_next_half_life_period(self):
+        s_stmt = """
+            SELECT job_usage FROM association_table
+            WHERE username='1002' AND bank='C'
+            """
+        dataframe = pd.read_sql_query(s_stmt, acct_conn)
+        self.assertEqual(float(dataframe.iloc[0]), 17044.0)
+
+        jobs.update_job_usage(acct_conn, jobs_conn, pdhl=1)
+
+        dataframe = pd.read_sql_query(s_stmt, acct_conn)
+        self.assertEqual(float(dataframe.iloc[0]), 8496.0)
 
     # remove database and log file
     @classmethod

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -278,7 +278,7 @@ class TestAccountingCLI(unittest.TestCase):
         select_stmt = "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='1002' AND bank='C'"
         dataframe = pd.read_sql_query(select_stmt, acct_conn)
         usage_factor = dataframe.iloc[0]
-        self.assertEqual(usage_factor["usage_factor_period_0"], 17044.0)
+        self.assertEqual(usage_factor["usage_factor_period_0"], 16956.0)
 
         select_stmt = (
             "SELECT job_usage FROM association_table WHERE username='1002' AND bank='C'"
@@ -339,7 +339,7 @@ class TestAccountingCLI(unittest.TestCase):
         usage_factor = jobs.calc_usage_factor(
             jobs_conn, acct_conn, pdhl=1, user=user, bank=bank
         )
-        self.assertEqual(usage_factor, 4519.0)
+        self.assertEqual(usage_factor, 4366.0)
 
     # simulate a half-life period further; re-calculate
     # usage for user1001 to make sure its value goes down
@@ -352,7 +352,7 @@ class TestAccountingCLI(unittest.TestCase):
             jobs_conn, acct_conn, pdhl=1, user=user, bank=bank
         )
 
-        self.assertEqual(usage_factor, 2277.00)
+        self.assertEqual(usage_factor, 2199.5)
 
     # simulate a half-life period further; assure the new end of the
     # current half-life period gets updated

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -222,6 +222,23 @@ def add_edit_bank_arg(subparsers):
     )
 
 
+def add_update_usage_arg(subparsers):
+    subparser_update_usage = subparsers.add_parser(
+        "update-usage", help="update usage factors for associations"
+    )
+    subparser_update_usage.set_defaults(func="update_usage")
+    subparser_update_usage.add_argument(
+        "job_archive_db_path",
+        help="job-archive DB location",
+        metavar="JOB-ARCHIVE_DB_PATH",
+    )
+    subparser_update_usage.add_argument(
+        "--priority-decay-half-life",
+        help="contribution of historical usage in weeks on the composite usage value",
+        metavar="PRIORITY DECAY HALF LIFE",
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -235,6 +252,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_view_bank_arg(subparsers)
     add_delete_bank_arg(subparsers)
     add_edit_bank_arg(subparsers)
+    add_update_usage_arg(subparsers)
 
 
 def set_db_location(args):
@@ -302,6 +320,9 @@ def select_accounting_function(args, conn, output_file, parser):
         aclif.delete_bank(conn, args.bank)
     elif args.func == "edit_bank":
         aclif.edit_bank(conn, args.bank, args.shares)
+    elif args.func == "update_usage":
+        jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
+        jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)
     else:
         print(parser.print_usage())
 


### PR DESCRIPTION
### Background 

Noted in #117, there is currently no call to the `calc_usage_factor()` function, which is responsible for calculating an association's job usage value. This is another prerequisite for our server-side plugin work, where we are periodically re-calculating both usage and fairshare values and updating them, where they'll then be used to calculate a user's job priority.

But as I was adding a new subcommand that calls `calc_usage_factor()`, I noticed myself struggling to read the function itself. The function has lots of long comments, long variable names, and lots of calls to the flux-accounting database inside the function. I didn't like how much time was spent trying to figure out what I wrote. The other issue I found was with the calculation itself. I believe some of the calculations for job usage values were incorrect; I think a refactor is in order.

### Solution

The first half of this PR is a pretty significant cleanup and refactor of the `calc_usage_factor()` function. It involves the following:

- removing/editing a lot of long comments
- renaming long variable names
- adding helper functions that read from/write to the flux-accounting database
- changing the behavior of returning decayed usage values
- changing the unit tests (adding `unittest.mock()` and fixing the expected values) to reflect the calculation changes in `calc_usage_factor()`)

To visualize the refactor to `calc_usage_factor()`, I created a flowchart to represent a sample call to the function (you should be able to click on the image to expand it):

![calc_usage_factor flowchart](https://user-images.githubusercontent.com/20131404/115597997-c50dbe00-a28e-11eb-9e4b-1f59df665cca.png)

The second part of this PR adds a new subcommand to `flux account`: `update-usage`, which fetches all associations from the flux-accounting database and calls `calc_usage_factor()` for each one. It then checks to see if the current half-life period needs to be updated. It takes one positional argument: a path to the job-archive DB. An optional argument can also be passed: the **PriorityDecayHalfLife** parameter, which if not specified, defaults to 1 (this mirrors the default value when the flux-accounting database is initially created as well).

```console
[moussa1@docker-desktop src]$ flux account update-usage -h
usage: flux-account.py update-usage [-h]
                                    [--priority-decay-half-life PRIORITY DECAY HALF LIFE]
                                    JOB-ARCHIVE_DB_PATH

positional arguments:
  JOB-ARCHIVE_DB_PATH   job-archive DB location

optional arguments:
  -h, --help            show this help message and exit
  --priority-decay-half-life PRIORITY DECAY HALF LIFE
                        contribution of historical usage in weeks on the
                        composite usage value
```

### Testing

I added two new unit tests to `test_job_archive_interface.py` that call `update_job_usage()` at two different periods: one in the current half-life period (to ensure that current historical usage factors do NOT get updated), and one in the next half-life period (to ensure that current historical usage factors DO get updated). 

### Future Work/Impact

I was thinking that this PR would enable job usage values to be periodically calculated via a `cron` job to regularly update historical job usage values for users, and that it could be used in combination with the `data_reader` and `data_writer` classes in the weighted tree library to re-calculate fairshare values (based on the newly-calculated job usage values) and periodically update the flux-accounting database. 