### PR TITLE
flux-account-priority-update: change `bulk_update` method

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -8,7 +8,8 @@ TESTSCRIPTS = \
 	t1004-mf-priority-small-tie-all.t \
 	t1005-max-jobs-limits.t \
 	t1006-update-fshare.t \
-	t1007-flux-account.t
+	t1007-flux-account.t \
+	t1008-mf-priority-update.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/scripts/send_payload.py
+++ b/t/scripts/send_payload.py
@@ -7,7 +7,6 @@ import flux
 h = flux.Flux()
 
 with open(sys.argv[1]) as data_file:
-    data = json.load(data_file)
+    bulk_update_data = json.load(data_file)
 
-for user in data["users"]:
-    h.rpc("job-manager.mf_priority.rec_update", user).get()
+h.rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -24,14 +24,14 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 test_expect_success 'create a group of users with unique fairshare values' '
 	cat <<-EOF >fake_small_no_tie.json
 	{
-		"users" : [
-			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.285714", "max_jobs": "5"},
-			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.142857", "max_jobs": "5"},
-			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.428571", "max_jobs": "5"},
-			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.714286", "max_jobs": "5"},
-			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.571429", "max_jobs": "5"},
-			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0", "max_jobs": "5"},
-			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.857143", "max_jobs": "5"}
+		"data" : [
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_jobs": 5},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_jobs": 5},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_jobs": 5},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_jobs": 5},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_jobs": 5},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_jobs": 5},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_jobs": 5}
 		]
 	}
 	EOF

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -24,15 +24,15 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 test_expect_success 'create a group of users with some ties in fairshare values' '
 	cat <<-EOF >fake_small_tie.json
 	{
-		"users" : [
-			{"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.5", "max_jobs": "5"},
-			{"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.5", "max_jobs": "5"},
-			{"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "0.75", "max_jobs": "5"},
-			{"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.5", "max_jobs": "5"},
-			{"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.5", "max_jobs": "5"},
-			{"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "0.75", "max_jobs": "5"},
-			{"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "1.0", "max_jobs": "5"},
-			{"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.875", "max_jobs": "5"}
+		"data" : [
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_jobs": 5},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_jobs": 5},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_jobs": 5},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_jobs": 5},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_jobs": 5},
+			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_jobs": 5},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_jobs": 5},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_jobs": 5}
 		]
 	}
 	EOF

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -24,16 +24,16 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 test_expect_success 'create a group of users with many ties in fairshare values' '
 	cat <<-EOF >fake_small_tie_all.json
 	{
-	    "users" : [
-	        {"userid": "5011", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667", "max_jobs": "5"},
-	        {"userid": "5012", "bank": "account1", "default_bank": "account1", "fairshare": "0.666667", "max_jobs": "5"},
-	        {"userid": "5013", "bank": "account1", "default_bank": "account1", "fairshare": "1", "max_jobs": "5"},
-	        {"userid": "5021", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667", "max_jobs": "5"},
-	        {"userid": "5022", "bank": "account2", "default_bank": "account2", "fairshare": "0.666667", "max_jobs": "5"},
-	        {"userid": "5023", "bank": "account2", "default_bank": "account2", "fairshare": "1", "max_jobs": "5"},
-	        {"userid": "5031", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667", "max_jobs": "5"},
-	        {"userid": "5032", "bank": "account3", "default_bank": "account3", "fairshare": "0.666667", "max_jobs": "5"},
-	        {"userid": "5033", "bank": "account3", "default_bank": "account3", "fairshare": "1", "max_jobs": "5"}
+	    "data" : [
+	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_jobs": 5},
+	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_jobs": 5},
+	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_jobs": 5},
+	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_jobs": 5},
+	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_jobs": 5},
+	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_jobs": 5},
+	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_jobs": 5},
+	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_jobs": 5},
+	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_jobs": 5}
 	    ]
 	}
 	EOF

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -24,9 +24,9 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 test_expect_success 'create fake_user.json' '
 	cat <<-EOF >fake_user.json
 	{
-		"users" : [
-			{"userid": "5011", "bank": "account3", "default_bank": "account3", "fairshare": "0.45321", "max_jobs": "3"},
-			{"userid": "5011", "bank": "account2", "default_bank": "account3", "fairshare": "0.11345", "max_jobs": "2"}
+		"data" : [
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": 3},
+			{"userid": 5011, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_jobs": 2}
 		]
 	}
 	EOF
@@ -83,8 +83,8 @@ test_expect_success 'submit a job while already having max number of active jobs
 test_expect_success 'increase the max jobs count of the user' '
 	cat <<-EOF >new_max_jobs_limit.json
 	{
-		"users" : [
-			{"userid": "5011", "bank": "account3", "default_bank": "account3", "fairshare": "0.45321", "max_jobs": "4"}
+		"data" : [
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": 4}
 		]
 	}
 	EOF

--- a/t/t1008-mf-priority-update.t
+++ b/t/t1008-mf-priority-update.t
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin order with no ties'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+FLUX_EXEC_PATH=${SHARNESS_TEST_SRCDIR}/../src/cmd:${FLUX_EXEC_PATH}
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1
+'
+
+test_expect_success 'add some users to the DB' '
+	flux account -p ${DB_PATH} add-user --username=user5011 --userid=5011 --bank=account1 &&
+	flux account -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=account1 &&
+	flux account -p ${DB_PATH} add-user --username=user5013 --userid=5013 --bank=account1
+'
+
+test_expect_success 'send the user information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+test_expect_success 'successfully submit jobs as each user' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 hostname) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5012 hostname) &&
+	jobid3=$(flux python ${SUBMIT_AS} 5013 hostname) &&
+	flux jobs -A | grep "$jobid1\|$jobid2\|$jobid3"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Mentioned in #133, currently the bulk update script that queries information from the flux-accounting database and sends it to the multi-factor priority plugin sends one JSON payload for every row in the database. This can be inefficient for a database with many users in it and could potentially cause problems if a user submits a job in the middle of a bulk update.

---

#### Implementation

This is a **[WIP]** PR that improves the bulk update script by changing how the JSON payload is structured and sent to the plugin. Previously, for every user-bank row in the `association_table`, a payload was created containing all the necessary data and then sent to the plugin with every iteration. 

```
for every row in the association_table:
    create one payload with result of SQLite query

    send it to plugin with flux.Flux().rpc()
```

Now, for every user-bank row, the bulk update scripts creates one payload and appends it to a list. This list is then sent via RPC just once to the plugin.

```
for every row in the association_table:
    create one payload with result of SQLite query

    append it to a list of payloads

send the list of payloads to the plugin with flux.Flux().rpc()
```

This PR also changes how the plugin unpacks the data since it is now receiving just one payload. It unpacks the array of JSON objects and iterates through it in a `for` loop, unpacking the user-bank information and adding it to the appropriate data structures in the plugin using `json_object_get ()`.

```c++
uid = (char *) json_string_value (json_object_get (el, "userid"));
```

I also added a new sharness test, `t1008-mf-priority-update.t` that tests the bulk update script by creating a test flux-accounting DB with some sample users and banks. It then uses `flux-account-priority-update.py` to send the DB information to the plugin, and then submits `hostname` jobs as each user to make sure their information was successfully sent and accepted in the plugin (if not, the plugin should reject the submitted jobs with a message saying the user does not exist in the flux-accounting DB).

Fixes #133 