### PR TITLE
NEWS.md: add release notes for v0.10.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+flux-accounting version 0.10.0 - 2021-09-30
+-------------------------------------------
+
+#### Fixes
+
+* Fix bug in add-user where wrong number of arguments were passed to function (#140)
+
+* Fix bug in edit-user to ensure an edit made in one user/bank row was only made in just that one row instead of in multiple rows in the flux-accounting database (#140)
+
+#### Features
+
+* Add a new front-end update script that will re-calculate users' fairshare values and update them in the flux-accounting database (#138)
+
+* Add new Quality of Service table in the flux-accounting database, which will hold Quality of Services and their associated priorities (#143)
+
+* Add new sharness tests for Python subcommands (#140)
+
+* Remove pandas dependency from flux-accounting, which was required to build/install (#144)
+
 flux-accounting version 0.9.0 - 2021-09-07
 ------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for `v0.10.0`. I'll keep this **[WIP]** until the fix from #150 has landed.

Once this gets merged, I'll be sure to create an annotated tag using the following instruction:

```
git tag -a v0.10.0 -m "Tag v0.10.0" && git push upstream v0.10.0
```