### PR TITLE
association_table: remove unused fields

### DIFF
--- a/src/bindings/python/fluxacct/accounting/accounting_cli_functions.py
+++ b/src/bindings/python/fluxacct/accounting/accounting_cli_functions.py
@@ -156,7 +156,7 @@ def view_user(conn, user):
         print(e_database_error)
 
 
-def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall_pj=60):
+def add_user(conn, username, bank, admin_level=1, shares=1):
 
     try:
         # insert the user values into association_table
@@ -169,11 +169,9 @@ def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall
                 username,
                 admin_level,
                 bank,
-                shares,
-                max_jobs,
-                max_wall_pj
+                shares
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -183,8 +181,6 @@ def add_user(conn, username, bank, admin_level=1, shares=1, max_jobs=1, max_wall
                 admin_level,
                 bank,
                 shares,
-                max_jobs,
-                max_wall_pj,
             ),
         )
         # commit changes
@@ -230,8 +226,6 @@ def edit_user(conn, username, field, new_value):
         "admin_level",
         "bank",
         "shares",
-        "max_jobs",
-        "max_wall_pj",
     ]
     if field in fields:
         the_field = field

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -94,8 +94,6 @@ def create_db(
                 admin_level   smallint(6) DEFAULT 1   NOT NULL,
                 bank          tinytext                NOT NULL,
                 shares        int(11)     DEFAULT 1   NOT NULL,
-                max_jobs      int(11)                 NOT NULL,
-                max_wall_pj   int(11)                 NOT NULL,
                 job_usage     real        DEFAULT 0.0 NOT NULL,
                 fairshare     real        DEFAULT 0.0 NOT NULL,
                 PRIMARY KEY   (username, bank)

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -56,10 +56,9 @@ class TestDB(unittest.TestCase):
             """
             INSERT INTO association_table
             (creation_time, mod_time, deleted, username, admin_level,
-            bank, shares, max_jobs, max_wall_pj)
+            bank, shares)
             VALUES
-            (0, 0, 0, "test user", 1, "test account", 0, 0,
-            0)
+            (0, 0, 0, "test user", 1, "test account", 0)
             """
         )
         cursor = conn.cursor()

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -35,8 +35,6 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
-            max_jobs="100",
-            max_wall_pj="60",
         )
         cursor = acct_conn.cursor()
         num_rows_assoc_table = cursor.execute("DELETE FROM association_table").rowcount
@@ -55,8 +53,6 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
-            max_jobs="100",
-            max_wall_pj="60",
         )
         aclif.add_user(
             acct_conn,
@@ -64,8 +60,6 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
-            max_jobs="100",
-            max_wall_pj="60",
         )
 
         self.assertRaises(sqlite3.IntegrityError)
@@ -79,8 +73,6 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
-            max_jobs="100",
-            max_wall_pj="60",
         )
         aclif.add_user(
             acct_conn,
@@ -88,8 +80,6 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="other_acct",
             shares="10",
-            max_jobs="100",
-            max_wall_pj="60",
         )
         cursor = acct_conn.cursor()
         cursor.execute("SELECT * from association_table where username='dup_user'")
@@ -101,11 +91,9 @@ class TestAccountingCLI(unittest.TestCase):
 
     # edit a value for a user in the association table
     def test_04_edit_user_value(self):
-        aclif.edit_user(acct_conn, "fluxuser", "max_jobs", "10000")
+        aclif.edit_user(acct_conn, "fluxuser", "shares", "10000")
         cursor = acct_conn.cursor()
-        cursor.execute(
-            "SELECT max_jobs FROM association_table where username='fluxuser'"
-        )
+        cursor.execute("SELECT shares FROM association_table where username='fluxuser'")
 
         self.assertEqual(cursor.fetchone()[0], 10000)
 


### PR DESCRIPTION
##### Problem

The `association_table` currently contains two fields that have not been used with any features of flux-accounting: `max_jobs` and `max_wall_pj`. As a result of creating a set of smaller issues to handle per-user, per-job, and per-queue limits, it looks like these kinds of limits will either be handled by a mechanism other than the flux-accounting DB (I opened issue [#3652](https://github.com/flux-framework/flux-core/issues/3652) in flux-core to discuss part of these per-job limits) or changed in some way to be handled within flux-accounting. 

##### Solution

This PR just removes the `max_jobs` and `max_wall_pj` fields from the `association_table` to prepare for adding per-user limit support in flux-accounting.