### PR TITLE
association_table: add "default_bank" column, change plugin's default bank behavior

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -94,6 +94,7 @@ def create_db(
                 userid        int(11)     DEFAULT 65534 NOT NULL,
                 admin_level   smallint(6) DEFAULT 1     NOT NULL,
                 bank          tinytext                  NOT NULL,
+                default_bank  tinytext                  NOT NULL,
                 shares        int(11)     DEFAULT 1     NOT NULL,
                 job_usage     real        DEFAULT 0.0   NOT NULL,
                 fairshare     real        DEFAULT 0.5   NOT NULL,

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -56,9 +56,9 @@ class TestDB(unittest.TestCase):
             """
             INSERT INTO association_table
             (creation_time, mod_time, deleted, username, userid, admin_level,
-            bank, shares)
+            bank, default_bank, shares)
             VALUES
-            (0, 0, 0, "test user", 1234, 1, "test account", 0)
+            (0, 0, 0, "test user", 1234, 1, "test account", "test_account", 0)
             """
         )
         cursor = conn.cursor()

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -127,6 +127,46 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(len(num_rows_after_delete), 0)
 
+    # check for a new user's default bank
+    def test_07_check_default_bank_new_user(self):
+        u.add_user(
+            acct_conn,
+            username="test_user1",
+            uid="5000",
+            bank="test_bank",
+        )
+        cursor = acct_conn.cursor()
+        cursor.execute(
+            "SELECT default_bank FROM association_table WHERE username='test_user1'"
+        )
+
+        self.assertEqual(cursor.fetchone()[0], "test_bank")
+
+    # check for an existing user's default bank
+    def test_08_check_default_bank_existing_user(self):
+        u.add_user(
+            acct_conn,
+            username="test_user1",
+            uid="5000",
+            bank="other_test_bank",
+        )
+        cursor = acct_conn.cursor()
+        cursor.execute(
+            "SELECT default_bank FROM association_table WHERE username='test_user1'"
+        )
+
+        self.assertEqual(cursor.fetchone()[0], "test_bank")
+
+    # check that we can successfully edit the default bank for a user
+    def test_09_edit_default_bank(self):
+        u.edit_user(acct_conn, "test_user1", "default_bank", "other_test_bank")
+        cursor = acct_conn.cursor()
+        cursor.execute(
+            "SELECT default_bank FROM association_table WHERE username='test_user1'"
+        )
+
+        self.assertEqual(cursor.fetchone()[0], "other_test_bank")
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -58,6 +58,18 @@ def add_user(
     except KeyError as key_error:
         print(key_error)
 
+    # check for a default bank of the user being added; if the user is new, set
+    # the first bank they were added to as their default bank
+    cur = conn.cursor()
+    select_stmt = "SELECT default_bank FROM association_table WHERE username=?"
+    cur.execute(select_stmt, (username,))
+    row = cur.fetchone()
+
+    if row is None:
+        default_bank = bank
+    else:
+        default_bank = row[0]
+
     try:
         # insert the user values into association_table
         conn.execute(
@@ -70,9 +82,10 @@ def add_user(
                 userid,
                 admin_level,
                 bank,
+                default_bank,
                 shares
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -82,6 +95,7 @@ def add_user(
                 uid,
                 admin_level,
                 bank,
+                default_bank,
                 shares,
             ),
         )
@@ -129,6 +143,7 @@ def edit_user(conn, username, field, new_value):
         "username",
         "admin_level",
         "bank",
+        "default_bank",
         "shares",
         "max_jobs",
         "max_wall_pj",

--- a/src/plugins/bulk_update.py
+++ b/src/plugins/bulk_update.py
@@ -47,9 +47,16 @@ def bulk_update(path):
     cur = conn.cursor()
 
     # fetch all rows from association_table (will print out tuples)
-    for row in cur.execute("SELECT userid, bank, fairshare FROM association_table"):
+    for row in cur.execute(
+        "SELECT userid, bank, default_bank, fairshare FROM association_table"
+    ):
         # create a JSON payload with the results of the query
-        data = {"userid": str(row[0]), "bank": str(row[1]), "fairshare": str(row[2])}
+        data = {
+            "userid": str(row[0]),
+            "bank": str(row[1]),
+            "default_bank": str(row[2]),
+            "fairshare": str(row[3]),
+        }
 
         flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -96,11 +96,12 @@ static void rec_update_cb (flux_t *h,
                            const flux_msg_t *msg,
                            void *arg)
 {
-    char *uid, *fshare, *bank;
+    char *uid, *fshare, *bank, *default_bank;
 
-    if (flux_request_unpack (msg, NULL, "{s:s, s:s, s:s}",
+    if (flux_request_unpack (msg, NULL, "{s:s, s:s, s:s, s:s}",
                              "userid", &uid,
                              "bank", &bank,
+                             "default_bank", &default_bank,
                              "fairshare", &fshare) < 0) {
         flux_log_error (h, "failed to unpack custom_priority.trigger msg");
         goto error;
@@ -109,9 +110,7 @@ static void rec_update_cb (flux_t *h,
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "flux_respond");
 
-    // if the user being added to the does not yet have any entries in the map,
-    // treat their first bank as the "default" bank
-    if (users.count (std::atoi (uid)) == 0)
+    if (strcmp (bank, default_bank) == 0)
         users[std::atoi (uid)]["default"] = std::stod (fshare);
 
     users[std::atoi (uid)][bank] = std::stod (fshare);

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -45,9 +45,9 @@ test_expect_success 'create fake_payload.py' '
 	username = getpass.getuser()
 	userid = pwd.getpwnam(username).pw_uid
 	# create a JSON payload
-	data = {"userid": str(userid), "bank": "account3", "fairshare": "0.45321"}
+	data = {"userid": str(userid), "bank": "account3", "default_bank": "account3", "fairshare": "0.45321"}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()
-	data = {"userid": str(userid), "bank": "account2", "fairshare": "0.11345"}
+	data = {"userid": str(userid), "bank": "account2", "default_bank": "account3", "fairshare": "0.11345"}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()
 	EOF
 '

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -25,13 +25,13 @@ test_expect_success 'create a group of users with unique fairshare values' '
 	cat <<-EOF >fake_small_no_tie.json
 	{
 		"users" : [
-			{"userid": "5011", "bank": "account1", "fairshare": "0.285714"},
-			{"userid": "5012", "bank": "account1", "fairshare": "0.142857"},
-			{"userid": "5013", "bank": "account1", "fairshare": "0.428571"},
-			{"userid": "5021", "bank": "account2", "fairshare": "0.714286"},
-			{"userid": "5022", "bank": "account2", "fairshare": "0.571429"},
-			{"userid": "5031", "bank": "account3", "fairshare": "1.0"},
-			{"userid": "5032", "bank": "account3", "fairshare": "0.857143"}
+			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.285714"},
+			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.142857"},
+			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.428571"},
+			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.714286"},
+			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.571429"},
+			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0"},
+			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.857143"}
 		]
 	}
 	EOF

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -25,14 +25,14 @@ test_expect_success 'create a group of users with some ties in fairshare values'
 	cat <<-EOF >fake_small_tie.json
 	{
 		"users" : [
-			{"userid": "5011", "bank": "account1", "fairshare": "0.5"},
-			{"userid": "5012", "bank": "account1", "fairshare": "0.5"},
-			{"userid": "5013", "bank": "account1", "fairshare": "0.75"},
-			{"userid": "5021", "bank": "account2", "fairshare": "0.5"},
-			{"userid": "5022", "bank": "account2", "fairshare": "0.5"},
-			{"userid": "5023", "bank": "account2", "fairshare": "0.75"},
-			{"userid": "5031", "bank": "account3", "fairshare": "1.0"},
-			{"userid": "5032", "bank": "account3", "fairshare": "0.875"}
+			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.5"},
+			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.5"},
+			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.75"},
+			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.5"},
+			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.5"},
+			{"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "0.75"},
+			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0"},
+			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.875"}
 		]
 	}
 	EOF

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -25,15 +25,15 @@ test_expect_success 'create a group of users with many ties in fairshare values'
 	cat <<-EOF >fake_small_tie_all.json
 	{
 	    "users" : [
-	        {"userid": "5011", "bank": "account1", "fairshare": "0.666667"},
-	        {"userid": "5012", "bank": "account1", "fairshare": "0.666667"},
-	        {"userid": "5013", "bank": "account1", "fairshare": "1"},
-	        {"userid": "5021", "bank": "account2", "fairshare": "0.666667"},
-	        {"userid": "5022", "bank": "account2", "fairshare": "0.666667"},
-	        {"userid": "5023", "bank": "account2", "fairshare": "1"},
-	        {"userid": "5031", "bank": "account3", "fairshare": "0.666667"},
-	        {"userid": "5032", "bank": "account3", "fairshare": "0.666667"},
-	        {"userid": "5033", "bank": "account3", "fairshare": "1"}
+	        {"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667"},
+	        {"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667"},
+	        {"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "1"},
+	        {"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667"},
+	        {"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667"},
+	        {"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "1"},
+	        {"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667"},
+	        {"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667"},
+	        {"userid": "5033", "bank": "account3", "default_bank": "account3", "fairshare": "1"}
 	    ]
 	}
 	EOF


### PR DESCRIPTION
### Background

As discussed in #123, the "default" bank support added in #122 currently treats the first bank the user belonged to in the flux-accounting database as the default bank. It cannot be changed once the user gets added to the DB. It would be good to add more robust default bank support in both the flux-accounting database and the priority plugin, where a user's default bank could be changed by a sys admin even after they are initially added.

### Implementation

This PR adds a `default_bank` column to the `association_table` in the flux-accounting database. When a user/bank combination gets added to the database, a lookup is performed to see if the user already exists in the table and, if they do, what their default bank is. It will set the `default_bank` to the value of the first bank they are added to; however, this value can now be changed like most other fields in the `association_table` with the `edit-user` subcommand.

The `default_bank` column is now also added to the payload information that is sent to the multi-factor priority plugin. When the plugin extracts this data, it will look at the `default_bank` key-value pair and compare it to the `bank` key-value pair in the same payload using `strcmp`. If the values are the same, it will add the fairshare information to the "default" key in the map data structure in the plugin. 

This is similar to the behavior previously present in the plugin, except now, if there is ever an update to a user's default bank in the flux-accounting DB, that change should be reflected in 1) the new payloads sent by `bulk_update.py`, and 2) the map data structure that caches user-bank-fairshare information.

Fixes #123 