### PR TITLE
flux-accounting DB: add Quality of Service table, field in `association_table`

### DIFF
--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -44,7 +44,7 @@ symbols=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines, duplicate-code, too-many-instance-attributes, too-many-locals
+disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines, duplicate-code, too-many-instance-attributes, too-many-locals, too-many-branches
 
 
 [REPORTS]

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -2,6 +2,7 @@ acctpy_PYTHON = \
 	__init__.py \
 	user_subcommands.py \
 	bank_subcommands.py \
+	qos_subcommands.py \
 	job_archive_interface.py \
 	create_db.py
 
@@ -14,7 +15,8 @@ TESTSCRIPTS = \
 	test/test_create_db.py \
 	test/test_example.py \
 	test/test_job_archive_interface.py \
-	test/test_user_subcommands.py
+	test/test_user_subcommands.py \
+	test/test_qos_subcommands.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS)

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -159,4 +159,15 @@ def create_db(
     set_half_life_period_end(conn, priority_decay_half_life)
     logging.info("Created t_half_life_period_table successfully")
 
+    # QOS Table
+    # keeps track of what QOS' are defined and their associated priority
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS qos_table (
+            qos         tinytext        NOT NULL,
+            priority    int(11)         NOT NULL,
+            PRIMARY KEY (qos)
+        );"""
+    )
+
     conn.close()

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -99,6 +99,7 @@ def create_db(
                 job_usage     real        DEFAULT 0.0   NOT NULL,
                 fairshare     real        DEFAULT 0.5   NOT NULL,
                 max_jobs      int(11)     DEFAULT 5     NOT NULL,
+                qos           tinytext    DEFAULT ''    NOT NULL,
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/bindings/python/fluxacct/accounting/qos_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/qos_subcommands.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+
+
+def view_qos(conn, qos):
+    cur = conn.cursor()
+    try:
+        # get the information pertaining to a QOS in the DB
+        cur.execute("SELECT * FROM qos_table where qos=?", (qos,))
+        row = cur.fetchone()
+        if row is None:
+            print("QOS not found in qos_table")
+        else:
+            print(row)
+    except sqlite3.OperationalError as e_database_error:
+        print(e_database_error)
+
+
+def add_qos(conn, qos, priority):
+    try:
+        insert_stmt = "INSERT INTO qos_table (qos, priority) VALUES (?, ?)"
+        conn.execute(
+            insert_stmt,
+            (
+                qos,
+                priority,
+            ),
+        )
+
+        conn.commit()
+    # make sure entry is unique
+    except sqlite3.IntegrityError as integrity_error:
+        print(integrity_error)
+
+
+# WARNING: deleting QOS entries does not remove them from the association_table,
+# which could lead to inconsistencies when users submit jobs under that QOS.
+def delete_qos(conn, qos):
+    delete_stmt = "DELETE FROM qos_table WHERE qos=?"
+    cursor = conn.cursor()
+    cursor.execute(delete_stmt, (qos,))
+
+    conn.commit()
+
+
+def edit_qos(conn, qos, new_priority):
+    edit_stmt = "UPDATE qos_table SET priority=? WHERE qos=?"
+
+    # edit priority in qos_table
+    conn.execute(
+        edit_stmt,
+        (
+            new_priority,
+            qos,
+        ),
+    )
+    # commit changes
+    conn.commit()

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -63,9 +63,9 @@ class TestDB(unittest.TestCase):
             """
             INSERT INTO association_table
             (creation_time, mod_time, deleted, username, userid, admin_level,
-            bank, default_bank, shares)
+            bank, default_bank, shares, qos)
             VALUES
-            (0, 0, 0, "test user", 1234, 1, "test account", "test_account", 0)
+            (0, 0, 0, "test user", 1234, 1, "test account", "test_account", 0, "")
             """
         )
         cursor = conn.cursor()

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -53,6 +53,7 @@ class TestDB(unittest.TestCase):
             "sqlite_sequence",
             "job_usage_factor_table",
             "t_half_life_period_table",
+            "qos_table",
         ]
         self.assertEqual(list_of_tables, expected)
 

--- a/src/bindings/python/fluxacct/accounting/test/test_qos_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_qos_subcommands.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import qos_subcommands as q
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create example accounting database
+        c.create_db("TestQOSSubcommands.db")
+        global acct_conn
+        global cur
+
+        acct_conn = sqlite3.connect("TestQOSSubcommands.db")
+        cur = acct_conn.cursor()
+
+    # add a valid qos to qos_table
+    def test_01_add_valid_qos(self):
+        q.add_qos(acct_conn, qos="standby", priority=0)
+        cur.execute("SELECT * FROM qos_table WHERE qos='standby'")
+        rows = cur.fetchall()
+
+        self.assertEqual(len(rows), 1)
+
+    # let's make sure if we try to add it a second time,
+    # it fails gracefully
+    def test_02_add_dup_qos(self):
+        q.add_qos(acct_conn, qos="standby", priority=0)
+        self.assertRaises(sqlite3.IntegrityError)
+
+    # edit a value for a user in the association table
+    def test_03_edit_qos_priority(self):
+        q.edit_qos(acct_conn, qos="standby", new_priority=1000)
+        cur.execute("SELECT priority FROM qos_table where qos='standby'")
+
+        self.assertEqual(cur.fetchone()[0], 1000)
+
+    # remove a QOS currently in the qos_table
+    def test_04_delete_qos(self):
+        q.delete_qos(acct_conn, qos="standby")
+        cur.execute("SELECT * FROM qos_table WHERE qos='standby'")
+        rows = cur.fetchall()
+
+        self.assertEqual(len(rows), 0)
+
+    # trying to add a user with a bad QoS should raise a ValueError
+    def test_05_add_user_with_bad_qos(self):
+        u.add_user(acct_conn, username="u5011", uid="5011", bank="acct", qos="foo")
+
+        self.assertRaises(ValueError)
+
+    # trying to edit a user with a bad QoS should also raise a ValueError
+    def test_06_edit_user_with_bad_qos(self):
+        u.add_user(acct_conn, username="u5011", uid="5011", bank="acct")
+        u.edit_user(acct_conn, username="u5011", field="qos", new_value="foo")
+
+        self.assertRaises(ValueError)
+
+    # if we add multiple QoS to the qos_table, we should be able to specify it
+    # in the association_table as well
+    def test_07_add_multiple_qos_to_user(self):
+        q.add_qos(acct_conn, qos="standby", priority=0)
+        q.add_qos(acct_conn, qos="expedite", priority=10000)
+        q.add_qos(acct_conn, qos="special", priority=99999)
+
+        u.edit_user(
+            acct_conn,
+            username="u5011",
+            field="qos",
+            new_value="standby,expedite,special",
+        )
+        cur.execute("SELECT qos FROM association_table WHERE username='u5011'")
+
+        self.assertEqual(cur.fetchone()[0], "standby,expedite,special")
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        acct_conn.close()
+        os.remove("TestQOSSubcommands.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -46,6 +46,7 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
+            qos="",
         )
         cursor = acct_conn.cursor()
         num_rows_assoc_table = cursor.execute("DELETE FROM association_table").rowcount
@@ -65,6 +66,7 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
+            qos="",
         )
         u.add_user(
             acct_conn,
@@ -73,6 +75,7 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
+            qos="",
         )
 
         self.assertRaises(sqlite3.IntegrityError)
@@ -87,6 +90,7 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="acct",
             shares="10",
+            qos="",
         )
         u.add_user(
             acct_conn,
@@ -95,6 +99,7 @@ class TestAccountingCLI(unittest.TestCase):
             admin_level="1",
             bank="other_acct",
             shares="10",
+            qos="",
         )
         cursor = acct_conn.cursor()
         cursor.execute("SELECT * from association_table where username='dup_user'")

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -106,7 +106,13 @@ class TestAccountingCLI(unittest.TestCase):
 
     # edit a value for a user in the association table
     def test_04_edit_user_value(self):
-        u.edit_user(acct_conn, "fluxuser", "shares", "10000")
+        u.edit_user(
+            acct_conn,
+            username="fluxuser",
+            bank="acct",
+            field="shares",
+            new_value="10000",
+        )
         cursor = acct_conn.cursor()
         cursor.execute("SELECT shares FROM association_table where username='fluxuser'")
 
@@ -116,7 +122,13 @@ class TestAccountingCLI(unittest.TestCase):
     # exist should return a ValueError
     def test_05_edit_bad_field(self):
         with self.assertRaises(ValueError):
-            u.edit_user(acct_conn, "fluxuser", "foo", "bar")
+            u.edit_user(
+                acct_conn,
+                username="fluxuser",
+                bank="acct",
+                field="foo",
+                new_value="bar",
+            )
 
     # delete a user from the association table
     def test_06_delete_user(self):
@@ -169,7 +181,12 @@ class TestAccountingCLI(unittest.TestCase):
 
     # check that we can successfully edit the default bank for a user
     def test_09_edit_default_bank(self):
-        u.edit_user(acct_conn, "test_user1", "default_bank", "other_test_bank")
+        u.edit_user(
+            acct_conn,
+            username="test_user1",
+            field="default_bank",
+            new_value="other_test_bank",
+        )
         cursor = acct_conn.cursor()
         cursor.execute(
             "SELECT default_bank FROM association_table WHERE username='test_user1'"

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -45,6 +45,7 @@ def add_user(
     admin_level=1,
     shares=1,
     max_jobs=5,
+    qos="",
 ):
 
     # get uid of user
@@ -84,9 +85,10 @@ def add_user(
                 bank,
                 default_bank,
                 shares,
-                max_jobs
+                max_jobs,
+                qos
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -99,6 +101,7 @@ def add_user(
                 default_bank,
                 shares,
                 max_jobs,
+                qos,
             ),
         )
         # commit changes

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -140,7 +140,7 @@ def delete_user(conn, username, bank):
     conn.commit()
 
 
-def edit_user(conn, username, field, new_value):
+def edit_user(conn, username, field, new_value, bank=""):
     fields = [
         "username",
         "admin_level",
@@ -152,14 +152,33 @@ def edit_user(conn, username, field, new_value):
     if field in fields:
         the_field = field
 
-        # edit value in accounting database
-        conn.execute(
-            "UPDATE association_table SET " + the_field + "=? WHERE username=?",
-            (
-                new_value,
-                username,
-            ),
-        )
+        if bank != "":
+            update_stmt = (
+                "UPDATE association_table SET "
+                + the_field
+                + "=? WHERE username=? AND bank=?"
+            )
+            # edit value in accounting database
+            conn.execute(
+                update_stmt,
+                (
+                    new_value,
+                    username,
+                    bank,
+                ),
+            )
+        else:
+            update_stmt = (
+                "UPDATE association_table SET " + the_field + "=? WHERE username=?"
+            )
+            conn.execute(
+                update_stmt,
+                (
+                    new_value,
+                    username,
+                ),
+            )
+
         # commit changes
         conn.commit()
     else:

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -15,6 +15,7 @@ import os
 import fluxacct.accounting
 from fluxacct.accounting import user_subcommands as u
 from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import qos_subcommands as q
 from fluxacct.accounting import job_archive_interface as jobs
 from fluxacct.accounting import create_db as c
 
@@ -86,6 +87,12 @@ def add_add_user_arg(subparsers):
         help="max jobs",
         default=5,
         metavar="MAX_JOBS",
+    )
+    subparser_add_user.add_argument(
+        "--qos",
+        help="quality of service",
+        default="",
+        metavar="QUALITY OF SERVICE",
     )
 
 
@@ -305,6 +312,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.admin_level,
             args.shares,
             args.max_jobs,
+            args.qos,
         )
     elif args.func == "delete_user":
         u.delete_user(conn, args.username, args.bank)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -253,6 +253,39 @@ def add_update_usage_arg(subparsers):
     )
 
 
+def add_add_qos_arg(subparsers):
+    subparser_add_qos = subparsers.add_parser("add-qos", help="add a new qos")
+
+    subparser_add_qos.set_defaults(func="add_qos")
+    subparser_add_qos.add_argument("--qos", help="QOS name", metavar="QOS")
+    subparser_add_qos.add_argument(
+        "--priority", help="QOS priority", metavar="PRIORITY"
+    )
+
+
+def add_view_qos_arg(subparsers):
+    subparser_view_qos = subparsers.add_parser("view-qos", help="view QOS information")
+
+    subparser_view_qos.set_defaults(func="view_qos")
+    subparser_view_qos.add_argument("--qos", help="QOS name", metavar="QOS")
+
+
+def add_edit_qos_arg(subparsers):
+    subparser_edit_qos = subparsers.add_parser("edit-qos", help="edit a QOS' priority")
+
+    subparser_edit_qos.set_defaults(func="edit_qos")
+    subparser_edit_qos.add_argument("--qos", help="qos name", metavar="QOS")
+    subparser_edit_qos.add_argument(
+        "--priority", help="new priority", metavar="PRIORITY"
+    )
+
+
+def add_delete_qos_arg(subparsers):
+    subparser_delete_qos = subparsers.add_parser("delete-qos", help="remove a QOS")
+    subparser_delete_qos.set_defaults(func="delete_qos")
+    subparser_delete_qos.add_argument("--qos", help="QOS name", metavar="QOS")
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -267,6 +300,10 @@ def add_arguments_to_parser(parser, subparsers):
     add_delete_bank_arg(subparsers)
     add_edit_bank_arg(subparsers)
     add_update_usage_arg(subparsers)
+    add_add_qos_arg(subparsers)
+    add_view_qos_arg(subparsers)
+    add_edit_qos_arg(subparsers)
+    add_delete_qos_arg(subparsers)
 
 
 def set_db_location(args):
@@ -338,6 +375,14 @@ def select_accounting_function(args, conn, output_file, parser):
     elif args.func == "update_usage":
         jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
         jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)
+    elif args.func == "add_qos":
+        q.add_qos(conn, args.qos, args.priority)
+    elif args.func == "view_qos":
+        q.view_qos(conn, args.qos)
+    elif args.func == "edit_qos":
+        q.edit_qos(conn, args.qos, args.priority)
+    elif args.func == "delete_qos":
+        q.delete_qos(conn, args.qos)
     else:
         print(parser.print_usage())
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -109,6 +109,12 @@ def add_edit_user_arg(subparsers):
         metavar="USERNAME",
     )
     subparser_edit_user.add_argument(
+        "--bank",
+        help="bank",
+        default="",
+        metavar="BANK",
+    )
+    subparser_edit_user.add_argument(
         "--field",
         help="column name",
         metavar="FIELD",
@@ -303,7 +309,7 @@ def select_accounting_function(args, conn, output_file, parser):
     elif args.func == "delete_user":
         u.delete_user(conn, args.username, args.bank)
     elif args.func == "edit_user":
-        u.edit_user(conn, args.username, args.field, args.new_value)
+        u.edit_user(conn, args.username, args.field, args.new_value, args.bank)
     elif args.func == "view_job_records":
         jobs.view_job_records(
             conn,


### PR DESCRIPTION
This is an early [WIP] PR for defining and configuring Quality of Service (further referred to as QoS) in the flux-accounting database. In a subsequent PR, I plan to integrate this new table with the multi-factor priority plugin, where it will be used to affect the prioritization of jobs.

#### Background

QoS is a mechanism for further prioritizing submitted jobs. Each QoS has a unique name and an associated priority that can positively or negatively impact the priority of a job in a queue. Jobs that request (and are permitted) a QoS will incorporate the priority associated with that QoS in the multi-factor priority calculation. 

#### Implementation

This PR introduces the definition and configuration of QoS in the flux-accounting DB.

QoS is primarily defined and configured via its own table in the DB, named `qos_table`. It has two columns, one for the name of the QoS and one for the associated priority with it. The primary key of this table is the name of the QoS to prevent duplication. 

This table can be interacted with a new set of subcommands defined in `qos_subcommands.py`, which hosts basic functionality to add a new QoS(s), edit their associated priorities, view its information, and remove them from the table. The new subcommands introduced to interact with this new table are: `add-qos`, `view-qos`, `edit-qos`, and `delete-qos`. 

The other component of defining the QoS is to add it to each user/bank row in the `association_table`. This new `qos` column represents the available QoS(s) that the user is permitted to access when submitting jobs. This column will hold a text value that is comma-separated, with each available QoS under this column. It can be set when the user is first added to the DB or edited later on down the road. There is a helper function, `validate_qos()`, which will split the QoS(s) passed in to both the `add-user` and `edit-user` subcommands. It will check to see if the QoS passed in exist in the `qos_table` before adding them to a user/bank row in the `association_table`. A `ValueError` exception is raised if the QoS does not exist in the table.

_note: if a QoS is removed from the `qos_table`, those changes are not propagated to the `qos` column in the `association_table`, so a warning comment is left over the function to make note of this behavior._

#### Testing

Basic tests are added for both the functions defined in `qos_subcommands.py` as well as calling them from the front-end Python script `flux-account.py`.

~~`TODO`: add tests to ensure `ValueError` is raised when adding/editing a non-existent QoS in a user row.~~

EDIT: Those `ValueError` tests have been added now to both the unit tests for `qos_subcommands.py` and the sharness tests in `t1007-flux-account.t`.  