### PR TITLE
cmd: unify optional path argument

### DIFF
--- a/src/cmd/flux_account_update_fshare.cpp
+++ b/src/cmd/flux_account_update_fshare.cpp
@@ -44,8 +44,6 @@ int main (int argc, char** argv)
     std::string filepath;
     int rc;
 
-    // const std::string *err_msg;
-
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "-p") {

--- a/src/cmd/flux_account_update_fshare.cpp
+++ b/src/cmd/flux_account_update_fshare.cpp
@@ -27,10 +27,10 @@ const std::string DBPATH = std::string (X_LOCALSTATEDIR) + "/FluxAccounting.db";
 
 static void show_usage ()
 {
-    std::cout << "usage: flux update-fshare [-f DB_PATH]\n"
+    std::cout << "usage: flux update-fshare [-p DB_PATH]\n"
               << "optional arguments:\n"
               << "\t-h,--help\t\t\tShow this help message\n"
-              << "\t-f DB_PATH"
+              << "\t-p DB_PATH"
               << "\t\t\tSpecify location of the flux-accounting database"
               << std::endl;
 }
@@ -48,7 +48,7 @@ int main (int argc, char** argv)
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        if (arg == "-f") {
+        if (arg == "-p") {
             filepath = argv[i + 1];
             i++;
         } else {

--- a/src/fairness/print_hierarchy/flux_account_shares.cpp
+++ b/src/fairness/print_hierarchy/flux_account_shares.cpp
@@ -23,12 +23,12 @@ using namespace Flux::writer;
 
 static void show_usage ()
 {
-    std::cout << "usage: flux shares [-P DELIMITER] [-f DB_PATH]\n"
+    std::cout << "usage: flux shares [-P DELIMITER] [-p DB_PATH]\n"
               << "optional arguments:\n"
               << "\t-h,--help\t\t\tShow this help message\n"
               << "\t-P DELIMITER"
               << "\t\tPrint the database hierarchy in a parsable format\n"
-              << "\t-f DB_PATH"
+              << "\t-p DB_PATH"
               << "\t\t\tSpecify location of the flux-accounting database"
               << std::endl;
 }
@@ -44,7 +44,7 @@ int main (int argc, char** argv)
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        if (arg == "-f") {
+        if (arg == "-p") {
             filepath = argv[i + 1];
             i++;
         } else if (arg == "-P") {

--- a/t/expected/help_message.txt
+++ b/t/expected/help_message.txt
@@ -1,5 +1,5 @@
-usage: flux shares [-P DELIMITER] [-f DB_PATH]
+usage: flux shares [-P DELIMITER] [-p DB_PATH]
 optional arguments:
 	-h,--help			Show this help message
 	-P DELIMITER		Print the database hierarchy in a parsable format
-	-f DB_PATH			Specify location of the flux-accounting database
+	-p DB_PATH			Specify location of the flux-accounting database

--- a/t/t1000-print-hierarchy.t
+++ b/t/t1000-print-hierarchy.t
@@ -9,7 +9,7 @@ SMALL_TIE_ALL=${SHARNESS_TEST_SRCDIR}/expected/test_dbs/small_tie_all.db
 OUT_OF_INSERT_ORDER=${SHARNESS_TEST_SRCDIR}/expected/test_dbs/out_of_insert_order.db
 
 test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '
-    ${PRINT_HIERARCHY} -f ${SMALL_NO_TIE} > test_small_no_tie.txt
+    ${PRINT_HIERARCHY} -p ${SMALL_NO_TIE} > test_small_no_tie.txt
 '
 
 test_expect_success 'compare hierarchy outputs - small_no_tie.db' '
@@ -17,7 +17,7 @@ test_expect_success 'compare hierarchy outputs - small_no_tie.db' '
 '
 
 test_expect_success 'create hierarchy output from C++ - small_tie.db' '
-    ${PRINT_HIERARCHY} -f ${SMALL_TIE} > test_small_tie.txt
+    ${PRINT_HIERARCHY} -p ${SMALL_TIE} > test_small_tie.txt
 '
 
 test_expect_success 'compare hierarchy outputs - small_tie.db' '
@@ -25,7 +25,7 @@ test_expect_success 'compare hierarchy outputs - small_tie.db' '
 '
 
 test_expect_success 'create hierarchy output from C++ - small_tie_all.db' '
-    ${PRINT_HIERARCHY} -f ${SMALL_TIE_ALL} > test_small_tie_all.txt
+    ${PRINT_HIERARCHY} -p ${SMALL_TIE_ALL} > test_small_tie_all.txt
 '
 
 test_expect_success 'compare hierarchy outputs - small_tie_all.db' '
@@ -33,7 +33,7 @@ test_expect_success 'compare hierarchy outputs - small_tie_all.db' '
 '
 
 test_expect_success 'create parsable hierarchy output from C++ - small_no_tie.db' '
-    ${PRINT_HIERARCHY} -P "|" -f ${SMALL_NO_TIE} > test_small_no_tie_parsable.txt
+    ${PRINT_HIERARCHY} -P "|" -p ${SMALL_NO_TIE} > test_small_no_tie_parsable.txt
 '
 
 test_expect_success 'compare parsable hierarchy outputs - small_no_tie.db' '
@@ -41,7 +41,7 @@ test_expect_success 'compare parsable hierarchy outputs - small_no_tie.db' '
 '
 
 test_expect_success 'create parsable hierarchy output from C++ - small_tie.db' '
-    ${PRINT_HIERARCHY} -P "|" -f ${SMALL_TIE} > test_small_tie_parsable.txt
+    ${PRINT_HIERARCHY} -P "|" -p ${SMALL_TIE} > test_small_tie_parsable.txt
 '
 
 test_expect_success 'compare parsable hierarchy outputs - small_tie.db' '
@@ -49,7 +49,7 @@ test_expect_success 'compare parsable hierarchy outputs - small_tie.db' '
 '
 
 test_expect_success 'create parsable hierarchy output from C++ - small_tie_all.db' '
-    ${PRINT_HIERARCHY} -P "|" -f ${SMALL_TIE_ALL} > test_small_tie_all_parsable.txt
+    ${PRINT_HIERARCHY} -P "|" -p ${SMALL_TIE_ALL} > test_small_tie_all_parsable.txt
 '
 
 test_expect_success 'compare parsable hierarchy outputs - small_tie_all.db' '
@@ -57,7 +57,7 @@ test_expect_success 'compare parsable hierarchy outputs - small_tie_all.db' '
 '
 
 test_expect_success 'create custom parsable hierarchy output from C++ - small_tie.db' '
-    ${PRINT_HIERARCHY} -P , -f ${SMALL_TIE} > test_custom_small_tie_parsable.txt
+    ${PRINT_HIERARCHY} -P , -p ${SMALL_TIE} > test_custom_small_tie_parsable.txt
 '
 
 test_expect_success 'compare custom parsable hierarchy outputs - small_tie_all.db' '
@@ -81,7 +81,7 @@ test_expect_success 'compare help message for flux-shares when a bad argument is
 '
 
 test_expect_success 'create hierarchy output from C++ - out_of_insert_order.db' '
-    ${PRINT_HIERARCHY} -f ${OUT_OF_INSERT_ORDER} > test_out_of_insert_order.txt
+    ${PRINT_HIERARCHY} -p ${OUT_OF_INSERT_ORDER} > test_out_of_insert_order.txt
 '
 
 test_expect_success 'compare hierarchy outputs - out_of_insert_order.db' '

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -19,7 +19,7 @@ test_expect_success 'create t_small_no_tie.db' '
 '
 
 test_expect_success 'create hierarchy output from t_small_no_tie.db' '
-	${PRINT_HIERARCHY} -f $(pwd)/t_small_no_tie.db
+	${PRINT_HIERARCHY} -p $(pwd)/t_small_no_tie.db
 '
 
 test_expect_success 'run update fshare script - small_no_tie.db' '
@@ -27,7 +27,7 @@ test_expect_success 'run update fshare script - small_no_tie.db' '
 '
 
 test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '
-	${PRINT_HIERARCHY} -f $(pwd)/t_small_no_tie.db > pre_fshare_update.test
+	${PRINT_HIERARCHY} -p $(pwd)/t_small_no_tie.db > pre_fshare_update.test
 '
 
 test_expect_success 'compare hierarchy outputs' '
@@ -43,7 +43,7 @@ test_expect_success 'run update fshare script - small_no_tie.db' '
 '
 
 test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '
-	${PRINT_HIERARCHY} -f $(pwd)/t_small_no_tie.db > post_fshare_update.test
+	${PRINT_HIERARCHY} -p $(pwd)/t_small_no_tie.db > post_fshare_update.test
 '
 
 test_expect_success 'compare hierarchy outputs' '

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -9,7 +9,7 @@ CREATE_TEST_DB=${SHARNESS_TEST_SRCDIR}/scripts/create_test_db.py
 UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 test_expect_success 'trying to run update-fshare with bad DBPATH should return an error' '
-	test_must_fail ${UPDATE_FSHARE} -f foo.db > failure.out 2>&1 &&
+	test_must_fail ${UPDATE_FSHARE} -p foo.db > failure.out 2>&1 &&
 	test_debug "cat failure.out" &&
 	grep "error opening DB: unable to open database file" failure.out
 '
@@ -23,7 +23,7 @@ test_expect_success 'create hierarchy output from t_small_no_tie.db' '
 '
 
 test_expect_success 'run update fshare script - small_no_tie.db' '
-	${UPDATE_FSHARE} -f $(pwd)/t_small_no_tie.db
+	${UPDATE_FSHARE} -p $(pwd)/t_small_no_tie.db
 '
 
 test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '
@@ -39,7 +39,7 @@ test_expect_success 'update usage column in t_small_no_tie.db' '
 '
 
 test_expect_success 'run update fshare script - small_no_tie.db' '
-	${UPDATE_FSHARE} -f $(pwd)/t_small_no_tie.db
+	${UPDATE_FSHARE} -p $(pwd)/t_small_no_tie.db
 '
 
 test_expect_success 'create hierarchy output from C++ - small_no_tie.db' '


### PR DESCRIPTION
#### Problem

Noted in #169, the optional path argument for several of the flux-accounting commands are inconsistent and should be unified.

---

This small PR changes the optional path arguments for the differing flux-accounting commands to be consistent across all the commands, `-p`.

I also snuck in a commit that removes a dangling comment in this PR as well, I hope that is okay. 

---

Fixes #169