### PR TITLE
job-archive interface: remove `count_ranks()` helper function, import ResourceSet class

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -136,7 +136,7 @@ def add_job_records(rows):
     return job_records
 
 
-def view_job_records(conn, output_file, **kwargs):
+def get_job_records(conn, **kwargs):
     job_records = []
 
     # find out which args were passed and place them in a dict
@@ -179,13 +179,19 @@ def view_job_records(conn, output_file, **kwargs):
     cur = conn.cursor()
     cur.execute(select_stmt, (*tuple(params_list),))
     rows = cur.fetchall()
-    # if the length of dataframe is 0, that means
-    # no job records were found in the jobs table,
-    # so just return an empty list
+    # if the length of dataframe is 0, that means no job records were found
+    # in the jobs table, so just return an empty list
     if len(rows) == 0:
         return job_records
 
     job_records = add_job_records(rows)
+
+    return job_records
+
+
+def output_job_records(conn, output_file, **kwargs):
+    job_records = get_job_records(conn, **kwargs)
+
     if output_file is None:
         print_job_records(job_records)
     else:
@@ -350,9 +356,8 @@ def calc_usage_factor(jobs_conn, acct_conn, pdhl, user, bank):
 
     # get jobs that have completed since the last seen completed job
     last_j_ts = get_last_job_ts(acct_conn, user, bank)
-    user_jobs = view_job_records(
+    user_jobs = get_job_records(
         jobs_conn,
-        output_file=None,
         user=user,
         after_start_time=last_j_ts,
     )

--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -14,13 +14,7 @@ import pwd
 import csv
 import math
 
-
-def count_ranks(ranks):
-    if "-" in ranks:
-        ranks_count = ranks.replace("-", ",").split(",")
-        return int(ranks_count[1]) - int(ranks_count[0]) + 1
-
-    return int(ranks) + 1
+from flux.resource import ResourceSet
 
 
 def get_username(userid):
@@ -127,6 +121,8 @@ def add_job_records(rows):
     job_records = []
 
     for row in rows:
+        rset = ResourceSet(row[6])  # fetch R
+
         job_record = JobRecord(
             row[0],  # userid
             get_username(row[0]),  # username
@@ -134,7 +130,7 @@ def add_job_records(rows):
             row[2],  # t_submit
             row[3],  # t_run
             row[4],  # t_inactive
-            count_ranks(row[5]),  # nnodes
+            rset.nnodes,  # nnodes
             row[6],  # resources
         )
         job_records.append(job_record)

--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -65,7 +65,7 @@ def write_records_to_file(job_records, output_file):
 
 def print_job_records(job_records):
     print(
-        "{:<10} {:<10} {:<10} {:<10} {:<10} {:<10} {:<10} {:<10}".format(
+        "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
             "UserID",
             "Username",
             "JobID",
@@ -73,12 +73,11 @@ def print_job_records(job_records):
             "T_Run",
             "T_Inactive",
             "Nodes",
-            "R",
         )
     )
     for record in job_records:
         print(
-            "{:<10} {:<10} {:<10} {:<10} {:<10} {:<10} {:<10} {:<10}".format(
+            "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
                 record.userid,
                 record.username,
                 record.jobid,
@@ -86,7 +85,6 @@ def print_job_records(job_records):
                 record.t_run,
                 record.t_inactive,
                 record.nnodes,
-                record.resources,
             )
         )
 

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -39,12 +39,10 @@ class TestAccountingCLI(unittest.TestCase):
         jobs_conn.execute(
             """
                 CREATE TABLE IF NOT EXISTS jobs (
-                    id            int       NOT NULL,
+                    id            char(16)  NOT NULL,
                     userid        int       NOT NULL,
-                    username      text      NOT NULL,
                     ranks         text      NOT NULL,
                     t_submit      real      NOT NULL,
-                    t_sched       real      NOT NULL,
                     t_run         real      NOT NULL,
                     t_cleanup     real      NOT NULL,
                     t_inactive    real      NOT NULL,
@@ -87,9 +85,7 @@ class TestAccountingCLI(unittest.TestCase):
         interval = 0  # add to job timestamps to diversify job-archive records
 
         @mock.patch("time.time", mock.MagicMock(return_value=9000000))
-        def populate_job_archive_db(
-            jobs_conn, userid, username, ranks, nodes, num_entries
-        ):
+        def populate_job_archive_db(jobs_conn, userid, ranks, nodes, num_entries):
             nonlocal jobid
             nonlocal interval
             t_inactive_delta = 2000
@@ -124,10 +120,8 @@ class TestAccountingCLI(unittest.TestCase):
                         INSERT INTO jobs (
                             id,
                             userid,
-                            username,
                             ranks,
                             t_submit,
-                            t_sched,
                             t_run,
                             t_cleanup,
                             t_inactive,
@@ -135,15 +129,13 @@ class TestAccountingCLI(unittest.TestCase):
                             jobspec,
                             R
                         )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             jobid,
                             userid,
-                            username,
                             ranks,
                             (time.time() + interval) - 2000,
-                            (time.time() + interval) - 1000,
                             (time.time() + interval),
                             (time.time() + interval) + 1000,
                             (time.time() + interval) + t_inactive_delta,
@@ -163,15 +155,15 @@ class TestAccountingCLI(unittest.TestCase):
                 t_inactive_delta += 100
 
         # populate the job-archive DB with fake job entries
-        populate_job_archive_db(jobs_conn, 1001, "1001", "0", "fluke[0]", 2)
+        populate_job_archive_db(jobs_conn, 1001, "0", "fluke[0]", 2)
 
-        populate_job_archive_db(jobs_conn, 1002, "1002", "0-1", "fluke[0-1]", 3)
-        populate_job_archive_db(jobs_conn, 1002, "1002", "0", "fluke[0]", 2)
+        populate_job_archive_db(jobs_conn, 1002, "0-1", "fluke[0-1]", 3)
+        populate_job_archive_db(jobs_conn, 1002, "0", "fluke[0]", 2)
 
-        populate_job_archive_db(jobs_conn, 1003, "1003", "0-2", "fluke[0-2]", 3)
+        populate_job_archive_db(jobs_conn, 1003, "0-2", "fluke[0-2]", 3)
 
-        populate_job_archive_db(jobs_conn, 1004, "1004", "0-3", "fluke[0-3]", 4)
-        populate_job_archive_db(jobs_conn, 1004, "1004", "0", "fluke[0]", 4)
+        populate_job_archive_db(jobs_conn, 1004, "0-3", "fluke[0-3]", 4)
+        populate_job_archive_db(jobs_conn, 1004, "0", "fluke[0]", 4)
 
     # passing a valid jobid should return
     # its job information
@@ -333,10 +325,8 @@ class TestAccountingCLI(unittest.TestCase):
                 INSERT INTO jobs (
                     id,
                     userid,
-                    username,
                     ranks,
                     t_submit,
-                    t_sched,
                     t_run,
                     t_cleanup,
                     t_inactive,
@@ -344,15 +334,13 @@ class TestAccountingCLI(unittest.TestCase):
                     jobspec,
                     R
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     "200",
                     "1001",
-                    "1001",
                     "0",
                     time.time() + 100,
-                    time.time() + 200,
                     time.time() + 300,
                     time.time() + 400,
                     time.time() + 500,

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -152,21 +152,21 @@ class TestAccountingCLI(unittest.TestCase):
     # its job information
     def test_01_with_jobid_valid(self):
         my_dict = {"jobid": 102}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 1)
 
     # passing a bad jobid should return a
     # failure message
     def test_02_with_jobid_failure(self):
         my_dict = {"jobid": 000}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # passing a timestamp before the first job to
     # start should return all of the jobs
     def test_03_after_start_time_all(self):
         my_dict = {"after_start_time": 0}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 18)
 
     # passing a timestamp after all of the start time
@@ -174,7 +174,7 @@ class TestAccountingCLI(unittest.TestCase):
     @mock.patch("time.time", mock.MagicMock(return_value=11000000))
     def test_04_after_start_time_none(self):
         my_dict = {"after_start_time": time.time()}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # passing a timestamp before the end time of the
@@ -182,21 +182,21 @@ class TestAccountingCLI(unittest.TestCase):
     @mock.patch("time.time", mock.MagicMock(return_value=11000000))
     def test_05_before_end_time_all(self):
         my_dict = {"before_end_time": time.time()}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 18)
 
     # passing a timestamp before the end time of
     # the first completed jobs should return no jobs
     def test_06_before_end_time_none(self):
         my_dict = {"before_end_time": 0}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # passing a user not in the jobs table
     # should return no jobs
     def test_07_by_user_failure(self):
         my_dict = {"user": "9999"}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 0)
 
     # view_jobs_run_by_username() interacts with a
@@ -204,7 +204,7 @@ class TestAccountingCLI(unittest.TestCase):
     # just pass the userid
     def test_08_by_user_success(self):
         my_dict = {"user": "1001"}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 2)
 
     # passing a combination of params should further
@@ -212,14 +212,14 @@ class TestAccountingCLI(unittest.TestCase):
     @mock.patch("time.time", mock.MagicMock(return_value=9000500))
     def test_09_multiple_params(self):
         my_dict = {"user": "1001", "after_start_time": time.time()}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 1)
 
     # passing no parameters will result in a generic query
     # returning all results
     def test_10_no_options_passed(self):
         my_dict = {}
-        job_records = jobs.view_job_records(jobs_conn, op, **my_dict)
+        job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
         self.assertEqual(len(job_records), 18)
 
     # users that have run a lot of jobs should have a larger usage factor

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -443,7 +443,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.queues,
         )
     elif args.func == "view_job_records":
-        jobs.view_job_records(
+        jobs.output_job_records(
             conn,
             output_file,
             jobid=args.jobid,

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -17,5 +17,8 @@ RUN \
    && sudo adduser $USER sudo ; \
  fi
 
+# add site-packages to PYTHONPATH
+ENV PYTHONPATH="${PYTHONPATH}:/usr/lib/python3.6/site-packages"
+
 USER $USER
 WORKDIR /home/$USER

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -11,7 +11,8 @@ TESTSCRIPTS = \
 	t1007-flux-account.t \
 	t1008-mf-priority-update.t \
 	t1009-pop-db.t \
-	t1010-update-usage.t
+	t1010-update-usage.t \
+	t1011-job-archive-interface.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/scripts/create_job_archive_db.py
+++ b/t/scripts/create_job_archive_db.py
@@ -12,9 +12,7 @@ import sqlite3
 import sys
 
 
-def populate_job_archive_db(
-    jobs_conn, userid, username, ranks, num_entries, starting_jobid
-):
+def populate_job_archive_db(jobs_conn, userid, username, num_entries, starting_jobid):
     jobid = starting_jobid
     t_inactive_delta = 2000
 
@@ -43,15 +41,33 @@ def populate_job_archive_db(
                     jobid,
                     userid,
                     username,
-                    ranks,
-                    100000000 - 2000,
-                    100000000 - 1000,
+                    "0",
+                    99998000,
                     100000000,
-                    100000000 + 1000,
-                    100000000 + 2000,
+                    100001000,
+                    100002000,
                     "eventlog",
                     "jobspec",
-                    '{"version":1,"execution": {"R_lite":[{"rank":"0","children": {"core": "0"}}]}}',
+                    """{
+                      "version": 1,
+                      "execution": {
+                        "R_lite": [
+                          {
+                            "rank": "0",
+                            "children": {
+                                "core": "0-3",
+                                "gpu": "0"
+                             }
+                          }
+                        ],
+                        "starttime": 0,
+                        "expiration": 0,
+                        "nodelist": [
+                          "fluke[0]"
+                        ]
+                      }
+                    }
+                    """,
                 ),
             )
             # commit changes
@@ -83,10 +99,10 @@ def main():
     )
 
     # populate the job-archive DB with fake job entries
-    populate_job_archive_db(jobs_conn, 5011, "5011", "0", 2, 1000)
-    populate_job_archive_db(jobs_conn, 5012, "5012", "0", 3, 2000)
-    populate_job_archive_db(jobs_conn, 5013, "5013", "0", 3, 4000)
-    populate_job_archive_db(jobs_conn, 5021, "5014", "0", 4, 5000)
+    populate_job_archive_db(jobs_conn, 5011, "5011", 2, 1000)
+    populate_job_archive_db(jobs_conn, 5012, "5012", 3, 2000)
+    populate_job_archive_db(jobs_conn, 5013, "5013", 3, 4000)
+    populate_job_archive_db(jobs_conn, 5021, "5014", 4, 5000)
 
 
 if __name__ == "__main__":

--- a/t/scripts/create_job_archive_db.py
+++ b/t/scripts/create_job_archive_db.py
@@ -12,7 +12,7 @@ import sqlite3
 import sys
 
 
-def populate_job_archive_db(jobs_conn, userid, username, num_entries, starting_jobid):
+def populate_job_archive_db(jobs_conn, userid, num_entries, starting_jobid):
     jobid = starting_jobid
     t_inactive_delta = 2000
 
@@ -24,10 +24,8 @@ def populate_job_archive_db(jobs_conn, userid, username, num_entries, starting_j
                 INSERT INTO jobs (
                     id,
                     userid,
-                    username,
                     ranks,
                     t_submit,
-                    t_sched,
                     t_run,
                     t_cleanup,
                     t_inactive,
@@ -35,12 +33,11 @@ def populate_job_archive_db(jobs_conn, userid, username, num_entries, starting_j
                     jobspec,
                     R
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     jobid,
                     userid,
-                    username,
                     "0",
                     99998000,
                     100000000,
@@ -82,12 +79,10 @@ def main():
     jobs_conn.execute(
         """
             CREATE TABLE IF NOT EXISTS jobs (
-                id            int       NOT NULL,
+                id            char(16)  NOT NULL,
                 userid        int       NOT NULL,
-                username      text      NOT NULL,
                 ranks         text      NOT NULL,
                 t_submit      real      NOT NULL,
-                t_sched       real      NOT NULL,
                 t_run         real      NOT NULL,
                 t_cleanup     real      NOT NULL,
                 t_inactive    real      NOT NULL,
@@ -99,10 +94,10 @@ def main():
     )
 
     # populate the job-archive DB with fake job entries
-    populate_job_archive_db(jobs_conn, 5011, "5011", 2, 1000)
-    populate_job_archive_db(jobs_conn, 5012, "5012", 3, 2000)
-    populate_job_archive_db(jobs_conn, 5013, "5013", 3, 4000)
-    populate_job_archive_db(jobs_conn, 5021, "5014", 4, 5000)
+    populate_job_archive_db(jobs_conn, 5011, 2, 1000)
+    populate_job_archive_db(jobs_conn, 5012, 3, 2000)
+    populate_job_archive_db(jobs_conn, 5013, 3, 4000)
+    populate_job_archive_db(jobs_conn, 5021, 4, 5000)
 
 
 if __name__ == "__main__":

--- a/t/scripts/query.py
+++ b/t/scripts/query.py
@@ -1,0 +1,62 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Query a job-archive db for testing purposes
+
+# Usage: flux python query.py [OPTIONS] dbpath query
+
+import sys
+import argparse
+import sqlite3
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t", "--timeout", type=str, metavar="MS", help="Set busytimeout"
+    )
+    parser.add_argument(
+        "dbpath", type=str, metavar="DBPATH", nargs=1, help="database path"
+    )
+    parser.add_argument("query", type=str, metavar="QUERY", nargs=1, help="query")
+    args = parser.parse_args()
+
+    try:
+        dburi = "file:" + args.dbpath[0] + "?mode=ro"
+        con = sqlite3.connect(dburi, uri=True)
+    except sqlite3.Error as e:
+        print(e)
+        sys.exit(1)
+
+    if args.timeout:
+        con.execute("PRAGMA busy_wait = " + args.timeout)
+
+    con.row_factory = sqlite3.Row
+    cursor = con.cursor()
+
+    try:
+        cursor.execute(args.query[0])
+    except sqlite3.Error as e:
+        print(e)
+        sys.exit(1)
+
+    rows = cursor.fetchall()
+
+    #  make print below safe to handle utf-8
+    utf8out = open(1, "w", encoding="utf-8", closefd=False)
+
+    for row in rows:
+        for key in row.keys():
+            val = row[key]
+            print(f"{key} = {val}", file=utf8out)
+
+    con.close()
+    sys.exit(0)
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+test_description='Tests for update-usage command'
+
+. $(dirname $0)/sharness.sh
+
+DB_PATH=$(pwd)/FluxAccountingTest.db
+ARCHIVEDIR=`pwd`
+ARCHIVEDB="${ARCHIVEDIR}/jobarchive.db"
+QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 4 job
+
+# wait for job to be stored in job archive
+# arg1 - jobid
+# arg2 - database path
+wait_db() {
+        local jobid=$(flux job id $1)
+        local dbpath=$2
+        local i=0
+        query="select id from jobs;"
+        while ! ${QUERYCMD} -t 100 ${dbpath} "${query}" | grep $jobid > /dev/null \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1
+'
+
+test_expect_success 'add some users to the DB' '
+    username=$(whoami) &&
+    uid=$(id -u) &&
+	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account1 --shares=1 &&
+    flux account -p ${DB_PATH} add-user --username=user5011 --userid=5011 --bank=account1 --shares=1 &&
+    flux account -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=account1 --shares=1
+'
+
+test_expect_success 'flux account-shares works' '
+    flux account-shares -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'job-archive: set up config file' '
+        cat >archive.toml <<EOF &&
+[archive]
+dbpath = "${ARCHIVEDB}"
+period = "0.5s"
+busytimeout = "0.1s"
+EOF
+	flux config reload
+'
+
+test_expect_success 'load job-archive module' '
+    flux module load job-archive
+'
+
+test_expect_success 'submit some sleep 1 jobs under one user' '
+    jobid1=$(flux mini submit -N 1 sleep 1) &&
+    jobid2=$(flux mini submit -N 1 sleep 1) &&
+    jobid3=$(flux mini submit -n 2 -N 2 sleep 1) &&
+    wait_db $jobid1 ${ARCHIVEDB} &&
+    wait_db $jobid2 ${ARCHIVEDB} &&
+    wait_db $jobid3 ${ARCHIVEDB}
+'
+
+test_expect_success 'run update-usage and update-fshare commands' '
+    flux account -p ${DB_PATH} update-usage ${ARCHIVEDB} &&
+    flux account-update-fshare -p ${DB_PATH}
+'
+
+test_expect_success 'check that job usage and fairshare values get updated' '
+    flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update.test &&
+    grep "0.333333" post_update.test
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'job-archive: unload module' '
+    flux module unload job-archive
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As noted in #210, the `count_ranks()` helper function incorrectly parses the `ranks` column when there is a range of ranks. This leads to a `ValueError` when counting the number of nodes used in a job.

---

This PR removes the `count_ranks()` helper function and instead imports the `ResourceSet` class from flux-core, which can then extract `nnodes` from a job's `R`. Note that in both the unit test file for **job_archive_interface.py** and the sharness test file **t1010-update-usage.t**, the calculated usage values checked in the tests remain the same for all users, which ensures consistency after the change to the way the job-archive interface extracted the `nnodes` values from job records.

It also contains a small improvement to the `update-usage` command to add a special option to the `print_job_records()` function. Previously, when the `update-usage` command was run, all new job records were printed to `stdout` after the command was run. The command should no longer produce output to `stdout` once run.

A new sharness test, `t1011-job-archive-interface.t` is also added, which loads the job-archive module and submits a number of `sleep 1` jobs under one user. The `update-usage` command is then called to ensure that the job usage and fairshare values get updated for the user who submitted jobs as well as the other users in that same bank.

Fixes #210