### PR TITLE
database: rename max_jobs --> max_running_jobs

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -23,16 +23,16 @@ def print_user_rows(rows, bank):
         "shares",
         "job_usage",
         "fairshare",
-        "max_jobs",
+        "max_running_jobs",
         "qos",
     ]
     # print column names of association_table
     for header in user_headers:
-        print(header.ljust(15), end=" ")
+        print(header.ljust(18), end=" ")
     print()
     for row in rows:
         for col in list(row):
-            print(str(col).ljust(15), end=" ")
+            print(str(col).ljust(18), end=" ")
         print()
 
 
@@ -136,7 +136,7 @@ def view_bank(conn, bank, tree=False, users=False):
         if users is True:
             select_stmt = """
                         SELECT username,userid,default_bank,shares,job_usage,
-                        fairshare,max_jobs,qos FROM association_table
+                        fairshare,max_running_jobs,qos FROM association_table
                         WHERE bank=?
                         """
             cur.execute(

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -87,18 +87,18 @@ def create_db(
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS association_table (
-                creation_time bigint(20)                NOT NULL,
-                mod_time      bigint(20)  DEFAULT 0     NOT NULL,
-                deleted       tinyint(4)  DEFAULT 0     NOT NULL,
-                username      tinytext                  NOT NULL,
-                userid        int(11)     DEFAULT 65534 NOT NULL,
-                bank          tinytext                  NOT NULL,
-                default_bank  tinytext                  NOT NULL,
-                shares        int(11)     DEFAULT 1     NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
-                job_usage     real        DEFAULT 0.0   NOT NULL,
-                fairshare     real        DEFAULT 0.5   NOT NULL,
-                max_jobs      int(11)     DEFAULT 5     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
-                qos           tinytext    DEFAULT ''    NOT NULL    ON CONFLICT REPLACE DEFAULT '',
+                creation_time    bigint(20)                NOT NULL,
+                mod_time         bigint(20)  DEFAULT 0     NOT NULL,
+                deleted          tinyint(4)  DEFAULT 0     NOT NULL,
+                username         tinytext                  NOT NULL,
+                userid           int(11)     DEFAULT 65534 NOT NULL,
+                bank             tinytext                  NOT NULL,
+                default_bank     tinytext                  NOT NULL,
+                shares           int(11)     DEFAULT 1     NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
+                job_usage        real        DEFAULT 0.0   NOT NULL,
+                fairshare        real        DEFAULT 0.5   NOT NULL,
+                max_running_jobs int(11)     DEFAULT 5     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
+                qos              tinytext    DEFAULT ''    NOT NULL    ON CONFLICT REPLACE DEFAULT '',
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -60,7 +60,7 @@ def add_user(
     bank,
     uid=65534,
     shares=1,
-    max_jobs=5,
+    max_running_jobs=5,
     qos="",
 ):
 
@@ -102,7 +102,7 @@ def add_user(
             """
             INSERT INTO association_table (creation_time, mod_time, deleted,
                                            username, userid, bank, default_bank,
-                                           shares, max_jobs, qos)
+                                           shares, max_running_jobs, qos)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
@@ -114,7 +114,7 @@ def add_user(
                 bank,
                 default_bank,
                 shares,
-                max_jobs,
+                max_running_jobs,
                 qos,
             ),
         )
@@ -162,7 +162,7 @@ def edit_user(
     bank=None,
     default_bank=None,
     shares=None,
-    max_jobs=None,
+    max_running_jobs=None,
     qos=None,
 ):
     params = locals()
@@ -171,7 +171,7 @@ def edit_user(
         "bank",
         "default_bank",
         "shares",
-        "max_jobs",
+        "max_running_jobs",
         "qos",
     ]
     for field in editable_fields:

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -53,7 +53,8 @@ def bulk_update(path):
 
     # fetch all rows from association_table (will print out tuples)
     for row in cur.execute(
-        "SELECT userid, bank, default_bank, fairshare, max_jobs FROM association_table"
+        """SELECT userid, bank, default_bank,
+           fairshare, max_running_jobs FROM association_table"""
     ):
         # create a JSON payload with the results of the query
         single_user_data = {
@@ -61,7 +62,7 @@ def bulk_update(path):
             "bank": str(row[1]),
             "def_bank": str(row[2]),
             "fairshare": float(row[3]),
-            "max_jobs": int(row[4]),
+            "max_running_jobs": int(row[4]),
         }
         bulk_user_data.append(single_user_data)
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -72,10 +72,10 @@ def add_add_user_arg(subparsers):
         metavar="SHARES",
     )
     subparser_add_user.add_argument(
-        "--max-jobs",
-        help="max jobs",
+        "--max-running-jobs",
+        help="max number of jobs that can be running at the same time",
         default=5,
-        metavar="MAX_JOBS",
+        metavar="MAX_RUNNING_JOBS",
     )
     subparser_add_user.add_argument(
         "--qos",
@@ -123,10 +123,10 @@ def add_edit_user_arg(subparsers):
         metavar="SHARES",
     )
     subparser_edit_user.add_argument(
-        "--max-jobs",
-        help="max jobs",
+        "--max-running-jobs",
+        help="max number of jobs that can be running at the same time",
         default=None,
-        metavar="MAX_JOBS",
+        metavar="MAX_RUNNING_JOBS",
     )
     subparser_edit_user.add_argument(
         "--qos",
@@ -438,7 +438,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.bank,
             args.userid,
             args.shares,
-            args.max_jobs,
+            args.max_running_jobs,
             args.qos,
         )
     elif args.func == "delete_user":
@@ -450,7 +450,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.bank,
             args.default_bank,
             args.shares,
-            args.max_jobs,
+            args.max_running_jobs,
             args.qos,
         )
     elif args.func == "view_job_records":

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -105,7 +105,7 @@ static void rec_update_cb (flux_t *h,
                            void *arg)
 {
     char *bank, *def_bank = NULL;
-    int uid, max_jobs = 0;
+    int uid, max_running_jobs = 0;
     double fshare = 0.0;
     json_t *data, *jtemp = NULL;
     json_error_t error;
@@ -133,14 +133,14 @@ static void rec_update_cb (flux_t *h,
                             "bank", &bank,
                             "def_bank", &def_bank,
                             "fairshare", &fshare,
-                            "max_jobs", &max_jobs) < 0)
+                            "max_running_jobs", &max_running_jobs) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
         struct bank_info *b;
         b = &users[uid][bank];
 
         b->fairshare = fshare;
-        b->max_running_jobs = max_jobs;
+        b->max_running_jobs = max_running_jobs;
 
         users_def_bank[uid] = def_bank;
     }

--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -3,6 +3,6 @@ bank_id         bank            parent_bank     shares
 
 Users Under Bank A:
 
-username        userid          default_bank    shares          job_usage       fairshare       max_jobs        qos             
-user5011        5011            A               1               0.0             0.5             5               expedite        
-user5012        5012            A               1               0.0             0.5             5               expedite,standby 
+username           userid             default_bank       shares             job_usage          fairshare          max_running_jobs   qos                
+user5011           5011               A                  1                  0.0                0.5                5                  expedite           
+user5012           5012               A                  1                  0.0                0.5                5                  expedite,standby   

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -50,8 +50,8 @@ test_expect_success 'create fake_payload.py' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": 10},
-			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_jobs": 10}
+			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 10},
+			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 10}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
@@ -141,7 +141,7 @@ test_expect_success 'create a fake payload with a 0 fairshare key-value pair' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account4", "def_bank": "account3", "fairshare": 0.0, "max_jobs": 10}
+			{"userid": userid, "bank": "account4", "def_bank": "account3", "fairshare": 0.0, "max_running_jobs": 10}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
@@ -162,7 +162,7 @@ test_expect_success 'pass special key to user/bank struct to nullify information
 	cat <<-EOF >null_struct.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": -1}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": -1}
 		]
 	}
 	EOF
@@ -182,7 +182,7 @@ test_expect_success 'resend user/bank information with valid data and successful
 	cat <<-EOF >valid_info.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": 2}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2}
 		]
 	}
 	EOF

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -25,13 +25,13 @@ test_expect_success 'create a group of users with unique fairshare values' '
 	cat <<-EOF >fake_small_no_tie.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_jobs": 5},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_jobs": 5},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_jobs": 5},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_jobs": 5},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_jobs": 5},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_jobs": 5},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_jobs": 5}
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5}
 		]
 	}
 	EOF

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -25,14 +25,14 @@ test_expect_success 'create a group of users with some ties in fairshare values'
 	cat <<-EOF >fake_small_tie.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_jobs": 5},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_jobs": 5},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_jobs": 5},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_jobs": 5},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_jobs": 5},
-			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_jobs": 5},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_jobs": 5},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_jobs": 5}
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5},
+			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5}
 		]
 	}
 	EOF

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -25,15 +25,15 @@ test_expect_success 'create a group of users with many ties in fairshare values'
 	cat <<-EOF >fake_small_tie_all.json
 	{
 	    "data" : [
-	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_jobs": 5},
-	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_jobs": 5},
-	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_jobs": 5},
-	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_jobs": 5},
-	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_jobs": 5},
-	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_jobs": 5},
-	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_jobs": 5},
-	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_jobs": 5},
-	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_jobs": 5}
+	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5},
+	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5},
+	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5},
+	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5},
+	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5},
+	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5},
+	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5},
+	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5},
+	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5}
 	    ]
 	}
 	EOF

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -25,8 +25,8 @@ test_expect_success 'create fake_user.json' '
 	cat <<-EOF >fake_user.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": 2},
-			{"userid": 5011, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_jobs": 1}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2},
+			{"userid": 5011, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1}
 		]
 	}
 	EOF
@@ -76,17 +76,17 @@ test_expect_success 'submit a job while already having max number of running job
 '
 
 test_expect_success 'increase the max jobs count of the user' '
-	cat <<-EOF >new_max_jobs_limit.json
+	cat <<-EOF >new_max_running_jobs_limit.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_jobs": 3}
+			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 3}
 		]
 	}
 	EOF
 '
 
 test_expect_success 'update plugin with same new sample test data' '
-	flux python ${SEND_PAYLOAD} new_max_jobs_limit.json
+	flux python ${SEND_PAYLOAD} new_max_running_jobs_limit.json
 '
 
 test_expect_success 'make sure jobs are still running' '


### PR DESCRIPTION
#### Problem

The `max_jobs` column is confusing and doesn't clearly represent what the column is for: limiting the number of _running_ jobs a user/bank combo can have running at any given time. When the `max_active_jobs` limit is added, it would be clearer to rename `max_jobs` to something more distinct.

---

This PR contains work split off from #201 that renames `max_jobs` to `max_running_jobs` throughout the flux-accounting project to more clearly describe the difference between a "running" jobs count and an "active" jobs count for a user/bank combo. It contains renaming changes to:

- the database
- the Python commands
- the multi-factor priority plugin
- the existing sharness tests