### PR TITLE
mergify: set queue method to merge, not rebase

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,5 +32,5 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        method: rebase
+        method: merge
         update_method: rebase


### PR DESCRIPTION
Problem: Pointed out in flux-framework/flux-core#3916, the current mergify config specifies that PRs are merged using a rebase method and not merge. This would result in the PR branch being rebased onto the main branch instead of creating a merge commit.

This PR changes the queue action for PRs to be `merge`, with an `update_method` of `rebase`, which should be similar to the previous 'strict' mode used earlier.