### PR TITLE
`view-user`: add capability to view multiple rows

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -16,16 +16,36 @@ import pwd
 
 def view_user(conn, user):
     cur = conn.cursor()
+    headers = [
+        "creation_time",
+        "mod_time",
+        "deleted",
+        "username",
+        "userid",
+        "admin_level",
+        "bank",
+        "default_bank",
+        "shares",
+        "job_usage",
+        "fairshare",
+        "max_jobs",
+        "qos",
+    ]
     try:
         # get the information pertaining to a user in the DB
         cur.execute("SELECT * FROM association_table where username=?", (user,))
-        row = cur.fetchone()
-        if row is None:
+        rows = cur.fetchall()
+        if not rows:
             print("User not found in association_table")
         else:
-            col_headers = [description[0] for description in cur.description]
-            for key, val in zip(col_headers, row):
-                print(key + ": " + str(val))
+            # print column names of association_table
+            for header in headers:
+                print(header.ljust(15), end=" ")
+            print()
+            for row in rows:
+                for col in list(row):
+                    print(str(col).ljust(15), end=" ")
+                print()
     except sqlite3.OperationalError as e_database_error:
         print(e_database_error)
 

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -40,6 +40,15 @@ test_expect_success 'add some QOS to the DB' '
 	flux account -p ${DB_PATH} add-qos --qos=special --priority=99999
 '
 
+test_expect_success 'view some user information' '
+	flux account -p ${DB_PATH} view-user user5011 > user_info.out &&
+	grep -c "user5011" user_info.out > num_rows.test &&
+	cat <<-EOF >num_rows.expected &&
+	1
+	EOF
+	test_cmp num_rows.expected num_rows.test
+'
+
 test_expect_success 'add a QOS to an existing user account' '
 	flux account -p ${DB_PATH} edit-user --username=user5011 --field=qos --new-value="expedite"
 '


### PR DESCRIPTION
#### Problem

As mentioned in #185, the `view-user` subcommand only prints the first result of a SQLite query fetching user information from the `association_table` even if the user belongs to multiple banks (and thus has multiple rows in the table).

---

This PR uses `cursor.fetchall()` to fetch all possible rows and iterate through them to print out all rows instead of just one. It also makes use of `.ljust()` to print out rows in a table-like format, similar to the output format of `pandas`, a data formatting module I removed from the project a while ago.

```console
$ flux account view-user fluxuser
creation_time   mod_time        deleted         username        userid          admin_level     bank            default_bank    shares          job_usage       fairshare       max_jobs        qos             
1639680148      1639680148      0               fluxuser        1002            1               acct            acct            10              0.0             0.5             5                               
1639680148      1639680148      0               fluxuser        1002            1               other_acct      acct            10              0.0             0.5             5
```

Fixes #185