### PR TITLE
cmd: add bulk DB populate command

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -64,16 +64,17 @@ def add_user(
     qos="",
 ):
 
-    # get uid of user
-    fetched_uid = get_uid(username)
+    if uid == 65534:
+        # get uid of user
+        fetched_uid = get_uid(username)
 
-    try:
-        if isinstance(fetched_uid, int):
-            uid = fetched_uid
-        else:
-            raise KeyError
-    except KeyError as key_error:
-        print(key_error)
+        try:
+            if isinstance(fetched_uid, int):
+                uid = fetched_uid
+            else:
+                raise KeyError
+        except KeyError:
+            print("could not find UID for user; adding default UID")
 
     # check for a default bank of the user being added; if the user is new, set
     # the first bank they were added to as their default bank

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -46,4 +46,5 @@ dist_fluxcmd_SCRIPTS = \
 	flux-account.py \
 	flux-account-update-fshare \
 	flux-account-priority-update.py \
-	flux-account-shares
+	flux-account-shares \
+	flux-account-pop-db.py

--- a/src/cmd/flux-account-pop-db.py
+++ b/src/cmd/flux-account-pop-db.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import argparse
+import csv
+import os
+import sqlite3
+import sys
+
+from argparse import RawDescriptionHelpFormatter
+
+import fluxacct.accounting
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+
+
+def set_db_loc(args):
+    path = args.path if args.path else fluxacct.accounting.db_path
+
+    return path
+
+
+def est_sqlite_conn(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        sys.exit(1)
+
+    return conn
+
+
+def populate_db(path, users=None, banks=None):
+    conn = est_sqlite_conn(path)
+    cur = conn.cursor()
+
+    if banks is not None:
+        try:
+            with open(banks) as csv_file:
+                csv_reader = csv.reader(csv_file, delimiter=",")
+
+                for row in csv_reader:
+                    b.add_bank(
+                        conn,
+                        bank=row[0],
+                        parent_bank=row[1],
+                        shares=row[2],
+                    )
+        except IOError as err:
+            print(err)
+
+    if users is not None:
+        try:
+            with open(users) as csv_file:
+                csv_reader = csv.reader(csv_file, delimiter=",")
+
+                # assign default values to fields if
+                # their slot is empty in the csv file
+                for row in csv_reader:
+                    username = row[0]
+                    uid = row[1]
+                    bank = row[2]
+                    shares = row[3] if row[3] != "" else 1
+                    max_jobs = row[4] if row[4] != "" else 5
+                    qos = row[5]
+
+                    u.add_user(
+                        conn,
+                        username,
+                        bank,
+                        uid,
+                        shares,
+                        max_jobs,
+                        qos,
+                    )
+        except IOError as err:
+            print(err)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Populate a flux-accounting database with a .csv file.
+
+        Order of elements required for populating association_table:
+
+        Username,UserID,Bank,Shares,MaxJobs,QOS
+
+        [Shares] and [MaxJobs] can be left blank ('') in .csv file for a given row.
+
+        ----------------
+
+        Order of elements required for populating bank_table:
+
+        Bank,ParentBank,Shares
+
+        [ParentBank] can be left blank ('') in .csv file for a given row.
+        """,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-p", "--path", dest="path", help="specify location of database file"
+    )
+    parser.add_argument(
+        "-u", "--users", help="path to a .csv file containing user information"
+    )
+    parser.add_argument(
+        "-b", "--banks", help="path to a .csv file containing bank information"
+    )
+
+    args = parser.parse_args()
+
+    path = set_db_loc(args)
+
+    populate_db(path, args.users, args.banks)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -9,7 +9,8 @@ TESTSCRIPTS = \
 	t1005-max-jobs-limits.t \
 	t1006-update-fshare.t \
 	t1007-flux-account.t \
-	t1008-mf-priority-update.t
+	t1008-mf-priority-update.t \
+	t1009-pop-db.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/expected/pop_db/db_hierarchy_base.expected
+++ b/t/expected/pop_db/db_hierarchy_base.expected
@@ -1,0 +1,11 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1                   0
+ A                                                         1                   0
+  A                             user1000                   1                   0                 0.5
+  A                             user1001                   1                   0                 0.5
+  A                             user1002                   1                   0                 0.5
+  A                             user1003                   1                   0                 0.5
+  A                             user1004                   1                   0                 0.5
+ B                                                         1                   0
+ C                                                         1                   0
+  D                                                        1                   0

--- a/t/expected/pop_db/db_hierarchy_new_users.expected
+++ b/t/expected/pop_db/db_hierarchy_new_users.expected
@@ -1,0 +1,16 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1                   0
+ A                                                         1                   0
+  A                             user1000                   1                   0                 0.5
+  A                             user1001                   1                   0                 0.5
+  A                             user1002                   1                   0                 0.5
+  A                             user1003                   1                   0                 0.5
+  A                             user1004                   1                   0                 0.5
+ B                                                         1                   0
+  B                             user1005                   1                   0                 0.5
+  B                             user1006                   1                   0                 0.5
+  B                             user1007                   1                   0                 0.5
+  B                             user1008                   1                   0                 0.5
+  B                             user1009                   1                   0                 0.5
+ C                                                         1                   0
+  D                                                        1                   0

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+test_description='Test flux-account commands'
+. `dirname $0`/sharness.sh
+
+DB_PATH=$(pwd)/FluxAccountingTest.db
+EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/pop_db
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'create a banks.csv file containing bank information' '
+	cat <<-EOF >banks.csv
+	root,,1
+	A,root,1
+	B,root,1
+	C,root,1
+	D,C,1
+	EOF
+'
+
+test_expect_success 'populate flux-accounting DB with banks.csv' '
+	flux account-pop-db -p ${DB_PATH} -b banks.csv
+'
+
+test_expect_success 'create a users.csv file containing user information' '
+	cat <<-EOF >users.csv
+	user1000,1000,A,1,10,""
+	user1001,1001,A,1,10,""
+	user1002,1002,A,1,10,""
+	user1003,1003,A,1,10,""
+	user1004,1004,A,1,10,""
+	EOF
+'
+
+test_expect_success 'populate flux-accounting DB with users.csv' '
+	flux account-pop-db -p ${DB_PATH} -u users.csv
+'
+
+test_expect_success 'check database hierarchy to make sure all banks & users were added' '
+	flux account-shares -p ${DB_PATH} > db_hierarchy_base.test &&
+	test_cmp ${EXPECTED_FILES}/db_hierarchy_base.expected db_hierarchy_base.test
+'
+
+test_expect_success 'create a users.csv file with some missing optional user information' '
+	cat <<-EOF >users_optional_vals.csv
+	user1005,1005,B,1,5,""
+	user1006,1006,B,,,""
+	user1007,1007,B,1,7,""
+	user1008,1008,B,,,""
+	user1009,1009,B,1,9,""
+	EOF
+'
+
+test_expect_success 'populate flux-accounting DB with users_optional_vals.csv' '
+	flux account-pop-db -p ${DB_PATH} -u users_optional_vals.csv
+'
+
+test_expect_success 'check database hierarchy to make sure new users were added' '
+	flux account-shares -p ${DB_PATH} > db_hierarchy_new_users.test &&
+	test_cmp ${EXPECTED_FILES}/db_hierarchy_new_users.expected db_hierarchy_new_users.test
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Populating the DB with many users and banks can be tedious, as currently there are really only two options:

- using the `add-bank` and `add-user` commands one at a time to add users and banks
- going into an interactive SQLite shell and using `INSERT` commands, one a time, to add both users and banks to the database

This can be cumbersome and slow, especially when the time comes to install flux-accounting on a system and we need to migrate a large set of users.

---

This PR adds a new command to flux-accounting, `flux account-pop-db`, which allows an admin to bulk populate a flux-accounting DB's `bank_table` and `association_table` using `.csv` files. The path to the file can be passed via the command line, and this command will iterate through the file and call `add_user ()` or `add_bank ()`, depending on which file is used. You can also pass both options to populate both the `bank_table` and the `association_table` at the same time, like the following:

```console
$ flux account-pop-db -b bank_info.csv -u user_info.csv
```

The structure of the bank `.csv` file must be in the following format: `Bank,ParentBank,Shares`. The **ParentBank** slot can be left blank if needed. An example is below:

```
root,,1
A,root,1
B,root,1
```

The structure of the user `.csv` file must be in the following format: `Username,UserID,Bank,Shares,MaxJobs,QOS`. The **Shares** and **MaxJobs** slots can be left blank; if so, they will be filled in with the default values of their respective columns in the `association_table`. An example is below:

```
user1005,1005,B,1,5,""
user1006,1006,B,,,""
user1007,1007,B,1,7,""
user1008,1008,B,,,""
user1009,1009,B,1,9,""
```

Fixes #139 