### PR TITLE
mergify: add OR condition for approved reviews

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,9 @@ pull_request_rules:
       - status-success="coverage"
       - label="merge-when-passing"
       - label!="work-in-progress"
-      - "approved-reviews-by=@flux-framework/core"
+      - or:
+          - "approved-reviews-by=@flux-framework/core"
+          - "approved-reviews-by=@flux-framework/accounting"
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
       - -title~=^\[*[Ww][Ii][Pp]


### PR DESCRIPTION
This tiny PR adds an [OR condition](https://docs.mergify.io/conditions/#combining-conditions-with-operators) to `.mergify.yml` to accept a review from someone either on the `@flux-framework/core` team or the `@flux-framework/accounting` team.

I believe since this PR makes changes to Mergify, once approved, it will need to be merged manually.