### PR TITLE
database: change default DB path, update README build instructions

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -1,4 +1,4 @@
-db_dir = "@acct_db_path@"
-db_path = "@acct_db_path@/FluxAccounting.db"
+db_dir = "@X_LOCALSTATEDIR@/lib/flux/"
+db_path = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
 
 __all__ = ["db_dir", "db_path"]

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -167,9 +167,6 @@ def add_create_db_arg(subparsers):
     )
     subparser_create_db.set_defaults(func="create_db")
     subparser_create_db.add_argument(
-        "path", help="specify location of database file", metavar=("DATABASE PATH")
-    )
-    subparser_create_db.add_argument(
         "--priority-usage-reset-period",
         help="the number of weeks at which usage information gets reset to 0",
         metavar=("PRIORITY USAGE RESET PERIOD"),
@@ -407,7 +404,7 @@ def main():
     # to ONLY create the DB and then exit out successfully
     if args.func == "create_db":
         c.create_db(
-            args.path, args.priority_usage_reset_period, args.priority_decay_half_life
+            path, args.priority_usage_reset_period, args.priority_decay_half_life
         )
         sys.exit(0)
 

--- a/src/cmd/flux_account_update_fshare.cpp
+++ b/src/cmd/flux_account_update_fshare.cpp
@@ -23,7 +23,8 @@ using namespace Flux::accounting;
 using namespace Flux::reader;
 using namespace Flux::writer;
 
-const std::string DBPATH = std::string (X_LOCALSTATEDIR) + "/FluxAccounting.db";
+const std::string DBPATH = std::string (X_LOCALSTATEDIR)
+                                                + "/lib/flux/FluxAccounting.db";
 
 static void show_usage ()
 {

--- a/src/fairness/print_hierarchy/flux_account_shares.cpp
+++ b/src/fairness/print_hierarchy/flux_account_shares.cpp
@@ -21,6 +21,9 @@ extern "C" {
 using namespace Flux::accounting;
 using namespace Flux::writer;
 
+const std::string DBPATH = std::string (X_LOCALSTATEDIR)
+                                                + "/lib/flux/FluxAccounting.db";
+
 static void show_usage ()
 {
     std::cout << "usage: flux shares [-P DELIMITER] [-p DB_PATH]\n"
@@ -64,6 +67,9 @@ int main (int argc, char** argv)
             return rc;
         }
     }
+
+    if (filepath == "")
+        filepath = DBPATH;
 
     data_writer_stdout_t data_writer (indent, parsable, delimiter);
     rc = data_writer.write_acct_info (filepath, root);

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -6,7 +6,7 @@ FLUX_ACCOUNT=${SHARNESS_TEST_SRCDIR}/../src/cmd/flux-account.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 test_expect_success 'create flux-accounting DB' '
-	flux python ${FLUX_ACCOUNT} create-db $(pwd)/FluxAccountingTest.db
+	flux python ${FLUX_ACCOUNT} -p $(pwd)/FluxAccountingTest.db create-db
 '
 
 test_expect_success 'add some banks to the DB' '


### PR DESCRIPTION
#### Problem

Noted in #168, the default path for the FluxAccounting.db should be changed to `@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db`.

---

This PR changes the default path for the FluxAccounting.db to `@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db` since it is already set up to be owned by user flux. 

When building the project from source, one can use the following:

```shell
./autogen.sh && ./configure --localstatedir=/var/ && make -j && make check
```

to create a default DB location for `/var/lib/flux/`.

As long as the person or people administering the DB has permissions to this directory, then they should be able to interact with this DB, i.e adding banks and users, editing their information, and more. 

It also updates the default DB path for `flux account update-fshare` and adds a default DB path for `flux account account-shares`. 

Finally, it updates the build instructions in the top-level README with the new default DB location and removes the optional path arguments from the sample code blocks. 

---

Fixes #168