### PR TITLE
plugin: add queue priority to priority calculation, plugin

### DIFF
--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -54,7 +54,8 @@ def bulk_update(path):
     # fetch all rows from association_table (will print out tuples)
     for row in cur.execute(
         """SELECT userid, bank, default_bank,
-           fairshare, max_running_jobs, max_active_jobs FROM association_table"""
+           fairshare, max_running_jobs, max_active_jobs,
+           queues FROM association_table"""
     ):
         # create a JSON payload with the results of the query
         single_user_data = {
@@ -64,6 +65,7 @@ def bulk_update(path):
             "fairshare": float(row[3]),
             "max_running_jobs": int(row[4]),
             "max_active_jobs": int(row[5]),
+            "queues": str(row[6]),
         }
         bulk_user_data.append(single_user_data)
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -13,7 +13,8 @@ TESTSCRIPTS = \
 	t1009-pop-db.t \
 	t1010-update-usage.t \
 	t1011-job-archive-interface.t \
-	t1012-mf-priority-load.t
+	t1012-mf-priority-load.t \
+	t1013-mf-priority-queues.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -44,11 +44,39 @@ test_expect_success 'create fake_payload.py' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 10, "max_active_jobs": 12},
-			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 10, "max_active_jobs": 12}
+			{
+				"userid": userid,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 10,
+				"max_active_jobs": 12,
+				"queues": "standby,special"
+			},
+			{
+				"userid": userid,
+				"bank": "account2",
+				"def_bank": "account3",
+				"fairshare": 0.11345,
+				"max_running_jobs": 10,
+				"max_active_jobs": 12,
+				"queues": "standby"
+			}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "default",
+				"priority": 0,
+				"min_nodes_per_job": 0,
+				"max_nodes_per_job": 5,
+				"max_time_per_job": 64000
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
 	EOF
 '
 
@@ -156,7 +184,15 @@ test_expect_success 'pass special key to user/bank struct to nullify information
 	cat <<-EOF >null_struct.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": -1, "max_active_jobs": 12}
+			{
+				"userid": 5011,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": -1,
+				"max_active_jobs": 12,
+				"queues": "standby,special"
+			}
 		]
 	}
 	EOF
@@ -176,7 +212,15 @@ test_expect_success 'resend user/bank information with valid data and successful
 	cat <<-EOF >valid_info.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2, "max_active_jobs": 4}
+			{
+				"userid": 5011,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 2,
+				"max_active_jobs": 4,
+				"queues": "standby,special"
+			}
 		]
 	}
 	EOF

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -25,13 +25,13 @@ test_expect_success 'create a group of users with unique fairshare values' '
 	cat <<-EOF >fake_small_no_tie.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5, "max_active_jobs": 7}
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
 		]
 	}
 	EOF
@@ -39,6 +39,27 @@ test_expect_success 'create a group of users with unique fairshare values' '
 
 test_expect_success 'send the user information to the plugin' '
 	flux python ${SEND_PAYLOAD} fake_small_no_tie.json
+'
+
+test_expect_success 'add a default queue and send it to the plugin' '
+	cat <<-EOF >fake_payload.py
+	import flux
+	import json
+
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "default",
+				"priority": 0,
+				"min_nodes_per_job": 0,
+				"max_nodes_per_job": 5,
+				"max_time_per_job": 64000
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	EOF
+	flux python fake_payload.py
 '
 
 test_expect_success 'stop the queue' '

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -25,14 +25,14 @@ test_expect_success 'create a group of users with some ties in fairshare values'
 	cat <<-EOF >fake_small_tie.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5, "max_active_jobs": 7}
+			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
 		]
 	}
 	EOF
@@ -40,6 +40,27 @@ test_expect_success 'create a group of users with some ties in fairshare values'
 
 test_expect_success 'send the user information to the plugin' '
 	flux python ${SEND_PAYLOAD} fake_small_tie.json
+'
+
+test_expect_success 'add a default queue and send it to the plugin' '
+	cat <<-EOF >fake_payload.py
+	import flux
+	import json
+
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "default",
+				"priority": 0,
+				"min_nodes_per_job": 0,
+				"max_nodes_per_job": 5,
+				"max_time_per_job": 64000
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	EOF
+	flux python fake_payload.py
 '
 
 test_expect_success 'stop the queue' '

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -25,15 +25,15 @@ test_expect_success 'create a group of users with many ties in fairshare values'
 	cat <<-EOF >fake_small_tie_all.json
 	{
 	    "data" : [
-	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7},
-	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7}
+	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
+	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
 	    ]
 	}
 	EOF
@@ -41,6 +41,27 @@ test_expect_success 'create a group of users with many ties in fairshare values'
 
 test_expect_success 'send the user information to the plugin' '
 	flux python ${SEND_PAYLOAD} fake_small_tie_all.json
+'
+
+test_expect_success 'add a default queue and send it to the plugin' '
+	cat <<-EOF >fake_payload.py
+	import flux
+	import json
+
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "default",
+				"priority": 0,
+				"min_nodes_per_job": 0,
+				"max_nodes_per_job": 5,
+				"max_time_per_job": 64000
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	EOF
+	flux python fake_payload.py
 '
 
 test_expect_success 'stop the queue' '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -25,8 +25,24 @@ test_expect_success 'create fake_user.json' '
 	cat <<-EOF >fake_user.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 2, "max_active_jobs": 4},
-			{"userid": 5011, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 2}
+			{
+				"userid": 5011,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 2,
+				"max_active_jobs": 4,
+				"queues": ""
+			},
+			{
+				"userid": 5011,
+				"bank": "account2",
+				"def_bank": "account3",
+				"fairshare": 0.11345,
+				"max_running_jobs": 1,
+				"max_active_jobs": 2,
+				"queues": ""
+			}
 		]
 	}
 	EOF
@@ -34,6 +50,27 @@ test_expect_success 'create fake_user.json' '
 
 test_expect_success 'update plugin with sample test data' '
 	flux python ${SEND_PAYLOAD} fake_user.json
+'
+
+test_expect_success 'add a default queue and send it to the plugin' '
+	cat <<-EOF >fake_payload.py
+	import flux
+	import json
+
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "default",
+				"priority": 0,
+				"min_nodes_per_job": 0,
+				"max_nodes_per_job": 5,
+				"max_time_per_job": 64000
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	EOF
+	flux python fake_payload.py
 '
 
 test_expect_success 'submit max number of jobs' '
@@ -79,7 +116,15 @@ test_expect_success 'increase the max jobs count of the user' '
 	cat <<-EOF >new_max_running_jobs_limit.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 3, "max_active_jobs": 4}
+			{
+				"userid": 5011,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 3,
+				"max_active_jobs": 4,
+				"queues": ""
+			}
 		]
 	}
 	EOF
@@ -120,7 +165,15 @@ test_expect_success 'update max_active_jobs limit' '
 	cat <<-EOF >new_max_active_jobs_limit.json
 	{
 		"data" : [
-			{"userid": 5011, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 3, "max_active_jobs": 5}
+			{
+				"userid": 5011,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 3,
+				"max_active_jobs": 5,
+				"queues": ""
+			}
 		]
 	}
 	EOF
@@ -169,8 +222,24 @@ test_expect_success 'create another user with the same limits in multiple banks'
 	cat <<-EOF >fake_user2.json
 	{
 		"data" : [
-			{"userid": 5012, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 1, "max_active_jobs": 2},
-			{"userid": 5012, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 2}
+			{
+				"userid": 5012,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 1,
+				"max_active_jobs": 2,
+				"queues": ""
+			},
+			{
+				"userid": 5012,
+				"bank": "account2",
+				"def_bank": "account3",
+				"fairshare": 0.11345,
+				"max_running_jobs": 1,
+				"max_active_jobs": 2,
+				"queues": ""
+			}
 		]
 	}
 	EOF

--- a/t/t1008-mf-priority-update.t
+++ b/t/t1008-mf-priority-update.t
@@ -36,6 +36,10 @@ test_expect_success 'add some users to the DB' '
 	flux account -p ${DB_PATH} add-user --username=user5013 --userid=5013 --bank=account1
 '
 
+test_expect_success 'add a queue to the DB' '
+	flux account -p ${DB_PATH} add-queue default --priority=0
+'
+
 test_expect_success 'send the user information to the plugin' '
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -37,6 +37,18 @@ test_expect_success 'create fake_payload.py' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "default",
+				"priority": 0,
+				"min_nodes_per_job": 0,
+				"max_nodes_per_job": 5,
+				"max_time_per_job": 64000
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
 	flux.Flux().rpc("job-manager.mf_priority.reprioritize")
 	EOF
 '

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin queue support with a single user'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account -p ${DB_PATH} add-queue standby --priority=0 &&
+	flux account -p ${DB_PATH} add-queue expedite --priority=10000 &&
+	flux account -p ${DB_PATH} add-queue bronze --priority=200 &&
+	flux account -p ${DB_PATH} add-queue silver --priority=300 &&
+	flux account -p ${DB_PATH} add-queue gold --priority=400
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account -p ${DB_PATH} add-user --username=user5011 \
+		--userid=5011 --bank=account1 --queues="standby,bronze,silver,gold,expedite" &&
+	flux account -p ${DB_PATH} add-user --username=user5011 \
+		--userid=5011 --bank=account2 --queues="standby"
+'
+
+test_expect_success 'view user information' '
+	flux account -p ${DB_PATH} view-user user5011
+'
+
+test_expect_success 'send the user and queue information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+test_expect_success 'trying to submit a job without specifying a queue should attempt to use default queue' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 -n1 hostname > no_default_queue.out 2>&1 &&
+	test_debug "no_default_queue.out" &&
+	grep "No default queue exists" no_default_queue.out
+'
+
+test_expect_success 'adding a default queue allows users to run jobs without specifying a queue' '
+	flux account -p ${DB_PATH} add-queue default --priority=1000 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
+	jobid0=$(flux python ${SUBMIT_AS} 5011 -n1 hostname) &&
+	flux job wait-event -f json $jobid0 priority | jq '.context.priority' > job0.test &&
+	cat <<-EOF >job0.expected &&
+	10050000
+	EOF
+	test_cmp job0.expected job0.test &&
+	flux job cancel $jobid0
+'
+
+test_expect_success 'submit a job using a queue the user does not belong to' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account2 \
+		--setattr=system.queue=expedite -n1 hostname > unavail_queue.out 2>&1 &&
+	test_debug "unavail_queue.out" &&
+	grep "Queue not valid for user: expedite" unavail_queue.out
+'
+
+test_expect_success 'submit a job using a nonexistent queue' '
+	test_must_fail flux python ${SUBMIT_AS} 5011 --setattr=system.queue=foo \
+		-n1 hostname > bad_queue.out 2>&1 &&
+	test_debug "bad_queue.out" &&
+	grep "Queue does not exist: foo" bad_queue.out
+'
+
+test_expect_success 'submit a job using standby queue, which should not increase job priority' '
+	jobid1=$(flux python ${SUBMIT_AS} 5011 --job-name=standby \
+		--setattr=system.bank=account1 --setattr=system.queue=standby -n1 hostname) &&
+	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
+	cat <<-EOF >job1.expected &&
+	50000
+	EOF
+	test_cmp job1.expected job1.test
+'
+
+test_expect_success 'submit a job using expedite queue, which should increase priority' '
+	jobid2=$(flux python ${SUBMIT_AS} 5011 --job-name=expedite \
+		--setattr=system.bank=account1 --setattr=system.queue=expedite -n1 hostname) &&
+	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
+	cat <<-EOF >job2.expected &&
+	100050000
+	EOF
+	test_cmp job2.expected job2.test
+'
+
+test_expect_success 'submit a job using the rest of the available queues' '
+	jobid3=$(flux python ${SUBMIT_AS} 5011 --job-name=bronze --setattr=system.queue=bronze -n1 hostname) &&
+	jobid4=$(flux python ${SUBMIT_AS} 5011 --job-name=silver --setattr=system.queue=silver -n1 hostname) &&
+	jobid5=$(flux python ${SUBMIT_AS} 5011 --job-name=gold --setattr=system.queue=gold -n1 hostname)
+'
+
+test_expect_success 'check order of job queue' '
+	flux jobs -A --suppress-header --format={name} > multi_queues.test &&
+	cat <<-EOF >multi_queues.expected &&
+	expedite
+	gold
+	silver
+	bronze
+	standby
+	EOF
+	test_cmp multi_queues.expected multi_queues.test
+'
+
+test_expect_success 'cancel existing jobs' '
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3 &&
+	flux job cancel $jobid4 &&
+	flux job cancel $jobid5
+'
+
+test_expect_success 'unload mf_priority.so' '
+	flux jobtap remove mf_priority.so
+'
+
+test_expect_success 'submit a job to a nonexistent queue with no plugin information loaded' '
+	jobid6=$(flux python ${SUBMIT_AS} 5011 --setattr=system.queue=foo -n1 hostname) &&
+	test $(flux jobs -no {state} ${jobid6}) = PRIORITY
+'
+
+test_expect_success 'reload mf_priority.so and update it with the sample test data again' '
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
+	test $(flux jobs -no {state} ${jobid6}) = PRIORITY &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'ensure job exception was raised saying that the queue does not exist' '
+	flux job wait-event -v ${jobid6} exception > nonexistent_queue.test &&
+	grep "Queue does not exist: foo" nonexistent_queue.test
+'
+
+test_done


### PR DESCRIPTION
#### Background

The cleanup work described in #204 has now been completed with the merge of #205 and now allows for the start of integrating the use of queues into the priority plugin. I think there are two prongs to adding queue support into the plugin:

1) the use of a queue's associated priority to further increase or decrease the priority of a job submitted from a user/bank (which is the focus of this PR), and
2) the enforcement of per-job limits using a queue's associated limits (the work of a future PR)

---

This PR looks to integrate queue information into the priority calculation of a job in the multi-factor priority plugin. At a high level, the goal is to use queue information to further calculate a job priority using the information from the `queue_table` in the flux-accounting database, which for each queue, contains an associated priority and a number of limits. A queue can be specified on the command line like so (I looked at [this](https://github.com/flux-framework/flux-sched/blob/master/t/t1011-dynstate-change.t) flux-sched file for reference):

```console
$ flux mini submit --setattr=system.queue=expedite -n1 hostname
```

The plugin will both 1) verify that the queue exists and is a valid queue for the user/bank to run jobs in, and 2) use the associated priority of the queue to help calculate its priority. In the above example, an `expedite` queue will most likely have a high integer priority, so it will increase the priority of the submitted job.

In the bulk update script, a new payload is generated containing information of all the queues in the `queue_table` and sends it to the plugin. A new callback is also added in the plugin to unpack this information and place it in a map with the queue name as the key, and a `queue_info` struct as the value, which has the following members:

```c++
struct queue_info {
    int min_nodes_per_job;
    int max_nodes_per_job;
    int max_time_per_job;
    int priority;
};
```

Two new members are also added to the `bank_info` struct, so for every user/bank, information pertaining to what queues they are allowed to submit jobs in, as well as the integer priority associated with the queue they passed in when submitting a job are included in the struct.

I made a change to the final result of the priority calculation to no longer return the absolute value of an integer priority, but to instead check to see if the result is `< 0`, and if so, just return `FLUX_JOB_PRIORITY_MIN`, since if a low priority queue decreases the priority of a job so much so that the resulting priority is negative, then I think the right behavior would be to just return the minimum priority.

I'm posting this now and would be interested to see if @ryanday36 has any high-level feedback on how the queue priority calculation is implemented. Do the additions proposed in this PR sound reasonable at a high level and in-line to how queue priority affects a single job's priority on our current systems? Let me know.

Fixes #165
Fixes #204