### PR TITLE
job-archive interface: update optional `--priority-decay-half-life` argument

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -438,7 +438,7 @@ def check_end_hl(acct_conn, pdhl):
         acct_conn.commit()
 
 
-def update_job_usage(acct_conn, jobs_conn, pdhl):
+def update_job_usage(acct_conn, jobs_conn, pdhl=1):
     s_assoc = "SELECT username, bank FROM association_table"
     cur = acct_conn.cursor()
     cur.execute(s_assoc)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -275,7 +275,9 @@ def add_update_usage_arg(subparsers):
     )
     subparser_update_usage.add_argument(
         "--priority-decay-half-life",
-        help="contribution of historical usage in weeks on the composite usage value",
+        default=1,
+        type=int,
+        help="number of weeks for a job's usage contribution to a half-life decay",
         metavar="PRIORITY DECAY HALF LIFE",
     )
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -10,7 +10,8 @@ TESTSCRIPTS = \
 	t1006-update-fshare.t \
 	t1007-flux-account.t \
 	t1008-mf-priority-update.t \
-	t1009-pop-db.t
+	t1009-pop-db.t \
+	t1010-update-usage.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \
@@ -45,7 +46,10 @@ EXTRA_DIST= \
 	expected/flux_account/full_hierarchy.expected \
 	expected/flux_account/root_bank.expected \
 	expected/pop_db/db_hierarchy_base.expected \
-	expected/pop_db/db_hierarchy_new_users.expected
+	expected/pop_db/db_hierarchy_new_users.expected \
+	expected/job_usage/pre_update.expected \
+	expected/job_usage/post_update1.expected \
+	expected/job_usage/post_update2.expected
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output

--- a/t/expected/job_usage/post_update1.expected
+++ b/t/expected/job_usage/post_update1.expected
@@ -1,0 +1,12 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1               24000
+ account1                                                  1               16000
+  account1                          5011                   1                4000            0.428571
+  account1                          5012                   1                6000            0.285714
+  account1                          5013                   1                6000            0.285714
+ account2                                                  1                8000
+  account2                          5021                   1                8000            0.571429
+  account2                          5022                   1                   0            0.714286
+ account3                                                  1                   0
+  account3                          5031                   1                   0                   1
+  account3                          5032                   1                   0                   1

--- a/t/expected/job_usage/post_update2.expected
+++ b/t/expected/job_usage/post_update2.expected
@@ -1,0 +1,12 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1               24000
+ account1                                                  1               16000
+  account1                          5011                   1                4000            0.428571
+  account1                          5012                   1                6000            0.285714
+  account1                          5013                   1                6000            0.285714
+ account2                                                  1                8000
+  account2                          5021                   1                8000            0.571429
+  account2                          5022                   1                   0            0.714286
+ account3                                                  1                   0
+  account3                          5031                   1                   0                   1
+  account3                          5032                   1                   0                   1

--- a/t/expected/job_usage/pre_update.expected
+++ b/t/expected/job_usage/pre_update.expected
@@ -1,0 +1,12 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1                   0
+ account1                                                  1                   0
+  account1                          5011                   1                   0                 0.5
+  account1                          5012                   1                   0                 0.5
+  account1                          5013                   1                   0                 0.5
+ account2                                                  1                   0
+  account2                          5021                   1                   0                 0.5
+  account2                          5022                   1                   0                 0.5
+ account3                                                  1                   0
+  account3                          5031                   1                   0                 0.5
+  account3                          5032                   1                   0                 0.5

--- a/t/scripts/create_job_archive_db.py
+++ b/t/scripts/create_job_archive_db.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import sys
+
+
+def populate_job_archive_db(
+    jobs_conn, userid, username, ranks, num_entries, starting_jobid
+):
+    jobid = starting_jobid
+    t_inactive_delta = 2000
+
+    for i in range(num_entries):
+        jobid += 1
+        try:
+            jobs_conn.execute(
+                """
+                INSERT INTO jobs (
+                    id,
+                    userid,
+                    username,
+                    ranks,
+                    t_submit,
+                    t_sched,
+                    t_run,
+                    t_cleanup,
+                    t_inactive,
+                    eventlog,
+                    jobspec,
+                    R
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    jobid,
+                    userid,
+                    username,
+                    ranks,
+                    100000000 - 2000,
+                    100000000 - 1000,
+                    100000000,
+                    100000000 + 1000,
+                    100000000 + 2000,
+                    "eventlog",
+                    "jobspec",
+                    '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
+                ),
+            )
+            # commit changes
+            jobs_conn.commit()
+        # make sure entry is unique
+        except sqlite3.IntegrityError as integrity_error:
+            print(integrity_error)
+
+
+def main():
+    jobs_conn = sqlite3.connect("file:job-archive.sqlite?mode:rwc", uri=True)
+    jobs_conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS jobs (
+                id            int       NOT NULL,
+                userid        int       NOT NULL,
+                username      text      NOT NULL,
+                ranks         text      NOT NULL,
+                t_submit      real      NOT NULL,
+                t_sched       real      NOT NULL,
+                t_run         real      NOT NULL,
+                t_cleanup     real      NOT NULL,
+                t_inactive    real      NOT NULL,
+                eventlog      text      NOT NULL,
+                jobspec       text      NOT NULL,
+                R             text      NOT NULL,
+                PRIMARY KEY   (id)
+        );"""
+    )
+
+    # populate the job-archive DB with fake job entries
+    populate_job_archive_db(jobs_conn, 5011, "5011", "0", 2, 1000)
+    populate_job_archive_db(jobs_conn, 5012, "5012", "0", 3, 2000)
+    populate_job_archive_db(jobs_conn, 5013, "5013", "0", 3, 4000)
+    populate_job_archive_db(jobs_conn, 5021, "5014", "0", 4, 5000)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/t1010-update-usage.t
+++ b/t/t1010-update-usage.t
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+test_description='Test print-hierarchy command'
+
+. `dirname $0`/sharness.sh
+DB_PATH=$(pwd)/FluxAccountingTest.db
+CREATE_TEST_DB=${SHARNESS_TEST_SRCDIR}/scripts/create_test_db.py
+UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
+CREATE_JOB_ARCHIVE=${SHARNESS_TEST_SRCDIR}/scripts/create_job_archive_db.py
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account3 1
+'
+
+test_expect_success 'add some users to the DB' '
+	flux account -p ${DB_PATH} add-user --username=5011 --userid=5011 --bank=account1 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=5012 --userid=5012 --bank=account1 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=5013 --userid=5013 --bank=account1 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=5021 --userid=5021 --bank=account2 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=5022 --userid=5022 --bank=account2 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=5031 --userid=5031 --bank=account3 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=5032 --userid=5032 --bank=account3 --shares=1
+'
+
+test_expect_success 'create sample job-archive DB' '
+	flux python ${CREATE_JOB_ARCHIVE}
+'
+
+test_expect_success 'update-usage raises a usage error when passing a bad type for priority-decay-half-life' '
+	test_must_fail flux account -p ${DB_PATH} update-usage job-archive.sqlite \
+		--priority-decay-half-life foo > bad_arg.out 2>&1 &&
+	test_debug "cat bad_arg.out" &&
+	grep "flux-account.py update-usage: error: argument --priority-decay-half-life: invalid int value:" bad_arg.out
+'
+
+test_expect_success 'create & compare hierarchy output from FluxAccountingTest.db: pre-usage update' '
+	flux account-shares -p $(pwd)/FluxAccountingTest.db > pre_update.test &&
+	test_cmp ${SHARNESS_TEST_SRCDIR}/expected/job_usage/pre_update.expected pre_update.test
+'
+
+test_expect_success 'run update-usage and update-fshare commands' '
+	flux account -p ${DB_PATH} update-usage job-archive.sqlite &&
+	flux account-update-fshare -p ${DB_PATH}
+'
+
+test_expect_success 'create & compare hierarchy output from FluxAccountingTest.db: post-usage update 1' '
+	flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update1.test &&
+	test_cmp ${SHARNESS_TEST_SRCDIR}/expected/job_usage/post_update2.expected post_update1.test
+'
+
+test_expect_success 'run update-usage and update-fshare commands with an optional arg' '
+	flux account -p ${DB_PATH} update-usage job-archive.sqlite --priority-decay-half-life 1 &&
+	flux account-update-fshare -p ${DB_PATH}
+'
+
+test_expect_success 'create & compare hierarchy output from FluxAccountingTest.db: post-usage update 2' '
+	flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update2.test &&
+	test_cmp ${SHARNESS_TEST_SRCDIR}/expected/job_usage/post_update2.expected post_update2.test
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As described in #208, a `TypeError` occurs when not specifying a value for the `--priority-decay-half-life` optional argument in the `update-usage` command. This is because the argument has no default value, so if no value is specified, `None` is passed to the `calc_usage_factor()` function and it fails.

---

This PR fixes the `TypeError` in the `update-usage` command by adding a default value for the `--priority-decay-half-life` optional argument, 1, which matches the default value in the flux-accounting database. 

It also adds a new sharness test file, `t1010-update-usage.t`, which creates both a sample flux-accounting DB and job-archive DB, populated with a set of fake job records. It then runs the `update-usage` command twice, one using the default value and another specifying a value on the command line. It then checks to see that the job usage values do in fact get updated in the flux-accounting database by running the `flux account-shares` command. 