### PR TITLE
cmd: add a front-end fairshare update script

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = common cmd fairness bindings plugins
+SUBDIRS = common fairness bindings plugins cmd

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -1,2 +1,28 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = $(FLUX_CORE_CFLAGS)
+
+SUBDIRS = .
+
+noinst_PROGRAMS = flux-update-fshare
+
+flux_update_fshare_SOURCES = flux_update_fshare.cpp
+
+flux_update_fshare_LDADD = \
+    $(top_builddir)/src/fairness/weighted_tree/libweighted_tree.la
+
+flux_update_fshare_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CFLAGS) \
+    $(AM_CXXFLAGS) \
+    $(SQLITE_CFLAGS)
+
+flux_update_fshare_LDFLAGS = $(SQLITE_LIBS)
+
 dist_fluxcmd_SCRIPTS = \
-	flux-account.py
+	flux-account.py \
+	flux-update-fshare

--- a/src/cmd/flux_update_fshare.cpp
+++ b/src/cmd/flux_update_fshare.cpp
@@ -1,0 +1,86 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+#include <iostream>
+#include <iomanip>
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include "src/fairness/reader/data_reader_db.hpp"
+#include "src/fairness/writer/data_writer_db.hpp"
+
+using namespace Flux::accounting;
+using namespace Flux::reader;
+using namespace Flux::writer;
+
+const std::string DBPATH = std::string (X_LOCALSTATEDIR) + "/FluxAccounting.db";
+
+static void show_usage ()
+{
+    std::cout << "usage: flux update-fshare [-f DB_PATH]\n"
+              << "optional arguments:\n"
+              << "\t-h,--help\t\t\tShow this help message\n"
+              << "\t-f DB_PATH"
+              << "\t\t\tSpecify location of the flux-accounting database"
+              << std::endl;
+}
+
+
+int main (int argc, char** argv)
+{
+    std::shared_ptr<weighted_tree_node_t> root;
+    data_reader_db_t data_reader;
+    data_writer_db_t data_writer;
+    std::string filepath;
+    int rc;
+
+    // const std::string *err_msg;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "-f") {
+            filepath = argv[i + 1];
+            i++;
+        } else {
+            show_usage ();
+            rc = -1;
+            return rc;
+        }
+    }
+
+    if (filepath == "")
+        filepath = DBPATH;
+
+    root = data_reader.load_accounting_db (filepath);
+
+    if (root == nullptr) {
+        std::string e_msg = data_reader.err_message ();
+        std::cout << e_msg << std::endl;
+        return -1;
+    }
+
+    weighted_walk_t walker (root);
+
+    if (walker.run () < 0) {
+        std::cout << "Unable to calculate fairshare values" << std::endl;
+        return -1;
+    }
+
+    if (data_writer.write_acct_info (filepath, root) < 0) {
+        std::string e_msg = data_writer.err_message ();
+        std::cout << e_msg << std::endl;
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/fairness/Makefile.am
+++ b/src/fairness/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = weighted_tree reader print_hierarchy writer
+SUBDIRS = weighted_tree reader writer print_hierarchy

--- a/src/fairness/reader/data_reader_base.cpp
+++ b/src/fairness/reader/data_reader_base.cpp
@@ -9,6 +9,8 @@
 \************************************************************/
 #include "src/fairness/reader/data_reader_base.hpp"
 
+using namespace Flux::reader;
+
 /******************************************************************************
  *                                                                            *
  *                         Public Base Reader API                             *

--- a/src/fairness/reader/data_reader_base.hpp
+++ b/src/fairness/reader/data_reader_base.hpp
@@ -10,6 +10,8 @@
 #include <sqlite3.h>
 #include <cerrno>
 
+#include "src/fairness/weighted_tree/weighted_tree.hpp"
+
 using namespace Flux::accounting;
 
 namespace Flux {

--- a/src/fairness/weighted_tree/Makefile.am
+++ b/src/fairness/weighted_tree/Makefile.am
@@ -13,7 +13,9 @@ noinst_HEADERS = \
     ../account/account.hpp \
     weighted_tree.hpp \
     weighted_walk.hpp \
+    ../reader/data_reader_base.hpp \
     ../reader/data_reader_db.hpp \
+    ../writer/data_writer_base.hpp \
     ../writer/data_writer_db.hpp \
     ../writer/data_writer_stdout.hpp
 
@@ -21,13 +23,17 @@ libweighted_tree_la_SOURCES = \
     ../account/account.cpp \
     weighted_tree.cpp \
     weighted_walk.cpp \
+    ../reader/data_reader_base.cpp \
     ../reader/data_reader_db.cpp \
+    ../writer/data_writer_base.cpp \
     ../writer/data_writer_db.cpp \
     ../writer/data_writer_stdout.cpp \
     ../account/account.hpp \
     weighted_tree.hpp \
     weighted_walk.hpp \
+    ../reader/data_reader_base.hpp \
     ../reader/data_reader_db.hpp \
+    ../writer/data_writer_base.hpp \
     ../writer/data_writer_db.hpp \
     ../writer/data_writer_stdout.hpp
 

--- a/src/fairness/writer/data_writer_base.cpp
+++ b/src/fairness/writer/data_writer_base.cpp
@@ -7,8 +7,9 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
-
 #include "src/fairness/writer/data_writer_base.hpp"
+
+using namespace Flux::writer;
 
 /******************************************************************************
  *                                                                            *

--- a/src/fairness/writer/data_writer_base.hpp
+++ b/src/fairness/writer/data_writer_base.hpp
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#include "src/fairness/weighted_tree/weighted_tree.hpp"
 
 using namespace Flux::accounting;
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -7,6 +7,7 @@ TESTSCRIPTS = \
 	t1003-mf-priority-small-tie.t \
 	t1004-mf-priority-small-tie-all.t \
 	t1005-max-jobs-limits.t \
+	t1006-update-fshare.t \
 	t1007-flux-account.t
 
 dist_check_SCRIPTS = \

--- a/t/expected/post_fshare_update.expected
+++ b/t/expected/post_fshare_update.expected
@@ -1,0 +1,12 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                    1000                 180
+ account1                                               1000                 121
+  account1                      leaf.1.1               10000                 100            0.571429
+  account1                      leaf.1.2                1000                  11            0.428571
+  account1                      leaf.1.3              100000                  10            0.714286
+ account2                                                100                  58
+  account2                      leaf.2.1              100000                  55            0.142857
+  account2                      leaf.2.2               10000                   3            0.285714
+ account3                                                 10                   1
+  account3                      leaf.3.1                 100                   0                   1
+  account3                      leaf.3.2                  10                   1            0.857143

--- a/t/expected/pre_fshare_update.expected
+++ b/t/expected/pre_fshare_update.expected
@@ -1,0 +1,12 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                    1000                 133
+ account1                                               1000                 121
+  account1                      leaf.1.1               10000                 100            0.285714
+  account1                      leaf.1.2                1000                  11            0.142857
+  account1                      leaf.1.3              100000                  10            0.428571
+ account2                                                100                  11
+  account2                      leaf.2.1              100000                   8            0.714286
+  account2                      leaf.2.2               10000                   3            0.571429
+ account3                                                 10                   1
+  account3                      leaf.3.1                 100                   0                   1
+  account3                      leaf.3.2                  10                   1            0.857143

--- a/t/scripts/create_test_db.py
+++ b/t/scripts/create_test_db.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+
+import fluxacct.accounting
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import create_db as c
+
+
+def edit_usage_col(conn, username, value):
+    # edit value in accounting database
+    conn.execute(
+        "UPDATE association_table SET job_usage=? WHERE username=?",
+        (
+            value,
+            username,
+        ),
+    )
+    # commit changes
+    conn.commit()
+
+
+def main():
+    filename = "/usr/src/t/expected/t_small_no_tie.db"
+    c.create_db(filename)
+    conn = sqlite3.connect(filename)
+
+    b.add_bank(conn, bank="root", shares=1000)
+    b.add_bank(conn, parent_bank="root", bank="account1", shares=1000)
+    b.add_bank(conn, parent_bank="root", bank="account2", shares=100)
+    b.add_bank(conn, parent_bank="root", bank="account3", shares=10)
+
+    u.add_user(
+        conn,
+        username="leaf.1.1",
+        uid="5011",
+        bank="account1",
+        shares="10000",
+    )
+    u.add_user(
+        conn,
+        username="leaf.1.2",
+        uid="5012",
+        bank="account1",
+        shares="1000",
+    )
+    u.add_user(
+        conn,
+        username="leaf.1.3",
+        uid="5013",
+        bank="account1",
+        shares="100000",
+    )
+
+    u.add_user(
+        conn,
+        username="leaf.2.1",
+        uid="5021",
+        bank="account2",
+        shares="100000",
+    )
+    u.add_user(
+        conn,
+        username="leaf.2.2",
+        uid="5022",
+        bank="account2",
+        shares="10000",
+    )
+
+    u.add_user(
+        conn,
+        username="leaf.3.1",
+        uid="5031",
+        bank="account3",
+        shares="100",
+    )
+    u.add_user(
+        conn,
+        username="leaf.3.2",
+        uid="5032",
+        bank="account3",
+        shares="10",
+    )
+
+    edit_usage_col(conn, "leaf.1.1", 100)
+    edit_usage_col(conn, "leaf.1.2", 11)
+    edit_usage_col(conn, "leaf.1.3", 10)
+
+    edit_usage_col(conn, "leaf.2.1", 8)
+    edit_usage_col(conn, "leaf.2.2", 3)
+
+    edit_usage_col(conn, "leaf.3.1", 0)
+    edit_usage_col(conn, "leaf.3.2", 1)
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/t/scripts/update_usage_column.py
+++ b/t/scripts/update_usage_column.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import sys
+import os
+import sqlite3
+
+
+def edit_usage_col(conn, username, value):
+    # edit value in accounting database
+    conn.execute(
+        "UPDATE association_table SET job_usage=? WHERE username=?",
+        (
+            value,
+            username,
+        ),
+    )
+    # commit changes
+    conn.commit()
+
+
+def establish_sqlite_connection(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        sys.exit(1)
+
+    return conn
+
+
+def main():
+    path = sys.argv[1]
+    username = sys.argv[2]
+    value = sys.argv[3]
+
+    conn = establish_sqlite_connection(path)
+
+    edit_usage_col(conn, username, value)
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+test_description='Test print-hierarchy command'
+. `dirname $0`/sharness.sh
+PRINT_HIERARCHY=${FLUX_BUILD_DIR}/src/fairness/print_hierarchy/flux-shares
+UPDATE_FSHARE=${FLUX_BUILD_DIR}/src/cmd/flux-update-fshare
+
+CREATE_TEST_DB=${FLUX_BUILD_DIR}/t/scripts/create_test_db.py
+UPDATE_USAGE_COL=${FLUX_BUILD_DIR}/t/scripts/update_usage_column.py
+
+T_SMALL_NO_TIE=${FLUX_BUILD_DIR}/t/expected/t_small_no_tie.db
+
+test_expect_success 'trying to run update-fshare with bad DBPATH should return an error' '
+	test_must_fail ${UPDATE_FSHARE} -f foo.db > failure.out 2>&1 &&
+	test_debug "cat failure.out" &&
+	grep "error opening DB: unable to open database file" failure.out
+'
+
+test_expect_success 'create t_small_no_tie.db' '
+	flux python ${CREATE_TEST_DB}
+'
+
+test_expect_success 'create hierarchy output from t_small_no_tie.db' '
+	${PRINT_HIERARCHY} -f ${T_SMALL_NO_TIE}
+'
+
+test_expect_success 'run update fshare script - small_no_tie.db' '
+	${UPDATE_FSHARE} -f ${T_SMALL_NO_TIE}
+'
+
+test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '
+	${PRINT_HIERARCHY} -f ${T_SMALL_NO_TIE} > pre_fshare_update.test
+'
+
+test_expect_success 'compare hierarchy outputs' '
+	test_cmp ${FLUX_BUILD_DIR}/t/expected/pre_fshare_update.expected pre_fshare_update.test
+'
+
+test_expect_success 'update usage column in t_small_no_tie.db' '
+	flux python ${UPDATE_USAGE_COL} ${T_SMALL_NO_TIE} leaf.2.1 55
+'
+
+test_expect_success 'run update fshare script - small_no_tie.db' '
+	${UPDATE_FSHARE} -f ${T_SMALL_NO_TIE}
+'
+
+test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '
+	${PRINT_HIERARCHY} -f ${T_SMALL_NO_TIE} > post_fshare_update.test
+'
+
+test_expect_success 'compare hierarchy outputs' '
+	test_cmp ${FLUX_BUILD_DIR}/t/expected/post_fshare_update.expected post_fshare_update.test
+'
+
+test_expect_success 'delete t_small_no_tie.db' '
+	rm ${T_SMALL_NO_TIE}
+'
+
+test_done


### PR DESCRIPTION
#### Background

As noted in #135, there is a way to calculate fairshare values for users in a flux-accounting database using the `weighted_tree` library, but there is no implementation to call it with a front-end command and on a periodic time scale.

#### Implementation

This is an implementation of a front-end script that will load flux-accounting information from a DB, calculate fairshare values, and write the updated information back to the DB. It utilizes both the `data_reader` and `data_writer` classes to read/write the DB information. It takes one optional argument, a path to the flux-accounting DB. If no path is passed in, it will try to load a DB path using `X_LOCALSTATEDIR`, the path set for **FluxAccounting.db** when configuring with a custom `localstatedir`.

#### Testing

The tests for this front-end script utilize two helper scripts: one to create the test DB and populate it with users and banks, and one to simulate a user's job usage value being updated. The front-end fairshare update script will then run twice in the sharness test, before and after the job usage update. This is to ensure the fairshare values are correctly updated and reflected in the DB after the script runs.

---

My idea for this script's implementation is to run this as a `cron` job in conjunction with the job usage update subcommand in flux-accounting: `flux account update-usage`. After the job usage update script is run and new job usage values are calculated and updated in the DB, this fairshare update script will run and update users' fairshare values. 