### PR TITLE
flux-account.py: fix add-user, edit-user, edit-bank, add sharness tests for python subcommands

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -124,7 +124,7 @@ def edit_bank(conn, bank, shares):
     print(shares)
     # if user tries to edit a shares value <= 0,
     # raise an exception
-    if shares <= 0:
+    if int(shares) <= 0:
         raise Exception("New shares amount must be >= 0")
     try:
         # edit value in bank_table

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -45,6 +45,7 @@ def add_user(
     uid=65534,
     admin_level=1,
     shares=1,
+    max_jobs=5,
 ):
 
     # get uid of user
@@ -83,9 +84,10 @@ def add_user(
                 admin_level,
                 bank,
                 default_bank,
-                shares
+                shares,
+                max_jobs
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -97,6 +99,7 @@ def add_user(
                 bank,
                 default_bank,
                 shares,
+                max_jobs,
             ),
         )
         # commit changes

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -149,7 +149,6 @@ def edit_user(conn, username, field, new_value):
         "default_bank",
         "shares",
         "max_jobs",
-        "max_wall_pj",
     ]
     if field in fields:
         the_field = field

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -87,12 +87,6 @@ def add_add_user_arg(subparsers):
         default=1,
         metavar="MAX_JOBS",
     )
-    subparser_add_user.add_argument(
-        "--max-wall-pj",
-        help="max wall time per job",
-        default=60,
-        metavar="MAX_WALL_PJ",
-    )
 
 
 def add_delete_user_arg(subparsers):
@@ -305,7 +299,6 @@ def select_accounting_function(args, conn, output_file, parser):
             args.admin_level,
             args.shares,
             args.max_jobs,
-            args.max_wall_pj,
         )
     elif args.func == "delete_user":
         u.delete_user(conn, args.username, args.bank)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -84,7 +84,7 @@ def add_add_user_arg(subparsers):
     subparser_add_user.add_argument(
         "--max-jobs",
         help="max jobs",
-        default=1,
+        default=5,
         metavar="MAX_JOBS",
     )
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -55,6 +55,7 @@ def add_add_user_arg(subparsers):
     subparser_add_user.add_argument(
         "--userid",
         help="userid",
+        default=65534,
         metavar="USERID",
     )
     subparser_add_user.add_argument(

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -6,7 +6,8 @@ TESTSCRIPTS = \
 	t1002-mf-priority-small-no-tie.t \
 	t1003-mf-priority-small-tie.t \
 	t1004-mf-priority-small-tie-all.t \
-	t1005-max-jobs-limits.t
+	t1005-max-jobs-limits.t \
+	t1007-flux-account.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+test_description='Test flux-account commands'
+. `dirname $0`/sharness.sh
+PRINT_HIERARCHY=${FLUX_BUILD_DIR}/src/fairness/print_hierarchy/flux-shares
+FLUX_ACCOUNT=${FLUX_BUILD_DIR}/src/cmd/flux-account.py
+DB_PATH=${FLUX_BUILD_DIR}/t/FluxAccountingTest.db
+
+test_expect_success 'create flux-accounting DB' '
+	flux python ${FLUX_ACCOUNT} create-db ${FLUX_BUILD_DIR}/t/FluxAccountingTest.db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank root 1 &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank --parent-bank=root A 1 &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank --parent-bank=root B 1 &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank --parent-bank=root C 1
+'
+
+test_expect_success 'add some users to the DB' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5011 --userid=5011 --bank=A &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=A &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5013 --userid=5013 --bank=B &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5014 --userid=5014 --bank=C
+'
+
+test_expect_success 'trying to view a bank that does not exist in the DB should return an error message' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank foo > bad_bank.out &&
+	grep "Bank not found in bank_table" bad_bank.out
+'
+
+test_expect_success 'trying to view a bank that does exist in the DB should return some information' '
+	cat <<-EOF >good_bank.expected &&
+		   bank_id bank parent_bank  shares
+	0        2    A        root       1
+	EOF
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank A > good_bank.test &&
+	test_cmp good_bank.expected good_bank.test
+'
+
+test_expect_success 'trying to view a user who does not exist in the DB should return an error message' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user9999 > bad_user.out &&
+	grep "User not found in association_table" bad_user.out
+'
+
+test_expect_success 'trying to view a user that does exist in the DB should return some information' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5011 > good_user.test &&
+	grep "creation_time" good_user.test
+'
+
+test_expect_success 'edit a field in a user account' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-user --username=user5011 --field=shares --new-value=50
+'
+
+test_expect_success 'edit a field in a bank account' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-bank C --shares=50 &&
+	cat <<-EOF >edited_bank.expected &&
+		   bank_id bank parent_bank  shares
+	0        4    C        root      50
+	EOF
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank C > edited_bank.test &&
+	test_cmp edited_bank.expected edited_bank.test
+'
+
+test_expect_success 'remove a bank (and any corresponding users that belong to that bank)' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} delete-bank C
+'
+
+test_expect_success 'make sure both the DB and the user are successfully removed from DB' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank C > deleted_bank.out &&
+	grep "Bank not found in bank_table" deleted_bank.out &&
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5014 > deleted_user.out &&
+	grep "User not found in association_table" deleted_user.out
+'
+
+test_expect_success 'remove a user account' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} delete-user user5012 A
+'
+
+test_expect_success 'make sure the user is successfully removed from the DB' '
+	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5012 > deleted_user.out &&
+	grep "User not found in association_table" deleted_user.out
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm ${FLUX_BUILD_DIR}/t/FluxAccountingTest.db
+'
+
+test_done


### PR DESCRIPTION
~~_note: this PR is built on top of #131, so I will leave this as [WIP] until that PR is merged and then I will rebase._~~

_note: this PR will round out the `0.9.0` release for flux-accounting._

I noticed while doing some interactive testing with **flux-account.py** that a couple subcommands were broken/not working as expected, mostly because of some broken function headers that came partly as a result from #124 and from a general lack of testing. This PR includes some various minor fixes to a couple of the subcommands and user/bank functions.

This PR also adds a set of tests for **flux-acount.py** to hopefully prevent bugs like this from creeping into the code in the future. These tests use the basic subcommands that interact with user and bank accounts in the flux-accounting DB, such as adding a user account, editing some fields, adding a bank, and removing a bank, just to name a few.

note: A successful `view-user` call includes a `created` timestamp that will change with every run of the tests, so to test for success I am just `grep`-ing for a `creation_time` column. 

Fixes #137