### PR TITLE
user_subcommands.py: fix miscellaneous bugs

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -16,25 +16,11 @@ import pwd
 
 def view_user(conn, user):
     cur = conn.cursor()
-    headers = [
-        "creation_time",
-        "mod_time",
-        "deleted",
-        "username",
-        "userid",
-        "admin_level",
-        "bank",
-        "default_bank",
-        "shares",
-        "job_usage",
-        "fairshare",
-        "max_jobs",
-        "qos",
-    ]
     try:
         # get the information pertaining to a user in the DB
         cur.execute("SELECT * FROM association_table where username=?", (user,))
         rows = cur.fetchall()
+        headers = [description[0] for description in cur.description]
         if not rows:
             print("User not found in association_table")
         else:

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -201,7 +201,21 @@ def edit_user(
 
             conn.execute(update_stmt, tup)
 
-            # commit changes
-            conn.commit()
+    # update mod_time column
+    mod_time_tup = (
+        int(time.time()),
+        username,
+    )
+    if bank is not None:
+        update_stmt = """UPDATE association_table SET mod_time=?
+                         WHERE username=? AND bank=?"""
+        mod_time_tup = mod_time_tup + (bank,)
+    else:
+        update_stmt = "UPDATE association_table SET mod_time=? WHERE username=?"
+
+    conn.execute(update_stmt, mod_time_tup)
+
+    # commit changes
+    conn.commit()
 
     return 0

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -14,6 +14,24 @@ import time
 import pwd
 
 
+def get_uid(username):
+    try:
+        return pwd.getpwnam(username).pw_uid
+    except KeyError:
+        return str(username)
+
+
+def validate_qos(conn, qos):
+    cur = conn.cursor()
+    qos_list = qos.split(",")
+
+    for service in qos_list:
+        cur.execute("SELECT qos FROM qos_table WHERE qos=?", (service,))
+        row = cur.fetchone()
+        if row is None:
+            raise ValueError("QOS specified does not exist in qos_table")
+
+
 def view_user(conn, user):
     cur = conn.cursor()
     try:
@@ -34,24 +52,6 @@ def view_user(conn, user):
                 print()
     except sqlite3.OperationalError as e_database_error:
         print(e_database_error)
-
-
-def get_uid(username):
-    try:
-        return pwd.getpwnam(username).pw_uid
-    except KeyError:
-        return str(username)
-
-
-def validate_qos(conn, qos):
-    cur = conn.cursor()
-    qos_list = qos.split(",")
-
-    for service in qos_list:
-        cur.execute("SELECT qos FROM qos_table WHERE qos=?", (service,))
-        row = cur.fetchone()
-        if row is None:
-            raise ValueError("QOS specified does not exist in qos_table")
 
 
 def add_user(

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -99,18 +99,9 @@ def add_user(
         # insert the user values into association_table
         conn.execute(
             """
-            INSERT INTO association_table (
-                creation_time,
-                mod_time,
-                deleted,
-                username,
-                userid,
-                bank,
-                default_bank,
-                shares,
-                max_jobs,
-                qos
-            )
+            INSERT INTO association_table (creation_time, mod_time, deleted,
+                                           username, userid, bank, default_bank,
+                                           shares, max_jobs, qos)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
@@ -131,11 +122,7 @@ def add_user(
         # insert the user values into job_usage_factor_table
         conn.execute(
             """
-            INSERT INTO job_usage_factor_table (
-                username,
-                userid,
-                bank
-            )
+            INSERT INTO job_usage_factor_table (username, userid, bank)
             VALUES (?, ?, ?)
             """,
             (

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -122,7 +122,7 @@ def add_user(
         # insert the user values into job_usage_factor_table
         conn.execute(
             """
-            INSERT INTO job_usage_factor_table (username, userid, bank)
+            INSERT OR IGNORE INTO job_usage_factor_table (username, userid, bank)
             VALUES (?, ?, ?)
             """,
             (

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -267,7 +267,7 @@ def add_view_qos_arg(subparsers):
     subparser_view_qos = subparsers.add_parser("view-qos", help="view QOS information")
 
     subparser_view_qos.set_defaults(func="view_qos")
-    subparser_view_qos.add_argument("--qos", help="QOS name", metavar="QOS")
+    subparser_view_qos.add_argument("qos", help="QOS name", metavar="QOS")
 
 
 def add_edit_qos_arg(subparsers):
@@ -282,8 +282,9 @@ def add_edit_qos_arg(subparsers):
 
 def add_delete_qos_arg(subparsers):
     subparser_delete_qos = subparsers.add_parser("delete-qos", help="remove a QOS")
+
     subparser_delete_qos.set_defaults(func="delete_qos")
-    subparser_delete_qos.add_argument("--qos", help="QOS name", metavar="QOS")
+    subparser_delete_qos.add_argument("qos", help="QOS name", metavar="QOS")
 
 
 def add_add_queue_arg(subparsers):

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -71,13 +71,13 @@ test_expect_success 'add multiple QOS to an existing user account' '
 
 test_expect_success 'edit a QOS priority' '
 	flux account -p ${DB_PATH} edit-qos --qos=expedite --priority=20000 &&
-	flux account -p ${DB_PATH} view-qos --qos=expedite > edited_qos.out &&
+	flux account -p ${DB_PATH} view-qos expedite > edited_qos.out &&
 	grep "20000" edited_qos.out
 '
 
 test_expect_success 'remove a QOS' '
-	flux account -p ${DB_PATH} delete-qos --qos=special &&
-	flux account -p ${DB_PATH} view-qos --qos=special > deleted_qos.out &&
+	flux account -p ${DB_PATH} delete-qos special &&
+	flux account -p ${DB_PATH} view-qos special > deleted_qos.out &&
 	grep "QOS not found in qos_table" deleted_qos.out
 '
 


### PR DESCRIPTION
#### Problem

While working on some of the improvements discussed to PR #177, I noticed a couple small miscellaneous bugs in the `view-user` and `add-user` subcommands while running them in my Docker container. The bugs are listed as follows:

- Mentioned in #191, the `admin_level` column still remains in the output of the `view-user` command. This results in incorrect output and should be removed. 
- Mentioned in #192, a user/bank row is added to the `association_table` with a user/bank combination (e.g. `user1234`, `bankA`), the row is removed, and then re-added, a `UNIQUE` constraint fails in the `job_usage_factor_table`.

---

This PR fixes both issues in these subcommands and adds small improvements to try and help mitigate similar bugs in the future. 

In the `view-user` command, I've changed the way headers for the table output are fetched. Previously, I had handwritten each header in the table, which would quickly become inconsistent if I made a change to the `association_table` in the database. The `view-user` subcommand now uses `cursor.description` to fetch the headers directly from the table itself. This should ensure consistency in the output even if and when the table schema changes in the future.

In the `add-user` command, I've added an `OR IGNORE` clause to the `INSERT` SQL statement for the `job_usage_factor_table`. This ensures that previously deleted user/bank rows do not encounter a `UNIQUE constraint` failure when being re-added to the `association_table`.

In the `view-qos` and `delete-qos` commands, I've converted the `qos` argument into positional arguments for both of the commands.

Fixes #191
Fixes #192 