### PR TITLE
flux-shares: add data_writer_stdout subclass, add fairshare field to output

### DIFF
--- a/src/fairness/print_hierarchy/flux_shares.cpp
+++ b/src/fairness/print_hierarchy/flux_shares.cpp
@@ -16,12 +16,10 @@ extern "C" {
 #endif
 }
 
-#include "src/fairness/reader/data_reader_db.hpp"
+#include "src/fairness/writer/data_writer_stdout.hpp"
 
 using namespace Flux::accounting;
-using namespace Flux::reader;
-
-const std::string DBPATH = std::string (X_LOCALSTATEDIR) + "/FluxAccounting.db";
+using namespace Flux::writer;
 
 static void show_usage ()
 {
@@ -35,102 +33,14 @@ static void show_usage ()
               << std::endl;
 }
 
-void print_csv_header (const std::string& delimiter="|")
-{
-    std::cout << "Account" << delimiter
-              << "Username" << delimiter
-              << "RawShares" << delimiter
-              << "RawUsage"
-              << std::endl;
-}
-
-void print_csv (std::shared_ptr<weighted_tree_node_t> node,
-                const std::string& indent,
-                const std::string& delimiter="|")
-{
-
-    if (node == nullptr)
-        return;
-
-    // print node data
-    if (node->is_user ()) {
-        std::cout << indent << node->get_parent ()-> get_name () << delimiter
-                  << node->get_name () << delimiter
-                  << node->get_shares () << delimiter
-                  << node->get_usage ()
-                  << std::endl;
-    } else {
-        std::cout << indent << node->get_name () << delimiter << delimiter
-                  << node->get_shares () << delimiter
-                  << node->get_usage ()
-                  << std::endl;
-    }
-
-    // recur on subtree
-    for (int i = 0; i < node->get_num_children(); i++) {
-        print_csv(node->get_child (i), indent + " ", delimiter);
-    }
-}
-
-void pretty_print_header ()
-{
-    std::cout << std::setw(20) << std::left << "Account"
-              << std::setw(20) << std::right << "Username"
-              << std::setw(20) << std::right << "RawShares"
-              << std::setw(20) << std::right << "RawUsage"
-              << std::endl;
-}
-
-void pretty_print (std::shared_ptr<weighted_tree_node_t> node,
-                   const std::string& indent)
-{
-    std::string name;
-
-    if (node == nullptr)
-        return;
-
-    // print node data
-    if (node->is_user ()) {
-        name = indent + node->get_parent ()->get_name ();
-        std::cout << std::setw(20) << std::left << name
-                  << std::setw(20) << std::right << node->get_name ()
-                  << std::setw(20) << std::right << node->get_shares ()
-                  << std::setw(20) << std::right << node->get_usage ()
-                  << std::endl;
-    } else {
-        name = indent + node->get_name ();
-        std::cout << std::setw(20) << std::left << name
-                  << std::setw(20) << std::right << ""
-                  << std::setw(20) << std::right << node->get_shares ()
-                  << std::setw(20) << std::right << node->get_usage ()
-                  << std::endl;
-    }
-
-    // recur on subtree
-    for (int i = 0; i < node->get_num_children(); i++) {
-        pretty_print(node->get_child (i), indent + " ");
-    }
-}
-
-std::shared_ptr<weighted_tree_node_t> read_from_db (const std::string &filename)
-{
-    data_reader_db_t data_reader;
-    std::shared_ptr<weighted_tree_node_t> root;
-
-    root = data_reader.load_accounting_db (filename);
-    if (root == nullptr)
-        return nullptr;
-
-    return root;
-}
-
 
 int main (int argc, char** argv)
 {
-    bool parsable = false;
-    std::string filepath, delimiter, indent = "";
+    std::string filepath = "";
     int rc = 0;
     std::shared_ptr<weighted_tree_node_t> root;
+    std::string indent, delimiter = "";
+    bool parsable = false;
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -155,22 +65,8 @@ int main (int argc, char** argv)
         }
     }
 
-    if (filepath == "")
-        filepath = DBPATH;
-
-    root = read_from_db (filepath);
-    if (root == nullptr) {
-        rc = -1;
-        return rc;
-    }
-
-    if (parsable) {
-        print_csv_header (delimiter);
-        print_csv(root, indent, delimiter);
-    } else {
-        pretty_print_header ();
-        pretty_print (root, indent);
-    }
+    data_writer_stdout_t data_writer (indent, parsable, delimiter);
+    rc = data_writer.write_acct_info (filepath, root);
 
     return rc;
 }

--- a/src/fairness/reader/data_reader_db.cpp
+++ b/src/fairness/reader/data_reader_db.cpp
@@ -62,6 +62,7 @@ association's data and adds it to the weighted tree.
 int data_reader_db_t::add_assoc (const std::string &username,
                                  const std::string &shrs,
                                  const std::string &usg,
+                                 double fshare,
                                  std::shared_ptr<weighted_tree_node_t> &node)
 {
     // add user as a child of the node
@@ -70,6 +71,7 @@ int data_reader_db_t::add_assoc (const std::string &username,
                                                              true,
                                                              std::stoll (shrs),
                                                              std::stoll (usg));
+    user_node->set_fshare (fshare);
     return node->add_child (user_node);
 }
 
@@ -242,10 +244,11 @@ std::shared_ptr<weighted_tree_node_t> data_reader_db_t::get_sub_banks (
                 sqlite3_column_text (c_assoc, 1));
             std::string usage = reinterpret_cast<char const *> (
                 sqlite3_column_text (c_assoc, 3));
+            double fshare = sqlite3_column_double (c_assoc, 4);
 
             try {
                 // add association as a child of the node
-                if (add_assoc (username, shrs, usage, node) < 0) {
+                if (add_assoc (username, shrs, usage, fshare, node) < 0) {
                     m_err_msg += "Failed to add association\n";
                     errno = EINVAL;
 
@@ -358,7 +361,8 @@ std::shared_ptr<weighted_tree_node_t> data_reader_db_t::load_accounting_db (
                   "ORDER BY bank_table.bank";
 
     s_assoc = "SELECT association_table.username, association_table.shares, "
-              "association_table.bank, association_table.job_usage "
+              "association_table.bank, association_table.job_usage, "
+              "association_table.fairshare "
               "FROM association_table WHERE association_table.bank=?"
               "ORDER BY association_table.username";
 

--- a/src/fairness/reader/data_reader_db.hpp
+++ b/src/fairness/reader/data_reader_db.hpp
@@ -41,6 +41,7 @@ private:
     int add_assoc (const std::string &username,
                    const std::string &shrs,
                    const std::string &usg,
+                   double fshare,
                    std::shared_ptr<weighted_tree_node_t> &node);
 
     void aggregate_job_usage (std::shared_ptr<weighted_tree_node_t> node,

--- a/src/fairness/weighted_tree/Makefile.am
+++ b/src/fairness/weighted_tree/Makefile.am
@@ -14,7 +14,8 @@ noinst_HEADERS = \
     weighted_tree.hpp \
     weighted_walk.hpp \
     ../reader/data_reader_db.hpp \
-    ../writer/data_writer_db.hpp
+    ../writer/data_writer_db.hpp \
+    ../writer/data_writer_stdout.hpp
 
 libweighted_tree_la_SOURCES = \
     ../account/account.cpp \
@@ -22,11 +23,13 @@ libweighted_tree_la_SOURCES = \
     weighted_walk.cpp \
     ../reader/data_reader_db.cpp \
     ../writer/data_writer_db.cpp \
+    ../writer/data_writer_stdout.cpp \
     ../account/account.hpp \
     weighted_tree.hpp \
     weighted_walk.hpp \
     ../reader/data_reader_db.hpp \
-    ../writer/data_writer_db.hpp
+    ../writer/data_writer_db.hpp \
+    ../writer/data_writer_stdout.hpp
 
 libweighted_tree_la_CXXFLAGS = \
     $(WARNING_CXXFLAGS) \

--- a/src/fairness/writer/data_writer_stdout.cpp
+++ b/src/fairness/writer/data_writer_stdout.cpp
@@ -1,0 +1,164 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+#include <iostream>
+#include <iomanip>
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include "src/fairness/writer/data_writer_stdout.hpp"
+
+using namespace Flux::accounting;
+using namespace Flux::writer;
+using namespace Flux::reader;
+
+/******************************************************************************
+ *                                                                            *
+ *                          Private DB Writer API                             *
+ *                                                                            *
+ *****************************************************************************/
+
+std::shared_ptr<weighted_tree_node_t> read_from_db (const std::string &filename)
+{
+    std::string DBPATH = std::string (X_LOCALSTATEDIR) + "/FluxAccounting.db";
+
+    data_reader_db_t data_reader;
+    std::shared_ptr<weighted_tree_node_t> root;
+
+    root = (filename == "") ? data_reader.load_accounting_db (DBPATH) :
+        data_reader.load_accounting_db (filename);
+
+    if (root == nullptr)
+        return nullptr;
+
+    return root;
+}
+
+
+void data_writer_stdout_t::print_csv_header (const std::string& delimiter)
+{
+    std::cout << "Account" << delimiter
+              << "Username" << delimiter
+              << "RawShares" << delimiter
+              << "RawUsage" << delimiter
+              << "Fairshare"
+              << std::endl;
+}
+
+
+void data_writer_stdout_t::print_csv (
+                                    std::shared_ptr<weighted_tree_node_t> node,
+                                    const std::string& indent,
+                                    const std::string& delimiter)
+{
+
+    if (node == nullptr)
+        return;
+
+    // print node data
+    if (node->is_user ()) {
+        std::cout << indent << node->get_parent ()-> get_name () << delimiter
+                  << node->get_name () << delimiter
+                  << node->get_shares () << delimiter
+                  << node->get_usage () << delimiter
+                  << node->get_fshare ()
+                  << std::endl;
+    } else {
+        std::cout << indent << node->get_name () << delimiter << delimiter
+                  << node->get_shares () << delimiter
+                  << node->get_usage ()
+                  << std::endl;
+    }
+
+    // recur on subtree
+    for (int i = 0; i < node->get_num_children(); i++) {
+        print_csv(node->get_child (i), indent + " ", delimiter);
+    }
+}
+
+
+void data_writer_stdout_t::pretty_print_header ()
+{
+    std::cout << std::setw(20) << std::left << "Account"
+              << std::setw(20) << std::right << "Username"
+              << std::setw(20) << std::right << "RawShares"
+              << std::setw(20) << std::right << "RawUsage"
+              << std::setw(20) << std::right << "Fairshare"
+              << std::endl;
+}
+
+
+void data_writer_stdout_t::pretty_print (
+                                    std::shared_ptr<weighted_tree_node_t> node,
+                                    const std::string& indent)
+{
+    std::string name;
+
+    if (node == nullptr)
+        return;
+
+    // print node data
+    if (node->is_user ()) {
+        name = indent + node->get_parent ()->get_name ();
+        std::cout << std::setw(20) << std::left << name
+                  << std::setw(20) << std::right << node->get_name ()
+                  << std::setw(20) << std::right << node->get_shares ()
+                  << std::setw(20) << std::right << node->get_usage ()
+                  << std::setw(20) << std::right << node->get_fshare ()
+                  << std::endl;
+    } else {
+        name = indent + node->get_name ();
+        std::cout << std::setw(20) << std::left << name
+                  << std::setw(20) << std::right << ""
+                  << std::setw(20) << std::right << node->get_shares ()
+                  << std::setw(20) << std::right << node->get_usage ()
+                  << std::endl;
+    }
+
+    // recur on subtree
+    for (int i = 0; i < node->get_num_children(); i++) {
+        pretty_print(node->get_child (i), indent + " ");
+    }
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                         Public DB Writer API                               *
+ *                                                                            *
+ *****************************************************************************/
+
+int data_writer_stdout_t::write_acct_info (
+                                    const std::string &path,
+                                    std::shared_ptr<weighted_tree_node_t> node)
+{
+
+    std::shared_ptr<weighted_tree_node_t> root;
+    int rc = 0;
+
+    root = read_from_db (path);
+    if (root == nullptr) {
+        rc = -1;
+        return rc;
+    }
+
+    if (this->m_parsable) {
+        print_csv_header (this->m_delimiter);
+        print_csv (root, this->m_indent, this->m_delimiter);
+    } else {
+        pretty_print_header ();
+        pretty_print (root, this->m_indent);
+    }
+
+    return 0;
+}

--- a/src/fairness/writer/data_writer_stdout.hpp
+++ b/src/fairness/writer/data_writer_stdout.hpp
@@ -1,0 +1,81 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <sqlite3.h>
+#include <cerrno>
+
+#include "src/fairness/weighted_tree/weighted_walk.hpp"
+#include "src/fairness/reader/data_reader_db.hpp"
+#include "src/fairness/writer/data_writer_base.hpp"
+
+using namespace Flux::accounting;
+
+namespace Flux {
+namespace writer {
+
+/*!  Base data writer class.
+ */
+class data_writer_stdout_t : public data_writer_base_t {
+public:
+    data_writer_stdout_t (std::string indent = "",
+                          bool parsable = false,
+                          std::string delimiter = "")
+    {
+        m_indent = indent;
+        m_parsable = parsable;
+        m_delimiter = delimiter;
+    }
+    virtual ~data_writer_stdout_t () = default;
+
+    /*! Write fairshare values from a weighted tree.
+     *
+     * \param path          path to a flux-accounting database
+     * \param node          node of the weighted tree of the bank/user hierarchy
+     */
+    int write_acct_info (const std::string &path,
+                         std::shared_ptr<weighted_tree_node_t> node);
+
+private:
+    std::string m_indent = "";
+    bool m_parsable = false;
+    std::string m_delimiter = "";
+
+    /*! Print flux-accounting information with a custom delimiter.
+     *
+     * \param delimiter     custom delimiter for output
+     */
+    void print_csv_header (const std::string& delimiter="|");
+
+    /*! Bind a parameter to a compiled SQL statement
+     *
+     * \param node          node of the weighted tree of the bank/user hierarchy
+     * \param indent        level of indent in printing out the hierarchy
+     * \param delimiter     custom delimiter for output
+     */
+     void print_csv (std::shared_ptr<weighted_tree_node_t> node,
+                     const std::string& indent,
+                     const std::string& delimiter="|");
+
+    /*! Print the header in a nice format.
+     *
+     */
+    void pretty_print_header ();
+
+    /*! Print the user/bank hierarchy in a nice format.
+     *
+     * \param node      node of the weighted tree of the bank/user hierarchy
+     * \param indent    level of indent in printing out the hierarchy
+     */
+     void pretty_print (std::shared_ptr<weighted_tree_node_t> node,
+                        const std::string& indent);
+};
+
+} // namespace writer
+} // namespace Flux

--- a/t/expected/custom_small_tie_parsable.txt
+++ b/t/expected/custom_small_tie_parsable.txt
@@ -1,13 +1,13 @@
-Account,Username,RawShares,RawUsage
+Account,Username,RawShares,RawUsage,Fairshare
 root,,1000,133
  account1,,1000,120
-  account1,leaf.1.1,10000,100
-  account1,leaf.1.2,1000,10
-  account1,leaf.1.3,100000,10
+  account1,leaf.1.1,10000,100,0.5
+  account1,leaf.1.2,1000,10,0.5
+  account1,leaf.1.3,100000,10,0.75
  account2,,100,12
-  account2,leaf.2.1,10000,10
-  account2,leaf.2.2,1000,1
-  account2,leaf.2.3,100000,1
+  account2,leaf.2.1,10000,10,0.5
+  account2,leaf.2.2,1000,1,0.5
+  account2,leaf.2.3,100000,1,0.75
  account3,,10,1
-  account3,leaf.3.1,100,0
-  account3,leaf.3.2,10,1
+  account3,leaf.3.1,100,0,1
+  account3,leaf.3.2,10,1,0.875

--- a/t/expected/out_of_insert_order.txt
+++ b/t/expected/out_of_insert_order.txt
@@ -1,8 +1,8 @@
-Account                         Username           RawShares            RawUsage
+Account                         Username           RawShares            RawUsage           Fairshare
 root                                                       1                   0
  A                                                         1                   0
  B                                                         1                   0
  C                                                         1                   0
-  C                                userA                   1                   0
-  C                                userF                   1                   0
-  C                                userZ                   1                   0
+  C                                userA                   1                   0                   0
+  C                                userF                   1                   0                   0
+  C                                userZ                   1                   0                   0

--- a/t/expected/small_no_tie.txt
+++ b/t/expected/small_no_tie.txt
@@ -1,12 +1,12 @@
-Account                         Username           RawShares            RawUsage
+Account                         Username           RawShares            RawUsage           Fairshare
 root                                                    1000                 133
  account1                                               1000                 121
-  account1                      leaf.1.1               10000                 100
-  account1                      leaf.1.2                1000                  11
-  account1                      leaf.1.3              100000                  10
+  account1                      leaf.1.1               10000                 100            0.285714
+  account1                      leaf.1.2                1000                  11            0.142857
+  account1                      leaf.1.3              100000                  10            0.428571
  account2                                                100                  11
-  account2                      leaf.2.1              100000                   8
-  account2                      leaf.2.2               10000                   3
+  account2                      leaf.2.1              100000                   8            0.714286
+  account2                      leaf.2.2               10000                   3            0.571429
  account3                                                 10                   1
-  account3                      leaf.3.1                 100                   0
-  account3                      leaf.3.2                  10                   1
+  account3                      leaf.3.1                 100                   0                   1
+  account3                      leaf.3.2                  10                   1            0.857143

--- a/t/expected/small_no_tie_parsable.txt
+++ b/t/expected/small_no_tie_parsable.txt
@@ -1,12 +1,12 @@
-Account|Username|RawShares|RawUsage
+Account|Username|RawShares|RawUsage|Fairshare
 root||1000|133
  account1||1000|121
-  account1|leaf.1.1|10000|100
-  account1|leaf.1.2|1000|11
-  account1|leaf.1.3|100000|10
+  account1|leaf.1.1|10000|100|0.285714
+  account1|leaf.1.2|1000|11|0.142857
+  account1|leaf.1.3|100000|10|0.428571
  account2||100|11
-  account2|leaf.2.1|100000|8
-  account2|leaf.2.2|10000|3
+  account2|leaf.2.1|100000|8|0.714286
+  account2|leaf.2.2|10000|3|0.571429
  account3||10|1
-  account3|leaf.3.1|100|0
-  account3|leaf.3.2|10|1
+  account3|leaf.3.1|100|0|1
+  account3|leaf.3.2|10|1|0.857143

--- a/t/expected/small_tie.txt
+++ b/t/expected/small_tie.txt
@@ -1,13 +1,13 @@
-Account                         Username           RawShares            RawUsage
+Account                         Username           RawShares            RawUsage           Fairshare
 root                                                    1000                 133
  account1                                               1000                 120
-  account1                      leaf.1.1               10000                 100
-  account1                      leaf.1.2                1000                  10
-  account1                      leaf.1.3              100000                  10
+  account1                      leaf.1.1               10000                 100                 0.5
+  account1                      leaf.1.2                1000                  10                 0.5
+  account1                      leaf.1.3              100000                  10                0.75
  account2                                                100                  12
-  account2                      leaf.2.1               10000                  10
-  account2                      leaf.2.2                1000                   1
-  account2                      leaf.2.3              100000                   1
+  account2                      leaf.2.1               10000                  10                 0.5
+  account2                      leaf.2.2                1000                   1                 0.5
+  account2                      leaf.2.3              100000                   1                0.75
  account3                                                 10                   1
-  account3                      leaf.3.1                 100                   0
-  account3                      leaf.3.2                  10                   1
+  account3                      leaf.3.1                 100                   0                   1
+  account3                      leaf.3.2                  10                   1               0.875

--- a/t/expected/small_tie_all.txt
+++ b/t/expected/small_tie_all.txt
@@ -1,14 +1,14 @@
-Account                         Username           RawShares            RawUsage
+Account                         Username           RawShares            RawUsage           Fairshare
 root                                                    1000                1332
  account1                                               1000                 120
-  account1                      leaf.1.1               10000                 100
-  account1                      leaf.1.2                1000                  10
-  account1                      leaf.1.3              100000                  10
+  account1                      leaf.1.1               10000                 100            0.666667
+  account1                      leaf.1.2                1000                  10            0.666667
+  account1                      leaf.1.3              100000                  10                   1
  account2                                                100                  12
-  account2                      leaf.2.1               10000                  10
-  account2                      leaf.2.2                1000                   1
-  account2                      leaf.2.3              100000                   1
+  account2                      leaf.2.1               10000                  10            0.666667
+  account2                      leaf.2.2                1000                   1            0.666667
+  account2                      leaf.2.3              100000                   1                   1
  account3                                              10000                1200
-  account3                      leaf.3.1               10000                1000
-  account3                      leaf.3.2                1000                 100
-  account3                      leaf.3.3              100000                 100
+  account3                      leaf.3.1               10000                1000            0.666667
+  account3                      leaf.3.2                1000                 100            0.666667
+  account3                      leaf.3.3              100000                 100                   1

--- a/t/expected/small_tie_all_parsable.txt
+++ b/t/expected/small_tie_all_parsable.txt
@@ -1,14 +1,14 @@
-Account|Username|RawShares|RawUsage
+Account|Username|RawShares|RawUsage|Fairshare
 root||1000|1332
  account1||1000|120
-  account1|leaf.1.1|10000|100
-  account1|leaf.1.2|1000|10
-  account1|leaf.1.3|100000|10
+  account1|leaf.1.1|10000|100|0.666667
+  account1|leaf.1.2|1000|10|0.666667
+  account1|leaf.1.3|100000|10|1
  account2||100|12
-  account2|leaf.2.1|10000|10
-  account2|leaf.2.2|1000|1
-  account2|leaf.2.3|100000|1
+  account2|leaf.2.1|10000|10|0.666667
+  account2|leaf.2.2|1000|1|0.666667
+  account2|leaf.2.3|100000|1|1
  account3||10000|1200
-  account3|leaf.3.1|10000|1000
-  account3|leaf.3.2|1000|100
-  account3|leaf.3.3|100000|100
+  account3|leaf.3.1|10000|1000|0.666667
+  account3|leaf.3.2|1000|100|0.666667
+  account3|leaf.3.3|100000|100|1

--- a/t/expected/small_tie_parsable.txt
+++ b/t/expected/small_tie_parsable.txt
@@ -1,13 +1,13 @@
-Account|Username|RawShares|RawUsage
+Account|Username|RawShares|RawUsage|Fairshare
 root||1000|133
  account1||1000|120
-  account1|leaf.1.1|10000|100
-  account1|leaf.1.2|1000|10
-  account1|leaf.1.3|100000|10
+  account1|leaf.1.1|10000|100|0.5
+  account1|leaf.1.2|1000|10|0.5
+  account1|leaf.1.3|100000|10|0.75
  account2||100|12
-  account2|leaf.2.1|10000|10
-  account2|leaf.2.2|1000|1
-  account2|leaf.2.3|100000|1
+  account2|leaf.2.1|10000|10|0.5
+  account2|leaf.2.2|1000|1|0.5
+  account2|leaf.2.3|100000|1|0.75
  account3||10|1
-  account3|leaf.3.1|100|0
-  account3|leaf.3.2|10|1
+  account3|leaf.3.1|100|0|1
+  account3|leaf.3.2|10|1|0.875


### PR DESCRIPTION
#### Background

`flux_shares.cpp` currently contains its own convenience functions to print out information from a weighted tree object. 

Now that flux-accounting has the `data_writer` class, it might make more sense to move those convenience functions to a `data_writer` subclass that `flux_shares.cpp` can utilize.

#### Solution

This PR can be separated into three different parts.

Part 1 adds the newly-added fairshare field to `data_reader_db` so that fairshare info also gets added during the construction of a weighted tree object.

Part 2 adds a new subclass to the `data_writer` class (and to the weighted tree library): `data_writer_stdout`, which is responsible for writing flux-accounting information to stdout. It essentially moves the helper functions that used to be in `flux_shares.cpp` into this new subclass, which in turn can be called by `flux_shares.cpp`.

Part 3 changes the expected output in the sharness tests to include the new fairshare column.

#### Fulfillment

This PR should satisfy the remaining outstanding objectives in both #63 and #115:

> Adding this fairshare value to the output of flux shares

Fixes #63 
Fixes #115 