### PR TITLE
plugin: add a per-user/bank max jobs limit

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -98,6 +98,7 @@ def create_db(
                 shares        int(11)     DEFAULT 1     NOT NULL,
                 job_usage     real        DEFAULT 0.0   NOT NULL,
                 fairshare     real        DEFAULT 0.5   NOT NULL,
+                max_jobs      int(11)     DEFAULT 5     NOT NULL,
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/plugins/bulk_update.py
+++ b/src/plugins/bulk_update.py
@@ -48,7 +48,7 @@ def bulk_update(path):
 
     # fetch all rows from association_table (will print out tuples)
     for row in cur.execute(
-        "SELECT userid, bank, default_bank, fairshare FROM association_table"
+        "SELECT userid, bank, default_bank, fairshare, max_jobs FROM association_table"
     ):
         # create a JSON payload with the results of the query
         data = {
@@ -56,6 +56,7 @@ def bulk_update(path):
             "bank": str(row[1]),
             "default_bank": str(row[2]),
             "fairshare": str(row[3]),
+            "max_jobs": str(row[4]),
         }
 
         flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -5,7 +5,8 @@ TESTSCRIPTS = \
 	t1001-mf-priority-basic.t \
 	t1002-mf-priority-small-no-tie.t \
 	t1003-mf-priority-small-tie.t \
-	t1004-mf-priority-small-tie-all.t
+	t1004-mf-priority-small-tie-all.t \
+	t1005-max-jobs-limits.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -45,9 +45,9 @@ test_expect_success 'create fake_payload.py' '
 	username = getpass.getuser()
 	userid = pwd.getpwnam(username).pw_uid
 	# create a JSON payload
-	data = {"userid": str(userid), "bank": "account3", "default_bank": "account3", "fairshare": "0.45321"}
+	data = {"userid": str(userid), "bank": "account3", "default_bank": "account3", "fairshare": "0.45321", "max_jobs": "10"}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()
-	data = {"userid": str(userid), "bank": "account2", "default_bank": "account3", "fairshare": "0.11345"}
+	data = {"userid": str(userid), "bank": "account2", "default_bank": "account3", "fairshare": "0.11345", "max_jobs": "10"}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()
 	EOF
 '

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -123,4 +123,28 @@ test_expect_success 'reject job when invalid bank format is passed in' '
 	grep "unable to unpack bank arg" invalid_fmt.out
 '
 
+test_expect_success 'create a fake payload with an empty fairshare key-value pair' '
+	cat <<-EOF >empty_fairshare.py
+	import flux
+	import pwd
+	import getpass
+
+	username = getpass.getuser()
+	userid = pwd.getpwnam(username).pw_uid
+	# create a JSON payload
+	data = {"userid": str(userid), "bank": "account4", "default_bank": "account3", "fairshare": "", "max_jobs": "10"}
+	flux.Flux().rpc("job-manager.mf_priority.rec_update", data).get()
+	EOF
+'
+
+test_expect_success 'update plugin with sample test data' '
+	flux python empty_fairshare.py
+'
+
+test_expect_success 'submit a job with new bank and 0 fairshare should result in a job rejection' '
+	test_must_fail flux mini submit --setattr=system.bank=account4 hostname > zero_fairshare.out 2>&1 &&
+	test_debug "zero_fairshare.out" &&
+	grep "user fairshare value is 0" zero_fairshare.out
+'
+
 test_done

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -25,13 +25,13 @@ test_expect_success 'create a group of users with unique fairshare values' '
 	cat <<-EOF >fake_small_no_tie.json
 	{
 		"users" : [
-			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.285714"},
-			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.142857"},
-			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.428571"},
-			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.714286"},
-			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.571429"},
-			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0"},
-			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.857143"}
+			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.285714", "max_jobs": "5"},
+			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.142857", "max_jobs": "5"},
+			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.428571", "max_jobs": "5"},
+			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.714286", "max_jobs": "5"},
+			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.571429", "max_jobs": "5"},
+			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0", "max_jobs": "5"},
+			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.857143", "max_jobs": "5"}
 		]
 	}
 	EOF

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -25,14 +25,14 @@ test_expect_success 'create a group of users with some ties in fairshare values'
 	cat <<-EOF >fake_small_tie.json
 	{
 		"users" : [
-			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.5"},
-			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.5"},
-			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.75"},
-			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.5"},
-			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.5"},
-			{"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "0.75"},
-			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0"},
-			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.875"}
+			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.5", "max_jobs": "5"},
+			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.5", "max_jobs": "5"},
+			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.75", "max_jobs": "5"},
+			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.5", "max_jobs": "5"},
+			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.5", "max_jobs": "5"},
+			{"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "0.75", "max_jobs": "5"},
+			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0", "max_jobs": "5"},
+			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.875", "max_jobs": "5"}
 		]
 	}
 	EOF

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -25,15 +25,15 @@ test_expect_success 'create a group of users with many ties in fairshare values'
 	cat <<-EOF >fake_small_tie_all.json
 	{
 	    "users" : [
-	        {"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667"},
-	        {"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667"},
-	        {"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "1"},
-	        {"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667"},
-	        {"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667"},
-	        {"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "1"},
-	        {"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667"},
-	        {"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667"},
-	        {"userid": "5033", "bank": "account3", "default_bank": "account3", "fairshare": "1"}
+	        {"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667", "max_jobs": "5"},
+	        {"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667", "max_jobs": "5"},
+	        {"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "1", "max_jobs": "5"},
+	        {"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667", "max_jobs": "5"},
+	        {"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667", "max_jobs": "5"},
+	        {"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "1", "max_jobs": "5"},
+	        {"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667", "max_jobs": "5"},
+	        {"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667", "max_jobs": "5"},
+	        {"userid": "5033", "bank": "account3", "default_bank": "account3", "fairshare": "1", "max_jobs": "5"}
 	    ]
 	}
 	EOF

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+test_description='Test per-user max jobs limits'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${FLUX_BUILD_DIR}/t/scripts/submit_as.py
+SEND_PAYLOAD=${FLUX_BUILD_DIR}/t/scripts/send_payload.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create fake_user.json' '
+	cat <<-EOF >fake_user.json
+	{
+		"users" : [
+			{"userid": "5011", "bank": "account3", "default_bank": "account3", "fairshare": "0.45321", "max_jobs": "3"},
+			{"userid": "5011", "bank": "account2", "default_bank": "account3", "fairshare": "0.11345", "max_jobs": "2"}
+		]
+	}
+	EOF
+'
+
+test_expect_success 'update plugin with sample test data' '
+	flux python ${SEND_PAYLOAD} fake_user.json
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+test_expect_success 'submit max number of jobs' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} 5011 sleep 60)
+'
+
+test_expect_success 'submit a job while already having max number of active jobs' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_jobs.out 2>&1 &&
+	test_debug "cat max_jobs.out" &&
+	grep "user has max number of jobs submitted" max_jobs.out &&
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3
+'
+
+test_expect_success 'submit max number of jobs with other bank' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account2 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account2 sleep 60)
+'
+
+test_expect_success 'submit a job while already having max number of active jobs' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account2 sleep 60 > max_jobs.out 2>&1 &&
+	test_debug "cat max_jobs.out" &&
+	grep "user has max number of jobs submitted" max_jobs.out &&
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2
+'
+
+test_expect_success 'submit max number of jobs with a mix of default bank and explicity set bank' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account3 sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} 5011 sleep 60)
+'
+
+test_expect_success 'submit a job while already having max number of active jobs' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_jobs.out 2>&1 &&
+	test_debug "cat max_jobs.out" &&
+	grep "user has max number of jobs submitted" max_jobs.out
+'
+
+test_expect_success 'increase the max jobs count of the user' '
+	cat <<-EOF >new_max_jobs_limit.json
+	{
+		"users" : [
+			{"userid": "5011", "bank": "account3", "default_bank": "account3", "fairshare": "0.45321", "max_jobs": "4"}
+		]
+	}
+	EOF
+'
+
+test_expect_success 'update plugin with same sample test data; this should not reset current jobs count' '
+	flux python ${SEND_PAYLOAD} new_max_jobs_limit.json
+'
+
+test_expect_success 'submit a job successfully under the new max jobs limit' '
+	jobid4=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_jobs.out 2>&1 &&
+	test_debug "cat max_jobs.out" &&
+	grep "user has max number of jobs submitted" max_jobs.out &&
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3 &&
+	flux job cancel $jobid4
+'
+
+test_done


### PR DESCRIPTION
~~_note: this PR is built off of the changes proposed in #130, so I will leave this one as [WIP] until that one lands._~~

~~_#130 has landed, but there are a couple of questions that might alter the direction this PR takes, so I think I'll leave this PR as [WIP] until those questions are sorted out._~~

### Background

The multi-factor priority plugin added in #122 currently just calculates a user's job priority and does not enforce any kind of per-user limits like the ones laid out in #121. Some of the limits that flux-accounting has a direct impact on enforcing are the following:

**max_jobs:** max number of submitted jobs per user

**max_nodes:** max number of nodes used across all of a user's running jobs

This PR looks to add enforcement of the **max_jobs** per-user/bank combination limit to the priority plugin.

### Implementation

This PR looks to add limit support to the priority plugin by enforcing a limit on the maximum number of submitted jobs per user/bank combination.

In the flux-accounting DB, a new column is added to the `association_table` called **max_jobs**, which represents the maximum number of submitted jobs per user:

```sql
max_jobs  int(11)     DEFAULT 5   NOT NULL
```

In the plugin, this new **max_jobs** value is unpacked and stored in a new map-of-maps data structure, very similar to the one that stores user/bank/fairshare information. This value is then compared to the current number of submitted jobs, represented by another integer in the data structure. When a job is submitted and enters `job.validate`, the current number of submitted jobs is compared to the user's limit and is incremented if the user is under their limit. Once a job finishes running and enters `job.state.inactive`, the user's active count of submitted jobs is decremented. The decrement happens in a new callback added to the plugin called `inactive_cb ()`.

If a user has reached their limit and tries to submit another job, the job will be rejected with an error message saying that their limit has been reached.

