### PR TITLE
`edit-user`: change positional and optional arguments to match `edit-qos` subcommand

### DIFF
--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -44,7 +44,7 @@ symbols=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines, duplicate-code, too-many-instance-attributes, too-many-locals, too-many-branches, unused-argument, unused-variable
+disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines, duplicate-code, too-many-instance-attributes, too-many-locals, too-many-branches, unused-argument, unused-variable, line-too-long
 
 
 [REPORTS]

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -94,11 +94,11 @@ def create_db(
                 userid        int(11)     DEFAULT 65534 NOT NULL,
                 bank          tinytext                  NOT NULL,
                 default_bank  tinytext                  NOT NULL,
-                shares        int(11)     DEFAULT 1     NOT NULL,
+                shares        int(11)     DEFAULT 1     NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
                 job_usage     real        DEFAULT 0.0   NOT NULL,
                 fairshare     real        DEFAULT 0.5   NOT NULL,
-                max_jobs      int(11)     DEFAULT 5     NOT NULL,
-                qos           tinytext    DEFAULT ''    NOT NULL,
+                max_jobs      int(11)     DEFAULT 5     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
+                qos           tinytext    DEFAULT ''    NOT NULL    ON CONFLICT REPLACE DEFAULT '',
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/bindings/python/fluxacct/accounting/test/test_qos_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_qos_subcommands.py
@@ -67,7 +67,7 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to edit a user with a bad QoS should also raise a ValueError
     def test_06_edit_user_with_bad_qos(self):
         u.add_user(acct_conn, username="u5011", uid="5011", bank="acct")
-        u.edit_user(acct_conn, username="u5011", field="qos", new_value="foo")
+        u.edit_user(acct_conn, username="u5011", qos="foo")
 
         self.assertRaises(ValueError)
 
@@ -81,8 +81,7 @@ class TestAccountingCLI(unittest.TestCase):
         u.edit_user(
             acct_conn,
             username="u5011",
-            field="qos",
-            new_value="standby,expedite,special",
+            qos="standby,expedite,special",
         )
         cur.execute("SELECT qos FROM association_table WHERE username='u5011'")
 

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -110,25 +110,25 @@ class TestAccountingCLI(unittest.TestCase):
             acct_conn,
             username="fluxuser",
             bank="acct",
-            field="shares",
-            new_value="10000",
+            shares=10000,
         )
         cursor = acct_conn.cursor()
         cursor.execute("SELECT shares FROM association_table where username='fluxuser'")
 
         self.assertEqual(cursor.fetchone()[0], 10000)
 
-    # trying to edit a field in a column that doesn't
-    # exist should return a ValueError
-    def test_05_edit_bad_field(self):
-        with self.assertRaises(ValueError):
-            u.edit_user(
-                acct_conn,
-                username="fluxuser",
-                bank="acct",
-                field="foo",
-                new_value="bar",
-            )
+    # edit a value for a user in the association table
+    def test_05_edit_reset_user_value(self):
+        u.edit_user(
+            acct_conn,
+            username="fluxuser",
+            bank="acct",
+            shares="-1",
+        )
+        cursor = acct_conn.cursor()
+        cursor.execute("SELECT shares FROM association_table where username='fluxuser'")
+
+        self.assertEqual(cursor.fetchone()[0], 1)
 
     # delete a user from the association table
     def test_06_delete_user(self):
@@ -184,8 +184,7 @@ class TestAccountingCLI(unittest.TestCase):
         u.edit_user(
             acct_conn,
             username="test_user1",
-            field="default_bank",
-            new_value="other_test_bank",
+            default_bank="other_test_bank",
         )
         cursor = acct_conn.cursor()
         cursor.execute(

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -66,12 +66,6 @@ def add_add_user_arg(subparsers):
         metavar="BANK",
     )
     subparser_add_user.add_argument(
-        "--parent-acct",
-        help="parent account",
-        default="",
-        metavar="PARENT_ACCOUNT",
-    )
-    subparser_add_user.add_argument(
         "--shares",
         help="shares",
         default=1,

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -106,25 +106,39 @@ def add_edit_user_arg(subparsers):
     subparser_edit_user = subparsers.add_parser("edit-user", help="edit a user's value")
     subparser_edit_user.set_defaults(func="edit_user")
     subparser_edit_user.add_argument(
-        "--username",
+        "username",
         help="username",
         metavar="USERNAME",
     )
     subparser_edit_user.add_argument(
         "--bank",
-        help="bank",
-        default="",
+        help="bank to charge jobs against",
+        default=None,
         metavar="BANK",
     )
     subparser_edit_user.add_argument(
-        "--field",
-        help="column name",
-        metavar="FIELD",
+        "--default-bank",
+        help="default bank",
+        default=None,
+        metavar="DEFAULT_BANK",
     )
     subparser_edit_user.add_argument(
-        "--new-value",
-        help="new value",
-        metavar="VALUE",
+        "--shares",
+        help="shares",
+        default=None,
+        metavar="SHARES",
+    )
+    subparser_edit_user.add_argument(
+        "--max-jobs",
+        help="max jobs",
+        default=None,
+        metavar="MAX_JOBS",
+    )
+    subparser_edit_user.add_argument(
+        "--qos",
+        help="quality of service",
+        default=None,
+        metavar="QUALITY OF SERVICE",
     )
 
 
@@ -419,7 +433,15 @@ def select_accounting_function(args, conn, output_file, parser):
     elif args.func == "delete_user":
         u.delete_user(conn, args.username, args.bank)
     elif args.func == "edit_user":
-        u.edit_user(conn, args.username, args.field, args.new_value, args.bank)
+        u.edit_user(
+            conn,
+            args.username,
+            args.bank,
+            args.default_bank,
+            args.shares,
+            args.max_jobs,
+            args.qos,
+        )
     elif args.func == "view_job_records":
         jobs.view_job_records(
             conn,

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -50,11 +50,11 @@ test_expect_success 'view some user information' '
 '
 
 test_expect_success 'add a QOS to an existing user account' '
-	flux account -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="expedite"
+	flux account -p ${DB_PATH} edit-user user5011 --qos="expedite"
 '
 
 test_expect_success 'trying to add a non-existent QOS to a user account should return an error' '
-	flux account -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="foo" > bad_qos.out &&
+	flux account -p ${DB_PATH} edit-user user5011 --qos="foo" > bad_qos.out &&
 	grep "QOS specified does not exist in qos_table" bad_qos.out
 '
 
@@ -64,7 +64,7 @@ test_expect_success 'trying to add a user with a non-existent QOS should also re
 '
 
 test_expect_success 'add multiple QOS to an existing user account' '
-	flux account -p ${DB_PATH} edit-user --username=user5012 --field=qos --new-value="expedite,standby" &&
+	flux account -p ${DB_PATH} edit-user user5012 --qos="expedite,standby" &&
 	flux account -p ${DB_PATH} view-user user5012 > user5012.out &&
 	grep "expedite,standby" user5012.out
 '
@@ -112,7 +112,7 @@ test_expect_success 'trying to view a user that does exist in the DB should retu
 '
 
 test_expect_success 'edit a field in a user account' '
-	flux account -p ${DB_PATH} edit-user --username=user5011 --field=shares --new-value=50
+	flux account -p ${DB_PATH} edit-user user5011 --shares 50
 '
 
 test_expect_success 'edit a field in a bank account' '


### PR DESCRIPTION
#### Problem

While working on #176, a suggestion was made to keep the same arguments as the `add` subcommand instead of using the `--field` and `--new-value` optional args. The same improvement should probably also made to the `edit-user` subcommand. This will allow for multiple fields to be edited at the same time, allow for resets on optional fields, and will improve the overall usability of the command. 

---

This PR changes the `edit-user` subcommand to take the same positional and optional arguments as the `add-user` subcommand. This includes the following improvement to the command:

##### old usage

```console
$ flux account edit-user --username=user1234 --field="max_jobs" --new-value=1234
```

##### new usage

```console
$ flux account edit-user user1234 --max-jobs 100
```

It also allows for multiple values of a user/bank row to be edited at the same time:

```console
$ flux account edit-user user1234 --max-jobs 100 --qos "standby,expedite"
```

This new behavior should now match the behavior in the `edit-qos`, `edit-bank`, and `edit-queue` subcommands.

I also snuck in a tiny cleanup commit that removes the `--parent-acct` optional argument from the `add-user` subcommand. This is an obsolete argument that was left over from some previous cleanup; I hope that is okay. 

Fixes #178