### PR TITLE
python: break up accounting_cli_functions.py

### DIFF
--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -1,6 +1,7 @@
 acctpy_PYTHON = \
 	__init__.py \
-	accounting_cli_functions.py \
+	user_subcommands.py \
+	bank_subcommands.py \
 	job_archive_interface.py \
 	create_db.py
 

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -20,7 +20,8 @@ from unittest import mock
 
 from fluxacct.accounting import job_archive_interface as jobs
 from fluxacct.accounting import create_db as c
-from fluxacct.accounting import accounting_cli_functions as aclif
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
 
 
 class TestAccountingCLI(unittest.TestCase):
@@ -66,16 +67,16 @@ class TestAccountingCLI(unittest.TestCase):
         acct_conn.commit()
 
         # add bank hierarchy
-        aclif.add_bank(acct_conn, bank="A", shares=1)
-        aclif.add_bank(acct_conn, bank="B", parent_bank="A", shares=1)
-        aclif.add_bank(acct_conn, bank="C", parent_bank="B", shares=1)
-        aclif.add_bank(acct_conn, bank="D", parent_bank="B", shares=1)
+        b.add_bank(acct_conn, bank="A", shares=1)
+        b.add_bank(acct_conn, bank="B", parent_bank="A", shares=1)
+        b.add_bank(acct_conn, bank="C", parent_bank="B", shares=1)
+        b.add_bank(acct_conn, bank="D", parent_bank="B", shares=1)
 
         # add users
-        aclif.add_user(acct_conn, username="1001", bank="C")
-        aclif.add_user(acct_conn, username="1002", bank="C")
-        aclif.add_user(acct_conn, username="1003", bank="D")
-        aclif.add_user(acct_conn, username="1004", bank="D")
+        u.add_user(acct_conn, username="1001", bank="C")
+        u.add_user(acct_conn, username="1002", bank="C")
+        u.add_user(acct_conn, username="1003", bank="D")
+        u.add_user(acct_conn, username="1004", bank="D")
 
         jobid = 100
         interval = 0  # add to job timestamps to diversify job-archive records
@@ -394,7 +395,7 @@ class TestAccountingCLI(unittest.TestCase):
     # removing a user from the flux-accounting DB should NOT remove their job
     # usage history from the job_usage_factor_table
     def test_19_keep_job_usage_records_upon_delete(self):
-        aclif.delete_user(acct_conn, username="1001", bank="C")
+        u.delete_user(acct_conn, username="1001", bank="C")
 
         select_stmt = """
             SELECT * FROM

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -13,7 +13,7 @@ import unittest
 import os
 import sqlite3
 
-from fluxacct.accounting import accounting_cli_functions as aclif
+from fluxacct.accounting import user_subcommands as u
 from fluxacct.accounting import create_db as c
 
 
@@ -29,7 +29,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # add a valid user to association_table
     def test_01_add_valid_user(self):
-        aclif.add_user(
+        u.add_user(
             acct_conn,
             username="fluxuser",
             admin_level="1",
@@ -47,14 +47,14 @@ class TestAccountingCLI(unittest.TestCase):
     # adding a user with the same primary key (user_name, account) should
     # return an IntegrityError
     def test_02_add_duplicate_primary_key(self):
-        aclif.add_user(
+        u.add_user(
             acct_conn,
             username="fluxuser",
             admin_level="1",
             bank="acct",
             shares="10",
         )
-        aclif.add_user(
+        u.add_user(
             acct_conn,
             username="fluxuser",
             admin_level="1",
@@ -67,14 +67,14 @@ class TestAccountingCLI(unittest.TestCase):
     # adding a user with the same username BUT a different account should
     # succeed
     def test_03_add_duplicate_user(self):
-        aclif.add_user(
+        u.add_user(
             acct_conn,
             username="dup_user",
             admin_level="1",
             bank="acct",
             shares="10",
         )
-        aclif.add_user(
+        u.add_user(
             acct_conn,
             username="dup_user",
             admin_level="1",
@@ -91,7 +91,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # edit a value for a user in the association table
     def test_04_edit_user_value(self):
-        aclif.edit_user(acct_conn, "fluxuser", "shares", "10000")
+        u.edit_user(acct_conn, "fluxuser", "shares", "10000")
         cursor = acct_conn.cursor()
         cursor.execute("SELECT shares FROM association_table where username='fluxuser'")
 
@@ -101,7 +101,7 @@ class TestAccountingCLI(unittest.TestCase):
     # exist should return a ValueError
     def test_05_edit_bad_field(self):
         with self.assertRaises(ValueError):
-            aclif.edit_user(acct_conn, "fluxuser", "foo", "bar")
+            u.edit_user(acct_conn, "fluxuser", "foo", "bar")
 
     # delete a user from the association table
     def test_06_delete_user(self):
@@ -113,7 +113,7 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(len(num_rows_before_delete), 1)
 
-        aclif.delete_user(acct_conn, username="fluxuser", bank="acct")
+        u.delete_user(acct_conn, username="fluxuser", bank="acct")
 
         cursor.execute(
             "SELECT * FROM association_table WHERE username='fluxuser' AND bank='acct'"

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import time
+
+import pandas as pd
+
+
+def view_user(conn, user):
+    try:
+        # get the information pertaining to a user in the Accounting DB
+        select_stmt = "SELECT * FROM association_table where username=?"
+        dataframe = pd.read_sql_query(select_stmt, conn, params=(user,))
+        # if the length of dataframe is 0, that means
+        # the user specified was not found in the table
+        if len(dataframe.index) == 0:
+            print("User not found in association_table")
+        else:
+            print(dataframe)
+    except pd.io.sql.DatabaseError as e_database_error:
+        print(e_database_error)
+
+
+def add_user(conn, username, bank, admin_level=1, shares=1):
+
+    try:
+        # insert the user values into association_table
+        conn.execute(
+            """
+            INSERT INTO association_table (
+                creation_time,
+                mod_time,
+                deleted,
+                username,
+                admin_level,
+                bank,
+                shares
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                int(time.time()),
+                int(time.time()),
+                0,
+                username,
+                admin_level,
+                bank,
+                shares,
+            ),
+        )
+        # commit changes
+        conn.commit()
+        # insert the user values into job_usage_factor_table
+        conn.execute(
+            """
+            INSERT INTO job_usage_factor_table (
+                username,
+                bank
+            )
+            VALUES (?, ?)
+            """,
+            (
+                username,
+                bank,
+            ),
+        )
+        conn.commit()
+    # make sure entry is unique
+    except sqlite3.IntegrityError as integrity_error:
+        print(integrity_error)
+
+
+def delete_user(conn, username, bank):
+    # delete user account from association_table
+    delete_stmt = "DELETE FROM association_table WHERE username=? AND bank=?"
+    cursor = conn.cursor()
+    cursor.execute(
+        delete_stmt,
+        (
+            username,
+            bank,
+        ),
+    )
+    # commit changes
+    conn.commit()
+
+
+def edit_user(conn, username, field, new_value):
+    fields = [
+        "username",
+        "admin_level",
+        "bank",
+        "shares",
+        "max_jobs",
+        "max_wall_pj",
+    ]
+    if field in fields:
+        the_field = field
+
+        # edit value in accounting database
+        conn.execute(
+            "UPDATE association_table SET " + the_field + "=? WHERE username=?",
+            (
+                new_value,
+                username,
+            ),
+        )
+        # commit changes
+        conn.commit()
+    else:
+        raise ValueError("Field not found in association table")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -13,7 +13,8 @@ import sys
 import os
 
 import fluxacct.accounting
-from fluxacct.accounting import accounting_cli_functions as aclif
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import job_archive_interface as jobs
 from fluxacct.accounting import create_db as c
 
@@ -288,9 +289,9 @@ def set_output_file(args):
 
 def select_accounting_function(args, conn, output_file, parser):
     if args.func == "view_user":
-        aclif.view_user(conn, args.username)
+        u.view_user(conn, args.username)
     elif args.func == "add_user":
-        aclif.add_user(
+        u.add_user(
             conn,
             args.username,
             args.bank,
@@ -300,9 +301,9 @@ def select_accounting_function(args, conn, output_file, parser):
             args.max_wall_pj,
         )
     elif args.func == "delete_user":
-        aclif.delete_user(conn, args.username, args.bank)
+        u.delete_user(conn, args.username, args.bank)
     elif args.func == "edit_user":
-        aclif.edit_user(conn, args.username, args.field, args.new_value)
+        u.edit_user(conn, args.username, args.field, args.new_value)
     elif args.func == "view_job_records":
         jobs.view_job_records(
             conn,
@@ -313,13 +314,13 @@ def select_accounting_function(args, conn, output_file, parser):
             after_start_time=args.after_start_time,
         )
     elif args.func == "add_bank":
-        aclif.add_bank(conn, args.bank, args.shares, args.parent_bank)
+        b.add_bank(conn, args.bank, args.shares, args.parent_bank)
     elif args.func == "view_bank":
-        aclif.view_bank(conn, args.bank)
+        b.view_bank(conn, args.bank)
     elif args.func == "delete_bank":
-        aclif.delete_bank(conn, args.bank)
+        b.delete_bank(conn, args.bank)
     elif args.func == "edit_bank":
-        aclif.edit_bank(conn, args.bank, args.shares)
+        b.edit_bank(conn, args.bank, args.shares)
     elif args.func == "update_usage":
         jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
         jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)


### PR DESCRIPTION
##### Problem

`accounting_cli_functions.py` contains functions for both users and banks, resulting in a pretty large source file. It would probably be cleaner to break this up into two smaller files: one that contains user subcommands and one that contains bank subcommands.

---

This PR does just that; it breaks up `accounting_cli_functions.py` into two files: `user_subcommands.py` and `bank_subcommands.py` and reflects the new changes wherever the Python modules are used. 