### PR TITLE
ci: rename centos8 builder to "el"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ queue_rules:
       - status-success="python format"
       - status-success="python lint"
       - status-success="bionic - py3.6"
-      - status-success="centos8 - py3.6"
+      - status-success="el8 - py3.6"
       - status-success="coverage"
       - label="merge-when-passing"
       - label!="work-in-progress"

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -6,7 +6,7 @@ Docker is used under CI to speed up deployment of an environment with correct bu
 
 ### Local Testing
 
-Developers can test the docker images themselves. If new dependencies are needed, they can update the `$image` Dockerfiles manually (where `$image` is one of `bionic` or `centos8`). To run inside a local Docker image, run the command:
+Developers can test the docker images themselves. If new dependencies are needed, they can update the `$image` Dockerfiles manually (where `$image` is one of `bionic` or `el8`). To run inside a local Docker image, run the command:
 
 ```console
 docker-run-checks.sh -i $image [options] -- [arguments]

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -10,7 +10,7 @@
 PROJECT=flux-accounting
 BASE_DOCKER_REPO=fluxrm/flux-core
 
-IMAGE=centos8
+IMAGE=el8
 JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:centos8
+FROM fluxrm/flux-core:el8
 
 ARG USER=flux
 ARG UID=1000

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -141,10 +141,10 @@ matrix.add_build(
     jobs=2,
 )
 
-# Centos8
+# el8
 matrix.add_build(
-    name="centos8 - py3.6",
-    image="centos8",
+    name="el8 - py3.6",
+    image="el8",
     docker_tag=True,
 )
 


### PR DESCRIPTION
#### Problem

The upstream flux-core `centos8` images has been renamed to `el8` to reflect the fact that CentOS is EOL.

---

This PR updates the `centos8` image name used in CI accordingly.