### PR TITLE
NEWS: add release notes for `v0.13.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+flux-accounting version 0.13.0 - 2022-01-31
+-------------------------------------------
+
+#### Fixes
+
+* Improve sharness tests to use `flux account` commands directly in tests (#180)
+
+* Change positional and optional arguments in `edit-user` command to align with other `edit-*` commands (#181)
+
+* Fix bug in `view-user` preventing the ability to view more than one row if a user belonged to more than one bank (#187)
+
+* Remove outdated `admin_level` column from association_table in flux-accounting database (#188)
+
+* Fix incorrect listing of association_table headers in the `view-user` command (#193)
+
+* Fix `UNIQUE constraint` failure when re-adding a previously deleted user to the same bank in the flux-accounting database (#193)
+
+* Convert the `qos` argument into positional arguments for both the `view-qos` and `edit-qos` commands (#193)
+
+#### Features
+
+* Add new enforcement policy in multi-factor priority plugin to only count running jobs towards an "active" jobs counter (#177)
+
+* Add section to top-level README on flux-accounting database permissions (#188)
+
+* Add new optional arguments to `view-bank` command to view sub bank hierarchy trees or users belonging to a specific bank (#194)
+
+* Add bulk database populate tool to upload multiple user or bank rows at one time via `.csv` file (#195)
+
 flux-accounting version 0.12.0 - 2021-12-03
 -------------------------------------------
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -39,7 +39,13 @@ EXTRA_DIST= \
 	expected/test_dbs/small_no_tie.db \
 	expected/test_dbs/small_tie_all.db \
 	expected/test_dbs/small_tie_zero_shares.db \
-	expected/test_dbs/small_tie.db
+	expected/test_dbs/small_tie.db \
+	expected/flux_account/A_bank.expected \
+	expected/flux_account/D_bank.expected \
+	expected/flux_account/full_hierarchy.expected \
+	expected/flux_account/root_bank.expected \
+	expected/pop_db/db_hierarchy_base.expected \
+	expected/pop_db/db_hierarchy_new_users.expected
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.13.0`. ~~I'll keep this [WIP] until I've made a decision if any other fixes/new features should be merged before the end of the month.~~ 

Once this gets merged, I'll create an annotated tag using the following instruction:

```
git tag -a v0.13.0 -m "Tag v0.13.0" && git push upstream v0.13.0
```