### PR TITLE
plugin: change max jobs limit enforcement

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -199,9 +199,12 @@ static int priority_cb (flux_plugin_t *p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
 
-    if (b == NULL)
+    if (b == NULL) {
         flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB, "plugin",
                                      3, "mf_priority: bank info is missing");
+
+        return -1;
+    }
 
     b->current_jobs++;
 
@@ -353,9 +356,12 @@ static int inactive_cb (flux_plugin_t *p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
 
-    if (b == NULL)
+    if (b == NULL) {
         flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB, "plugin",
                                      3, "mf_priority: bank info is missing");
+
+        return -1;
+    }
 
     b->current_jobs--;
 

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:bionic-v0.28.0
+FROM fluxrm/flux-core:bionic
 
 ARG USER=flux
 ARG UID=1000

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:centos8-v0.28.0
+FROM fluxrm/flux-core:centos8
 
 ARG USER=flux
 ARG UID=1000


### PR DESCRIPTION
#### Problem

A little while ago it was brought up that the current enforcement of a max jobs limit used on our machines counts running jobs towards a user/bank row's max_jobs limit. Currently, the multi-factor priority plugin increments for all active jobs, not just running jobs.

---

This PR changes the way the plugin increments the `current_jobs` count for a user/bank row in the flux-accounting DB by incrementing the count when a job enters `job.state.priority` instead of `job.validate`. 

It also adds a new callback, `depend_cb ()`, which will tap into a job when it reaches `job.state.depend`. A check is performed in this callback to see if the user/bank already has `max_jobs` running; if it does, it adds a dependency on the recently submitted job and its job ID is pushed to the back of a list of held jobs for that user/bank. Once a currently running job for that user/bank reaches `job.state.inactive` (thus decrementing the user/bank's `current_jobs` count), a check is performed on the list of held jobs to see if there are any; if so, the dependency is removed from the first held job in the list and it can transition to the RUN state.

Since there is somewhat significant new behavior in the priority plugin, some changes were required to also be made in `t1005-max-jobs-limits.t`. The sharness tests now test that jobs submitted when a user/bank already has `max_jobs` running correctly stay in the DEPEND state until one job transitions to `job.state.inactive`, where it is then checked to be in the RUN state. 
