### PR TITLE
plugin: add max_active_jobs per-user/bank limit

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -98,6 +98,7 @@ def create_db(
                 job_usage        real        DEFAULT 0.0   NOT NULL,
                 fairshare        real        DEFAULT 0.5   NOT NULL,
                 max_running_jobs int(11)     DEFAULT 5     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
+                max_active_jobs  int(11)     DEFAULT 7     NOT NULL    ON CONFLICT REPLACE DEFAULT 7,
                 qos              tinytext    DEFAULT ''    NOT NULL    ON CONFLICT REPLACE DEFAULT '',
                 PRIMARY KEY   (username, bank)
         );"""

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -61,6 +61,7 @@ def add_user(
     uid=65534,
     shares=1,
     max_running_jobs=5,
+    max_active_jobs=7,
     qos="",
 ):
 
@@ -102,8 +103,9 @@ def add_user(
             """
             INSERT INTO association_table (creation_time, mod_time, deleted,
                                            username, userid, bank, default_bank,
-                                           shares, max_running_jobs, qos)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                           shares, max_running_jobs,
+                                           max_active_jobs, qos)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -115,6 +117,7 @@ def add_user(
                 default_bank,
                 shares,
                 max_running_jobs,
+                max_active_jobs,
                 qos,
             ),
         )
@@ -163,6 +166,7 @@ def edit_user(
     default_bank=None,
     shares=None,
     max_running_jobs=None,
+    max_active_jobs=None,
     qos=None,
 ):
     params = locals()
@@ -172,6 +176,7 @@ def edit_user(
         "default_bank",
         "shares",
         "max_running_jobs",
+        "max_active_jobs",
         "qos",
     ]
     for field in editable_fields:

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -54,7 +54,7 @@ def bulk_update(path):
     # fetch all rows from association_table (will print out tuples)
     for row in cur.execute(
         """SELECT userid, bank, default_bank,
-           fairshare, max_running_jobs FROM association_table"""
+           fairshare, max_running_jobs, max_active_jobs FROM association_table"""
     ):
         # create a JSON payload with the results of the query
         single_user_data = {
@@ -63,6 +63,7 @@ def bulk_update(path):
             "def_bank": str(row[2]),
             "fairshare": float(row[3]),
             "max_running_jobs": int(row[4]),
+            "max_active_jobs": int(row[5]),
         }
         bulk_user_data.append(single_user_data)
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -78,6 +78,12 @@ def add_add_user_arg(subparsers):
         metavar="MAX_RUNNING_JOBS",
     )
     subparser_add_user.add_argument(
+        "--max-active-jobs",
+        help="max number of both pending and running jobs",
+        default=7,
+        metavar="max_active_jobs",
+    )
+    subparser_add_user.add_argument(
         "--qos",
         help="quality of service",
         default="",
@@ -127,6 +133,12 @@ def add_edit_user_arg(subparsers):
         help="max number of jobs that can be running at the same time",
         default=None,
         metavar="MAX_RUNNING_JOBS",
+    )
+    subparser_edit_user.add_argument(
+        "--max-active-jobs",
+        help="max number of both pending and running jobs",
+        default=7,
+        metavar="max_active_jobs",
     )
     subparser_edit_user.add_argument(
         "--qos",
@@ -439,6 +451,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.userid,
             args.shares,
             args.max_running_jobs,
+            args.max_active_jobs,
             args.qos,
         )
     elif args.func == "delete_user":
@@ -451,6 +464,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.default_bank,
             args.shares,
             args.max_running_jobs,
+            args.max_active_jobs,
             args.qos,
         )
     elif args.func == "view_job_records":

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -35,6 +35,8 @@ struct bank_info {
     double fairshare;
     int max_run_jobs;
     int cur_run_jobs;
+    int max_active_jobs;
+    int cur_active_jobs;
     std::vector<long int> held_jobs;
 };
 
@@ -105,7 +107,7 @@ static void rec_update_cb (flux_t *h,
                            void *arg)
 {
     char *bank, *def_bank = NULL;
-    int uid, max_running_jobs = 0;
+    int uid, max_running_jobs, max_active_jobs = 0;
     double fshare = 0.0;
     json_t *data, *jtemp = NULL;
     json_error_t error;
@@ -128,12 +130,13 @@ static void rec_update_cb (flux_t *h,
     for (int i = 0; i < num_data; i++) {
         json_t *el = json_array_get(data, i);
 
-        if (json_unpack_ex (el, &error, 0, "{s:i, s:s, s:s, s:F, s:i}",
+        if (json_unpack_ex (el, &error, 0, "{s:i, s:s, s:s, s:F, s:i, s:i}",
                             "userid", &uid,
                             "bank", &bank,
                             "def_bank", &def_bank,
                             "fairshare", &fshare,
-                            "max_running_jobs", &max_running_jobs) < 0)
+                            "max_running_jobs", &max_running_jobs,
+                            "max_active_jobs", &max_active_jobs) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
         struct bank_info *b;
@@ -141,6 +144,7 @@ static void rec_update_cb (flux_t *h,
 
         b->fairshare = fshare;
         b->max_run_jobs = max_running_jobs;
+        b->max_active_jobs = max_active_jobs;
 
         users_def_bank[uid] = def_bank;
     }
@@ -225,7 +229,7 @@ static int validate_cb (flux_plugin_t *p,
 {
     int userid;
     char *bank = NULL;
-    int max_run_jobs = 0;
+    int max_run_jobs, cur_active_jobs, max_active_jobs = 0;
     double fairshare = 0.0;
 
     std::map<int, std::map<std::string, struct bank_info>>::iterator it;
@@ -264,11 +268,18 @@ static int validate_cb (flux_plugin_t *p,
 
     max_run_jobs = bank_it->second.max_run_jobs;
     fairshare = bank_it->second.fairshare;
+    cur_active_jobs = bank_it->second.cur_active_jobs;
+    max_active_jobs = bank_it->second.max_active_jobs;
 
     // if a user's fairshare value is 0, that means they shouldn't be able
     // to run jobs on a system
     if (fairshare == 0)
         return flux_jobtap_reject_job (p, args, "user fairshare value is 0");
+
+    // if a user/bank has reached their max_active_jobs limit, subsequently
+    // submitted jobs will be rejected
+    if (max_active_jobs > 0 && cur_active_jobs >= max_active_jobs)
+        return flux_jobtap_reject_job (p, args, "user has max active jobs");
 
     // special case where the user/bank bank_info struct is set to NULL; used
     // for testing the "if (b == NULL)" checks
@@ -290,6 +301,8 @@ static int validate_cb (flux_plugin_t *p,
                                  &bank_it->second,
                                  NULL) < 0)
         flux_log_error (h, "flux_jobtap_job_aux_set");
+
+    bank_it->second.cur_active_jobs++;
 
     return 0;
 }
@@ -380,6 +393,7 @@ static int inactive_cb (flux_plugin_t *p,
     }
 
     b->cur_run_jobs--;
+    b->cur_active_jobs--;
 
     // if the user/bank combo has any currently held jobs and the user is now
     // under their max jobs limit, remove the dependency from first held job

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -50,8 +50,8 @@ test_expect_success 'create fake_payload.py' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 10},
-			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 10}
+			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 10, "max_active_jobs": 12},
+			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 10, "max_active_jobs": 12}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
@@ -141,7 +141,7 @@ test_expect_success 'create a fake payload with a 0 fairshare key-value pair' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account4", "def_bank": "account3", "fairshare": 0.0, "max_running_jobs": 10}
+			{"userid": userid, "bank": "account4", "def_bank": "account3", "fairshare": 0.0, "max_running_jobs": 10, "max_active_jobs": 12}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
@@ -162,7 +162,7 @@ test_expect_success 'pass special key to user/bank struct to nullify information
 	cat <<-EOF >null_struct.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": -1}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": -1, "max_active_jobs": 12}
 		]
 	}
 	EOF
@@ -182,7 +182,7 @@ test_expect_success 'resend user/bank information with valid data and successful
 	cat <<-EOF >valid_info.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2, "max_active_jobs": 4}
 		]
 	}
 	EOF

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -25,13 +25,13 @@ test_expect_success 'create a group of users with unique fairshare values' '
 	cat <<-EOF >fake_small_no_tie.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5}
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5, "max_active_jobs": 7}
 		]
 	}
 	EOF

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -25,14 +25,14 @@ test_expect_success 'create a group of users with some ties in fairshare values'
 	cat <<-EOF >fake_small_tie.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5},
-			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5}
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5, "max_active_jobs": 7}
 		]
 	}
 	EOF

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -25,15 +25,15 @@ test_expect_success 'create a group of users with many ties in fairshare values'
 	cat <<-EOF >fake_small_tie_all.json
 	{
 	    "data" : [
-	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5},
-	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5},
-	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5},
-	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5},
-	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5},
-	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5},
-	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5},
-	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5},
-	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5}
+	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
+	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7}
 	    ]
 	}
 	EOF

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -25,8 +25,8 @@ test_expect_success 'create fake_user.json' '
 	cat <<-EOF >fake_user.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2},
-			{"userid": 5011, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2, "max_active_jobs": 4},
+			{"userid": 5011, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 2}
 		]
 	}
 	EOF
@@ -79,7 +79,7 @@ test_expect_success 'increase the max jobs count of the user' '
 	cat <<-EOF >new_max_running_jobs_limit.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 3}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 3, "max_active_jobs": 4}
 		]
 	}
 	EOF

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -99,4 +99,108 @@ test_expect_success 'cancel all remaining jobs' '
 	flux job cancel ${jobid2}
 '
 
+test_expect_success 'submit max number of jobs' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid4=$(flux python ${SUBMIT_AS} 5011 sleep 60)
+'
+
+test_expect_success '5th submitted job should be rejected because user has reached max_active_jobs limit' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_active_jobs.out 2>&1 &&
+	test_debug "cat max_active_jobs.out" &&
+	grep "user has max active jobs" max_active_jobs.out &&
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3 &&
+	flux job cancel $jobid4
+'
+
+test_expect_success 'update max_active_jobs limit' '
+	cat <<-EOF >new_max_active_jobs_limit.json
+	{
+		"data" : [
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 3, "max_active_jobs": 5}
+		]
+	}
+	EOF
+'
+
+test_expect_success 'update plugin with same new sample test data' '
+	flux python ${SEND_PAYLOAD} new_max_active_jobs_limit.json
+'
+
+test_expect_success 'submit max number of jobs' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid4=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	jobid5=$(flux python ${SUBMIT_AS} 5011 sleep 60)
+'
+
+test_expect_success '6th submitted job should be rejected because user has reached new max_active_jobs limit' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_active_jobs.out 2>&1 &&
+	test_debug "cat max_active_jobs.out" &&
+	grep "user has max active jobs" max_active_jobs.out
+'
+
+test_expect_success 'cancel one of the active jobs' '
+	flux job cancel $jobid5
+'
+
+test_expect_success 'newly submitted job should now be accepted since user is under their max_active_jobs limit' '
+	jobid7=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
+	flux job wait-event -f json $jobid7 priority | jq '.context.priority' > job7.test &&
+	cat <<-EOF >job7.expected &&
+	45321
+	EOF
+	test_cmp job7.expected job7.test
+'
+
+test_expect_success 'cancel all remaining active jobs' '
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3 &&
+	flux job cancel $jobid4 &&
+	flux job cancel $jobid7
+'
+
+test_expect_success 'create another user with the same limits in multiple banks' '
+	cat <<-EOF >fake_user2.json
+	{
+		"data" : [
+			{"userid": 5012, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 1, "max_active_jobs": 2},
+			{"userid": 5012, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 2}
+		]
+	}
+	EOF
+'
+
+test_expect_success 'update plugin with new user data' '
+	flux python ${SEND_PAYLOAD} fake_user2.json
+'
+
+test_expect_success 'submit max number of jobs under both banks' '
+	jobid1=$(flux python ${SUBMIT_AS} 5012 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 5012 sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} 5012 --setattr=system.bank=account2 sleep 60) &&
+	jobid4=$(flux python ${SUBMIT_AS} 5012 --setattr=system.bank=account2 sleep 60)
+'
+
+test_expect_success 'submitting a 3rd job under either bank should result in a job rejection' '
+	test_must_fail flux python ${SUBMIT_AS} 5012 sleep 60 > max_active_jobs.out 2>&1 &&
+	test_debug "cat max_active_jobs.out" &&
+	grep "user has max active jobs" max_active_jobs.out &&
+	test_must_fail flux python ${SUBMIT_AS} 5012 --setattr=system.bank=account2 sleep 60 > max_active_jobs2.out 2>&1 &&
+	test_debug "cat max_active_jobs2.out" &&
+	grep "user has max active jobs" max_active_jobs2.out
+'
+
+test_expect_success 'cancel all remaining jobs' '
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3 &&
+	flux job cancel $jobid4
+'
+
 test_done


### PR DESCRIPTION
#### Problem

The changes introduced in #177 left somewhat of a "bad behavior" loophole in the priority plugin when it comes to handling job submissions from a user/bank row. As a quick refresher, #177 introduced a change to the way the plugin kept track of a _running_ jobs for a user/bank row, so it only counts jobs that had entered the RUN state. So, for example, if a user/bank row had a `max_jobs` limit of 2, and they submitted 4 jobs at once, the first two jobs could enter the RUN state, but the other 2 would have dependencies added to them (thus, holding the jobs), until one of the first two jobs entered the INACTIVE state, which would remove the dependency on one of the held jobs and allow it to enter the RUN state.

However, there is currently no way to enforce the amount of _active_ jobs from a user/bank row. So, technically, someone with a `max_jobs` limit of 2 could submit 100 jobs at once, leaving 2 jobs to run at a time while 98 others sit in the queue. This behavior should be prevented and enforced for every user/bank combination.

---

This ~~[WIP]~~ PR introduces a new user/bank row limit to both the `association_table` in the flux-accounting database and to the multi-factor priority plugin, called `max_active_jobs`. This limit represents the maximum number of jobs able to be _pending + running_. This limit can be set at create time for a row and can be modified at any time for a row in the `association_table`.

In the priority plugin, this limit is integrated into every `bank_info` struct for every user/bank. Its limit is enforced when a job enters `job.validate`. If the number of _pending + running_ jobs reaches the `max_active_jobs` limit, subsequently submitted jobs will be rejected with a message saying that the limit has been reached, which I believe lines up with current behavior on our systems.

This counter is incremented as a job exits `job.validate` and is decremented as a job enters `job.state.inactive`.

Additional tests were added to `t1005-max-jobs-limits.t` to test the new limit by submitting a max number of jobs and ensuring an error message is output for jobs submitted while the `max_active_jobs` limit is reached.

Fixes #196