### PR TITLE
t: add multi-factor priority order sharness tests

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -2,7 +2,10 @@
 TESTSCRIPTS = \
 	t0000-sharness.t \
 	t1000-print-hierarchy.t \
-	t1001-mf-priority.t
+	t1001-mf-priority-basic.t \
+	t1002-mf-priority-small-no-tie.t \
+	t1003-mf-priority-small-tie.t \
+	t1004-mf-priority-small-tie-all.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/scripts/send_payload.py
+++ b/t/scripts/send_payload.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import flux
+
+h = flux.Flux()
+
+with open(sys.argv[1]) as data_file:
+    data = json.load(data_file)
+
+for user in data["users"]:
+    h.rpc("job-manager.mf_priority.rec_update", user).get()

--- a/t/scripts/submit_as.py
+++ b/t/scripts/submit_as.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import argparse
+from subprocess import Popen, PIPE
+
+import flux
+from flux.security import SecurityContext
+
+
+def run_process(cmd, input=None):
+    """Run command defined in `cmd` as a subprocess and return stdout
+
+    If `input` is given, send to subprocess stdin.
+
+    Copy any stderr to terminal and exit with error on subprocess failure.
+    """
+
+    with Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
+        out, err = proc.communicate(input)
+        if err:
+            sys.stderr.write(err.decode("utf-8"))
+        if proc.returncode != 0:
+            sys.exit(1)
+        return out.decode("utf-8").rstrip()
+
+
+def main():
+
+    if len(sys.argv) < 3:
+        sys.exit(f"Usage: submit-as USERID [MINI OPTS...] COMMAND")
+
+    userid = int(sys.argv[1])
+    os.environ["FLUX_HANDLE_USERID"] = str(userid)
+
+    minicmd = [
+        "flux",
+        "mini",
+        "run",
+        "--dry-run",
+        "--setattr=system.exec.test.duration=0.1",
+        *sys.argv[2:],
+    ]
+    jobspec = run_process(minicmd)
+
+    signedJ = SecurityContext().sign_wrap_as(userid, jobspec, mech_type="none")
+
+    submitcmd = ["flux", "job", "submit", "--flags=signed"]
+    jobid = run_process(submitcmd, input=signedJ)
+    print(jobid)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-test_description='Test multi-factor priority plugin'
+test_description='Test multi-factor priority plugin with a single user'
 
 . `dirname $0`/sharness.sh
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
-# BULK_UPDATE=${FLUX_BUILD_DIR}/t/scripts/send_fake_payloads.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin order with no ties'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${FLUX_BUILD_DIR}/t/scripts/submit_as.py
+SEND_PAYLOAD=${FLUX_BUILD_DIR}/t/scripts/send_payload.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create a group of users with unique fairshare values' '
+	cat <<-EOF >fake_small_no_tie.json
+	{
+		"users" : [
+			{"userid": "5011", "bank": "account1", "fairshare": "0.285714"},
+			{"userid": "5012", "bank": "account1", "fairshare": "0.142857"},
+			{"userid": "5013", "bank": "account1", "fairshare": "0.428571"},
+			{"userid": "5021", "bank": "account2", "fairshare": "0.714286"},
+			{"userid": "5022", "bank": "account2", "fairshare": "0.571429"},
+			{"userid": "5031", "bank": "account3", "fairshare": "1.0"},
+			{"userid": "5032", "bank": "account3", "fairshare": "0.857143"}
+		]
+	}
+	EOF
+'
+
+test_expect_success 'send the user information to the plugin' '
+	flux python ${SEND_PAYLOAD} fake_small_no_tie.json
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+test_expect_success 'submit jobs as each user' '
+	flux python ${SUBMIT_AS} 5011 hostname &&
+	flux python ${SUBMIT_AS} 5012 hostname &&
+	flux python ${SUBMIT_AS} 5013 hostname &&
+	flux python ${SUBMIT_AS} 5021 hostname &&
+	flux python ${SUBMIT_AS} 5022 hostname &&
+	flux python ${SUBMIT_AS} 5031 hostname &&
+	flux python ${SUBMIT_AS} 5032 hostname
+'
+
+test_expect_success 'check order of job queue' '
+	flux jobs -A --suppress-header --format={userid} > small_no_tie.test &&
+	cat <<-EOF >small_no_tie.expected &&
+	5031
+	5032
+	5021
+	5022
+	5013
+	5011
+	5012
+	EOF
+	test_cmp small_no_tie.expected small_no_tie.test
+'
+
+test_done

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin with some ties'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${FLUX_BUILD_DIR}/t/scripts/submit_as.py
+SEND_PAYLOAD=${FLUX_BUILD_DIR}/t/scripts/send_payload.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create a group of users with some ties in fairshare values' '
+	cat <<-EOF >fake_small_tie.json
+	{
+		"users" : [
+			{"userid": "5011", "bank": "account1", "fairshare": "0.5"},
+			{"userid": "5012", "bank": "account1", "fairshare": "0.5"},
+			{"userid": "5013", "bank": "account1", "fairshare": "0.75"},
+			{"userid": "5021", "bank": "account2", "fairshare": "0.5"},
+			{"userid": "5022", "bank": "account2", "fairshare": "0.5"},
+			{"userid": "5023", "bank": "account2", "fairshare": "0.75"},
+			{"userid": "5031", "bank": "account3", "fairshare": "1.0"},
+			{"userid": "5032", "bank": "account3", "fairshare": "0.875"}
+		]
+	}
+	EOF
+'
+
+test_expect_success 'send the user information to the plugin' '
+	flux python ${SEND_PAYLOAD} fake_small_tie.json
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+test_expect_success 'submit jobs as each user' '
+	flux python ${SUBMIT_AS} 5011 hostname &&
+	flux python ${SUBMIT_AS} 5012 hostname &&
+	flux python ${SUBMIT_AS} 5013 hostname &&
+	flux python ${SUBMIT_AS} 5021 hostname &&
+	flux python ${SUBMIT_AS} 5022 hostname &&
+	flux python ${SUBMIT_AS} 5023 hostname &&
+	flux python ${SUBMIT_AS} 5031 hostname &&
+	flux python ${SUBMIT_AS} 5032 hostname
+'
+
+test_expect_success 'check order of job queue' '
+	flux jobs -A --suppress-header --format={userid} > small_tie.test &&
+	cat <<-EOF >small_tie.expected &&
+	5031
+	5032
+	5013
+	5023
+	5011
+	5012
+	5021
+	5022
+	EOF
+	test_cmp small_tie.expected small_tie.test
+'
+
+test_done

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin with many ties'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${FLUX_BUILD_DIR}/t/scripts/submit_as.py
+SEND_PAYLOAD=${FLUX_BUILD_DIR}/t/scripts/send_payload.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create a group of users with many ties in fairshare values' '
+	cat <<-EOF >fake_small_tie_all.json
+	{
+	    "users" : [
+	        {"userid": "5011", "bank": "account1", "fairshare": "0.666667"},
+	        {"userid": "5012", "bank": "account1", "fairshare": "0.666667"},
+	        {"userid": "5013", "bank": "account1", "fairshare": "1"},
+	        {"userid": "5021", "bank": "account2", "fairshare": "0.666667"},
+	        {"userid": "5022", "bank": "account2", "fairshare": "0.666667"},
+	        {"userid": "5023", "bank": "account2", "fairshare": "1"},
+	        {"userid": "5031", "bank": "account3", "fairshare": "0.666667"},
+	        {"userid": "5032", "bank": "account3", "fairshare": "0.666667"},
+	        {"userid": "5033", "bank": "account3", "fairshare": "1"}
+	    ]
+	}
+	EOF
+'
+
+test_expect_success 'send the user information to the plugin' '
+	flux python ${SEND_PAYLOAD} fake_small_tie_all.json
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+test_expect_success 'submit jobs as each user' '
+	flux python ${SUBMIT_AS} 5011 hostname &&
+	flux python ${SUBMIT_AS} 5012 hostname &&
+	flux python ${SUBMIT_AS} 5013 hostname &&
+	flux python ${SUBMIT_AS} 5021 hostname &&
+	flux python ${SUBMIT_AS} 5022 hostname &&
+	flux python ${SUBMIT_AS} 5023 hostname &&
+	flux python ${SUBMIT_AS} 5031 hostname &&
+	flux python ${SUBMIT_AS} 5032 hostname &&
+	flux python ${SUBMIT_AS} 5033 hostname
+'
+
+test_expect_success 'check order of job queue' '
+	flux jobs -A --suppress-header --format={userid} > small_tie_all.test &&
+	cat <<-EOF >small_tie_all.expected &&
+	5013
+	5023
+	5033
+	5011
+	5012
+	5021
+	5022
+	5031
+	5032
+	EOF
+	test_cmp small_tie_all.expected small_tie_all.test
+'
+
+test_done


### PR DESCRIPTION
### Background

Currently, the sharness test for the multi-factor priority plugin tests the plugin with just a single user submitting jobs and making sure the priority calculation is behaving as expected.

As discussed in #125, it would be nice to expand this testing further to simulate a "multi-user" environment, where different users are submitting jobs against the same plugin to make sure 1) the priority calculated for submitted jobs are calculated correctly, and 2) the order in which jobs should be run are behaving as expected. @grondo very nicely wrote up a Python script that allows jobs to be submitted under an arbitrary userid. We can disable job execution using `flux queue stop` so no jobs are actually run, submit a number of jobs to the queue, and then examine the queue to make sure the ordering of jobs is correct.

### Solution

This PR attempts to build off of the work done in #122 and #125 to add sharness tests that make use of multiple users submitting jobs with the multi-factor priority plugin loaded. 

The first change is a renaming of the original multi-factor priority plugin test file, `t1001-mf-priority.t` --> `t1001-mf-priority-basic.t`. This name change is to indicate that the tests being run in this file are single-user tests that make sure priority calculation is correct when submitting jobs as a single user, and not much else.

Three new `.t` files are also added, each simulating a separate "multi-user" environment:

**t1002-mf-priority-small-no-tie.t**: this simulates an environment where every user has a unique fairshare value when submitting their job.

**t1003-mf-priority-small-tie.t**: this simulates an environment where only a couple of users have ties in their fairshare values.

**t1004-mf-priority-small-tie-all.t**: this simulates an environment where every user has at least one tie in their fairshare value. 

Each test file sends a payload RPC to the plugin containing the users' information. The queue is stopped so no jobs are actually run. The Python plugin script `submit_as.py` is then run to submit identical jobs as all of the different users in the payload. The order of the queue is then extracted using `flux jobs --suppress-header --format={userid}` and compared to an expected ordering of jobs based on the type of environment being tested. 

The expected ordering for each environment is described as follows:

- In an environment where every user has a unique fairshare value, the jobs at the top of the queue should be of users with the highest fairshare values (i.e. fairshare values closer to 1). 

- In an environment where there are ties in fairshare, the time that a job was submitted is then used to further order jobs (I _think_ this is handled by something other than the plugin, maybe the job-manager?). Earlier submitted jobs will be placed higher in the queue than later submitted jobs if both users have the same fairshare value.

Like it was mentioned in #125, eventually, we will want to test the "end to end" system like the `fluxorama` Docker container, but this might be a good start to testing multi-user environments with use of the multi-factor priority plugin. It might also be helpful once we begin adding more factors, like job size. 