### PR TITLE
create_test_db: change path to a command line arg

### DIFF
--- a/t/scripts/create_test_db.py
+++ b/t/scripts/create_test_db.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import sqlite3
+import sys
 
 import fluxacct.accounting
 from fluxacct.accounting import user_subcommands as u
@@ -30,7 +31,11 @@ def edit_usage_col(conn, username, value):
 
 
 def main():
-    filename = "/usr/src/t/expected/t_small_no_tie.db"
+    if len(sys.argv) < 2:
+        print("You must pass a path to the flux-accounting DB")
+        sys.exit(-1)
+
+    filename = sys.argv[1]
     c.create_db(filename)
     conn = sqlite3.connect(filename)
 

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -17,7 +17,7 @@ test_expect_success 'trying to run update-fshare with bad DBPATH should return a
 '
 
 test_expect_success 'create t_small_no_tie.db' '
-	flux python ${CREATE_TEST_DB}
+	flux python ${CREATE_TEST_DB} ${FLUX_BUILD_DIR}/t/expected/t_small_no_tie.db
 '
 
 test_expect_success 'create hierarchy output from t_small_no_tie.db' '


### PR DESCRIPTION
**Problem**: The path to the test DB in `create_test_db.py` is hard-coded in, which results in a `FileNotFoundError` when running the test on LC systems because I don't have permission to write files to `/usr/src`.

Change the helper script to take a command line argument which will represent a path to the DB file.

**Solution**: Use `${FLUX_BUILD_DIR}` in the sharness test when setting the path to the DB file, and set the path inside the flux-accounting directory.

Fixes #145