### PR TITLE
database: add queue_table, subcommands for interacting with queue_table

### DIFF
--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -44,7 +44,7 @@ symbols=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines, duplicate-code, too-many-instance-attributes, too-many-locals, too-many-branches
+disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines, duplicate-code, too-many-instance-attributes, too-many-locals, too-many-branches, unused-argument, unused-variable
 
 
 [REPORTS]

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -3,6 +3,7 @@ acctpy_PYTHON = \
 	user_subcommands.py \
 	bank_subcommands.py \
 	qos_subcommands.py \
+	queue_subcommands.py \
 	job_archive_interface.py \
 	create_db.py
 
@@ -16,7 +17,8 @@ TESTSCRIPTS = \
 	test/test_example.py \
 	test/test_job_archive_interface.py \
 	test/test_user_subcommands.py \
-	test/test_qos_subcommands.py
+	test/test_qos_subcommands.py \
+	test/test_queue_subcommands.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS)

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -171,4 +171,18 @@ def create_db(
         );"""
     )
 
+    # Queue Table
+    # stores queue limit information
+    logging.info("Creating queue_table in DB...")
+    conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS queue_table (
+                queue               tinytext                NOT NULL,
+                min_nodes_per_job   int(11),
+                max_nodes_per_job   int(11),
+                max_time_per_job    int(11),
+                PRIMARY KEY (queue)
+            );"""
+    )
+
     conn.close()

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+
+
+def view_queue(conn, queue):
+    cur = conn.cursor()
+    try:
+        # get the information pertaining to a queue in the DB
+        cur.execute("SELECT * FROM queue_table where queue=?", (queue,))
+        row = cur.fetchone()
+        if row is None:
+            print("queue not found in queue_table")
+        else:
+            col_headers = [description[0] for description in cur.description]
+            for key, val in zip(col_headers, row):
+                print(key + ": " + str(val))
+    except sqlite3.OperationalError as e_database_error:
+        print(e_database_error)
+
+
+def add_queue(conn, queue, min_nodes="", max_nodes="", max_time=""):
+    try:
+        insert_stmt = """
+                      INSERT INTO queue_table (
+                        queue,
+                        min_nodes_per_job,
+                        max_nodes_per_job,
+                        max_time_per_job
+                      ) VALUES (?, ?, ?, ?)
+                      """
+        conn.execute(
+            insert_stmt,
+            (
+                queue,
+                min_nodes,
+                max_nodes,
+                max_time,
+            ),
+        )
+
+        conn.commit()
+    # make sure entry is unique
+    except sqlite3.IntegrityError as integrity_error:
+        print(integrity_error)
+
+
+def delete_queue(conn, queue):
+    delete_stmt = "DELETE FROM queue_table WHERE queue=?"
+    cursor = conn.cursor()
+    cursor.execute(delete_stmt, (queue,))
+
+    conn.commit()
+
+
+def edit_queue(
+    conn, queue, min_nodes_per_job=None, max_nodes_per_job=None, max_time_per_job=None
+):
+    params = locals()
+    editable_fields = ["min_nodes_per_job", "max_nodes_per_job", "max_time_per_job"]
+
+    for field in editable_fields:
+        if params[field] is not None:
+            # check that the passed in value is truly an integer
+            try:
+                updated_value = int(params[field])
+            except ValueError:
+                print("passed in value must be an integer")
+
+            # passing a value of -1 will clear any previously set limit
+            if int(params[field]) == -1:
+                update_stmt = "UPDATE queue_table SET " + field + "='' WHERE queue=?"
+                conn.execute(
+                    update_stmt,
+                    (queue,),
+                )
+            else:
+                update_stmt = "UPDATE queue_table SET " + field + "=? WHERE queue=?"
+                conn.execute(
+                    update_stmt,
+                    (
+                        params[field],
+                        queue,
+                    ),
+                )
+
+            # commit changes
+            conn.commit()
+
+    return 0

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -54,6 +54,7 @@ class TestDB(unittest.TestCase):
             "job_usage_factor_table",
             "t_half_life_period_table",
             "qos_table",
+            "queue_table",
         ]
         self.assertEqual(list_of_tables, expected)
 

--- a/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import queue_subcommands as q
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        c.create_db("TestQueueSubcommands.db")
+        global acct_conn
+        global cur
+
+        acct_conn = sqlite3.connect("TestQueueSubcommands.db")
+        cur = acct_conn.cursor()
+
+    # add a valid queue to queue_table
+    def test_01_add_valid_queue(self):
+        q.add_queue(acct_conn, queue="queue_1")
+        cur.execute("SELECT * FROM queue_table WHERE queue='queue_1'")
+        rows = cur.fetchall()
+
+        self.assertEqual(len(rows), 1)
+
+    # let's make sure if we try to add it a second time,
+    # it fails gracefully
+    def test_02_add_dup_queue(self):
+        q.add_queue(acct_conn, queue="queue_1")
+        self.assertRaises(sqlite3.IntegrityError)
+
+    # edit a value for a queue in the queue_table
+    def test_03_edit_queue_successfully(self):
+        q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job=100)
+        cur.execute("SELECT max_nodes_per_job FROM queue_table WHERE queue='queue_1'")
+
+        self.assertEqual(cur.fetchone()[0], 100)
+
+    # edit multiple fields for a given queue
+    def test_04_edit_multiple_fields(self):
+        q.edit_queue(
+            acct_conn, queue="queue_1", min_nodes_per_job=1, max_nodes_per_job=128
+        )
+        cur.execute(
+            "SELECT min_nodes_per_job, max_nodes_per_job FROM queue_table WHERE queue='queue_1'"
+        )
+        results = cur.fetchall()
+
+        self.assertEqual(results[0][0], 1)
+        self.assertEqual(results[0][1], 128)
+
+    # edit a value with a bad type for a queue in the queue_table
+    def test_05_edit_queue_bad_type(self):
+        with self.assertRaises(ValueError):
+            q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job="foo")
+
+    # reset a value for a queue in the queue_table
+    def test_06_reset_queue_limit(self):
+        q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job=-1)
+        cur.execute("SELECT max_nodes_per_job FROM queue_table where queue='queue_1'")
+
+        self.assertEqual(cur.fetchone()[0], "")
+
+    # remove a queue currently in the queue_table
+    def test_07_delete_queue(self):
+        q.delete_queue(acct_conn, queue="queue_1")
+        cur.execute("SELECT * FROM queue_table WHERE queue='queue_1'")
+        rows = cur.fetchall()
+
+        self.assertEqual(len(rows), 0)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        acct_conn.close()
+        os.remove("TestQueueSubcommands.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -18,6 +18,7 @@ from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import qos_subcommands as q
 from fluxacct.accounting import job_archive_interface as jobs
 from fluxacct.accounting import create_db as c
+from fluxacct.accounting import queue_subcommands as qu
 
 
 def add_path_arg(parser):
@@ -283,6 +284,76 @@ def add_delete_qos_arg(subparsers):
     subparser_delete_qos.add_argument("--qos", help="QOS name", metavar="QOS")
 
 
+def add_add_queue_arg(subparsers):
+    subparser_add_queue = subparsers.add_parser("add-queue", help="add a new queue")
+
+    subparser_add_queue.set_defaults(func="add_queue")
+    subparser_add_queue.add_argument("queue", help="queue name", metavar="QUEUE")
+    subparser_add_queue.add_argument(
+        "--min-nodes-per-job",
+        help="min nodes per job",
+        default="",
+        metavar="MIN NODES PER JOB",
+    )
+    subparser_add_queue.add_argument(
+        "--max-nodes-per-job",
+        help="max nodes per job",
+        default="",
+        metavar="MAX NODES PER JOB",
+    )
+    subparser_add_queue.add_argument(
+        "--max-time-per-job",
+        help="max time per job",
+        default="",
+        metavar="MAX TIME PER JOB",
+    )
+
+
+def add_view_queue_arg(subparsers):
+    subparser_view_queue = subparsers.add_parser(
+        "view-queue", help="view queue information"
+    )
+
+    subparser_view_queue.set_defaults(func="view_queue")
+    subparser_view_queue.add_argument("queue", help="queue name", metavar="QUEUE")
+
+
+def add_edit_queue_arg(subparsers):
+    subparser_edit_queue = subparsers.add_parser(
+        "edit-queue", help="edit a queue's priority"
+    )
+
+    subparser_edit_queue.set_defaults(func="edit_queue")
+    subparser_edit_queue.add_argument("queue", help="queue name", metavar="QUEUE")
+    subparser_edit_queue.add_argument(
+        "--min-nodes-per-job",
+        help="min nodes per job",
+        default=None,
+        metavar="MIN NODES PER JOB",
+    )
+    subparser_edit_queue.add_argument(
+        "--max-nodes-per-job",
+        help="max nodes per job",
+        default=None,
+        metavar="MAX NODES PER JOB",
+    )
+    subparser_edit_queue.add_argument(
+        "--max-time-per-job",
+        help="max time per job",
+        default=None,
+        metavar="MAX TIME PER JOB",
+    )
+
+
+def add_delete_queue_arg(subparsers):
+    subparser_delete_queue = subparsers.add_parser(
+        "delete-queue", help="remove a queue"
+    )
+
+    subparser_delete_queue.set_defaults(func="delete_queue")
+    subparser_delete_queue.add_argument("queue", help="queue name", metavar="QUEUE")
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -301,6 +372,10 @@ def add_arguments_to_parser(parser, subparsers):
     add_view_qos_arg(subparsers)
     add_edit_qos_arg(subparsers)
     add_delete_qos_arg(subparsers)
+    add_add_queue_arg(subparsers)
+    add_view_queue_arg(subparsers)
+    add_edit_queue_arg(subparsers)
+    add_delete_queue_arg(subparsers)
 
 
 def set_db_location(args):
@@ -380,6 +455,26 @@ def select_accounting_function(args, conn, output_file, parser):
         q.edit_qos(conn, args.qos, args.priority)
     elif args.func == "delete_qos":
         q.delete_qos(conn, args.qos)
+    elif args.func == "add_queue":
+        qu.add_queue(
+            conn,
+            args.queue,
+            args.min_nodes_per_job,
+            args.max_nodes_per_job,
+            args.max_time_per_job,
+        )
+    elif args.func == "view_queue":
+        qu.view_queue(conn, args.queue)
+    elif args.func == "delete_queue":
+        qu.delete_queue(conn, args.queue)
+    elif args.func == "edit_queue":
+        qu.edit_queue(
+            conn,
+            args.queue,
+            args.min_nodes_per_job,
+            args.max_nodes_per_job,
+            args.max_time_per_job,
+        )
     else:
         print(parser.print_usage())
 

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -123,6 +123,37 @@ test_expect_success 'make sure the user is successfully removed from the DB' '
 	grep "User not found in association_table" deleted_user.out
 '
 
+test_expect_success 'add a queue with no optional args to the queue_table' '
+	flux account -p ${DB_PATH} add-queue queue_1
+'
+
+test_expect_success 'add a queue with some optional args' '
+	flux account -p ${DB_PATH} add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120
+'
+
+test_expect_success 'edit some queue information' '
+	flux account -p ${DB_PATH} edit-queue --max-nodes-per-job 100 queue_1
+'
+
+test_expect_success 'edit multiple columns for one queue' '
+	flux account -p ${DB_PATH} edit-queue queue_1 --min-nodes-per-job 1 --max-nodes-per-job 128
+'
+
+test_expect_success 'reset a queue limit' '
+	flux account -p ${DB_PATH} edit-queue queue_1 --max-nodes-per-job -1 &&
+	flux account -p ${DB_PATH} view-queue queue_1 > reset_limit.test &&
+	grep "max_nodes_per_job: " reset_limit.test
+'
+
+test_expect_success 'remove a queue from the queue_table' '
+	flux account -p ${DB_PATH} delete-queue queue_2
+'
+
+test_expect_success 'make sure the queue is successfully removed from the DB' '
+	flux account -p ${DB_PATH} view-queue queue_2 > deleted_queue.out &&
+	grep "queue not found in queue_table" deleted_queue.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -3,66 +3,77 @@
 test_description='Test flux-account commands'
 . `dirname $0`/sharness.sh
 FLUX_ACCOUNT=${SHARNESS_TEST_SRCDIR}/../src/cmd/flux-account.py
+FLUX_EXEC_PATH=${SHARNESS_TEST_SRCDIR}/../src/cmd:${FLUX_EXEC_PATH}
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+# test_expect_success 'create flux-accounting DB' '
+# 	flux python ${FLUX_ACCOUNT} -p $(pwd)/FluxAccountingTest.db create-db
+# '
+
 test_expect_success 'create flux-accounting DB' '
-	flux python ${FLUX_ACCOUNT} -p $(pwd)/FluxAccountingTest.db create-db
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '
 
 test_expect_success 'add some banks to the DB' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank root 1 &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank --parent-bank=root A 1 &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank --parent-bank=root B 1 &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-bank --parent-bank=root C 1
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root A 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root B 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root C 1
 '
 
 test_expect_success 'add some users to the DB' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5011 --userid=5011 --bank=A &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=A &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5013 --userid=5013 --bank=B &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5014 --userid=5014 --bank=C
+	flux account -p ${DB_PATH} add-user --username=user5011 --userid=5011 --bank=A &&
+	flux account -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=A &&
+	flux account -p ${DB_PATH} add-user --username=user5013 --userid=5013 --bank=B &&
+	flux account -p ${DB_PATH} add-user --username=user5014 --userid=5014 --bank=C
 '
 
 test_expect_success 'add some QOS to the DB' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-qos --qos=standby --priority=0 &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-qos --qos=expedite --priority=10000
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-qos --qos=special --priority=99999
+	flux account -p ${DB_PATH} add-qos --qos=standby --priority=0 &&
+	flux account -p ${DB_PATH} add-qos --qos=expedite --priority=10000
+	flux account -p ${DB_PATH} add-qos --qos=special --priority=99999
 '
 
 test_expect_success 'add a QOS to an existing user account' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="expedite"
+	flux account -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="expedite"
 '
 
 test_expect_success 'trying to add a non-existent QOS to a user account should return an error' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="foo" > bad_qos.out &&
+	flux account -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="foo" > bad_qos.out &&
 	grep "QOS specified does not exist in qos_table" bad_qos.out
 '
 
 test_expect_success 'trying to add a user with a non-existent QOS should also return an error' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} add-user --username=user5015 --userid=5015 --bank=A --qos="foo" > bad_qos2.out &&
+	flux account -p ${DB_PATH} add-user --username=user5015 --userid=5015 --bank=A --qos="foo" > bad_qos2.out &&
 	grep "QOS specified does not exist in qos_table" bad_qos2.out
 '
 
 test_expect_success 'add multiple QOS to an existing user account' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-user --username=user5012 --field=qos --new-value="expedite,standby" &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5012 > user5012.out &&
+	flux account -p ${DB_PATH} edit-user --username=user5012 --field=qos --new-value="expedite,standby" &&
+	flux account -p ${DB_PATH} view-user user5012 > user5012.out &&
 	grep "expedite,standby" user5012.out
 '
 
 test_expect_success 'edit a QOS priority' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-qos --qos=expedite --priority=20000 &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-qos --qos=expedite > edited_qos.out &&
+	flux account -p ${DB_PATH} edit-qos --qos=expedite --priority=20000 &&
+	flux account -p ${DB_PATH} view-qos --qos=expedite > edited_qos.out &&
 	grep "20000" edited_qos.out
 '
 
 test_expect_success 'remove a QOS' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} delete-qos --qos=special &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-qos --qos=special > deleted_qos.out &&
+	flux account -p ${DB_PATH} delete-qos --qos=special &&
+	flux account -p ${DB_PATH} view-qos --qos=special > deleted_qos.out &&
 	grep "QOS not found in qos_table" deleted_qos.out
 '
 
 test_expect_success 'trying to view a bank that does not exist in the DB should return an error message' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank foo > bad_bank.out &&
+	flux account -p ${DB_PATH} view-bank foo > bad_bank.out &&
 	grep "Bank not found in bank_table" bad_bank.out
 '
 
@@ -73,53 +84,53 @@ test_expect_success 'trying to view a bank that does exist in the DB should retu
 	parent_bank: root
 	shares: 1
 	EOF
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank A > good_bank.test &&
+	flux account -p ${DB_PATH} view-bank A > good_bank.test &&
 	test_cmp good_bank.expected good_bank.test
 '
 
 test_expect_success 'trying to view a user who does not exist in the DB should return an error message' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user9999 > bad_user.out &&
+	flux account -p ${DB_PATH} view-user user9999 > bad_user.out &&
 	grep "User not found in association_table" bad_user.out
 '
 
 test_expect_success 'trying to view a user that does exist in the DB should return some information' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5011 > good_user.test &&
+	flux account -p ${DB_PATH} view-user user5011 > good_user.test &&
 	grep "creation_time" good_user.test
 '
 
 test_expect_success 'edit a field in a user account' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-user --username=user5011 --field=shares --new-value=50
+	flux account -p ${DB_PATH} edit-user --username=user5011 --field=shares --new-value=50
 '
 
 test_expect_success 'edit a field in a bank account' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} edit-bank C --shares=50 &&
+	flux account -p ${DB_PATH} edit-bank C --shares=50 &&
 	cat <<-EOF >edited_bank.expected &&
 	bank_id: 4
 	bank: C
 	parent_bank: root
 	shares: 50
 	EOF
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank C > edited_bank.test &&
+	flux account -p ${DB_PATH} view-bank C > edited_bank.test &&
 	test_cmp edited_bank.expected edited_bank.test
 '
 
 test_expect_success 'remove a bank (and any corresponding users that belong to that bank)' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} delete-bank C
+	flux account -p ${DB_PATH} delete-bank C
 '
 
 test_expect_success 'make sure both the DB and the user are successfully removed from DB' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-bank C > deleted_bank.out &&
+	flux account -p ${DB_PATH} view-bank C > deleted_bank.out &&
 	grep "Bank not found in bank_table" deleted_bank.out &&
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5014 > deleted_user.out &&
+	flux account -p ${DB_PATH} view-user user5014 > deleted_user.out &&
 	grep "User not found in association_table" deleted_user.out
 '
 
 test_expect_success 'remove a user account' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} delete-user user5012 A
+	flux account -p ${DB_PATH} delete-user user5012 A
 '
 
 test_expect_success 'make sure the user is successfully removed from the DB' '
-	flux python ${FLUX_ACCOUNT} -p ${DB_PATH} view-user user5012 > deleted_user.out &&
+	flux account -p ${DB_PATH} view-user user5012 > deleted_user.out &&
 	grep "User not found in association_table" deleted_user.out
 '
 


### PR DESCRIPTION
#### Problem

As discussed in #164, there is a need for being able to define and configure queue information within the flux-accounting database.

---

#### Solution

This is a [WIP] PR that I just wanted to post before the Thanksgiving break that adds such support within the DB. It adds a new table, `queue_table`, which holds just 4 columns - the name of the queue and a couple of required limits associated with each queue:

```
queue               tinytext        NOT NULL,
min_nodes_per_job   int(11),
max_nodes_per_job   int(11),
max_time_per_job    int(11),
PRIMARY KEY (queue)
```

_Note that the only column that is required when adding a new queue is the name; if not specified, all of the limit columns could just be empty, with no default values._

Support for interacting with this table from the command line with a number of subcommands added to `flux account`: `add-queue`, `view-queue`, `delete-queue`, and `edit_queue`. These functions allow a DB admin to add, edit, remove, and view queue information to the flux-accounting DB.

#### Usage

```console
[moussa1@docker-desktop src]$ flux account add-queue -h
positional arguments:
  QUEUE                 queue name

optional arguments:
  -h, --help            show this help message and exit
  --min-nodes-per-job MIN NODES PER JOB    min nodes per job
  --max-nodes-per-job MAX NODES PER JOB    max nodes per job
  --max-time-per-job  MAX TIME PER JOB     max time per job
```

```console
[moussa1@docker-desktop src]$ flux account view-queue -h
positional arguments:
  QUEUE       queue name

optional arguments:
  -h, --help  show this help message and exit
```

```console
[moussa1@docker-desktop src]$ flux account edit-queue -h
optional arguments:
  -h, --help         show this help message and exit
  --queue queue      queue name
  --field FIELD      column name
  --new-value VALUE  new value
```

```console
[moussa1@docker-desktop src]$ flux account delete-queue -h
positional arguments:
  QUEUE       queue name

optional arguments:
  -h, --help  show this help message and exit
```
Both unit tests and sharness tests were added with the new subcommands and module.

Fixes #164