### PR TITLE
view-bank: improve command, add more sharness tests

### DIFF
--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -1,0 +1,8 @@
+bank_id         bank            parent_bank     shares          
+2               A               root            1               
+
+Users Under Bank A:
+
+username        userid          default_bank    shares          job_usage       fairshare       max_jobs        qos             
+user5011        5011            A               1               0.0             0.5             5               expedite        
+user5012        5012            A               1               0.0             0.5             5               expedite,standby 

--- a/t/expected/flux_account/D_bank.expected
+++ b/t/expected/flux_account/D_bank.expected
@@ -1,0 +1,6 @@
+bank_id         bank            parent_bank     shares          
+5               D               root            1               
+
+D
+ E
+ F

--- a/t/expected/flux_account/full_hierarchy.expected
+++ b/t/expected/flux_account/full_hierarchy.expected
@@ -1,0 +1,14 @@
+bank_id         bank            parent_bank     shares          
+1               root                            1               
+
+root
+ A
+  user5011
+  user5012
+ B
+  user5013
+ C
+  user5014
+ D
+  E
+  F

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -12,10 +12,6 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
-# test_expect_success 'create flux-accounting DB' '
-# 	flux python ${FLUX_ACCOUNT} -p $(pwd)/FluxAccountingTest.db create-db
-# '
-
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '


### PR DESCRIPTION
#### Problem

Mentioned in #184, the `view-bank` command does not list children banks or users for a given bank. Moreover, the output when running this command can be sort of clunky and not pleasing. This PR looks to improve the command and add some more tests that make use of this command.

---

This is a small [WIP] PR looking to improve the command by changing the format of the output when viewing a bank within the flux-accounting database. Specifically, it looks to improve the output in the following ways:

- improve the output when viewing bank information to be formatted like a table, similar to the format of the `pandas` module before it was removed from flux-accounting:

```console
$ flux account view-bank A
bank_id         bank            parent_bank     shares          
2               A               root            1   
```

- viewing a bank that contains sub banks will also print a hierarchy with the passed-in bank acting as the root of the tree, i.e viewing a the root bank will print out the entire user/bank hierarchy, or viewing a bank with sub banks will print out a smaller user/bank hierarchy. A couple of examples are shown below:

```console
$ flux account view-bank root
root
 A
  user5011
  user5012
 B
  user5013
 C
  user5014
 D
  E
  F
```

```console
$ flux account view-bank D
D
 E
 F
```

- viewing a bank with users under that bank will also print all subsequent user information from the `association_table`. For example, a leaf bank `A` with users under this bank will show the following output:

```console
$ flux account view-bank A
bank_id         bank            parent_bank     shares          
2               A               root            1               

Users Under Bank A:

username        userid          default_bank    shares          job_usage       fairshare       max_jobs        qos             
user5011        5011            A               1               0.0             0.5             5               expedite        
user5012        5012            A               1               0.0             0.5             5               expedite,standby 
```

Note that some columns from the `association_table` are omitted under this output, as I deemed them not totally relevant to any information concerning banks - the columns presented here are more or less the most crucial from the table. 

#### Testing

New tests are added in **t1007-flux-account.t** to test the new output features of the `view-bank` command. All expected output is added into a new folder inside of the `t/expected/` directory called `flux_account`, which for now just hosts all `view-bank` output. Eventually, I think it would be nice to move all large output from the tests within **t1007-flux-account.t** to this directory, but that's probably best for a future PR.

---

Fixes #184