### PR TITLE
[WIP] priority plugin: add configurable plugin factor weights for priority calculation

### DIFF
--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -17,7 +17,8 @@ TESTSCRIPTS = \
 	test/test_example.py \
 	test/test_job_archive_interface.py \
 	test/test_user_subcommands.py \
-	test/test_queue_subcommands.py
+	test/test_queue_subcommands.py \
+	test/test_plugin_factor_subcommands.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS)

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -3,6 +3,7 @@ acctpy_PYTHON = \
 	user_subcommands.py \
 	bank_subcommands.py \
 	queue_subcommands.py \
+	plugin_factor_subcommands.py \
 	job_archive_interface.py \
 	create_db.py
 

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -174,5 +174,27 @@ def create_db(
                 PRIMARY KEY (queue)
             );"""
     )
+    logging.info("Created queue_table successfully")
+
+    # Plugin Weight Table
+    # stores the weights for all of the priority factors in the multi-factor
+    # priority plugin
+    logging.info("Creating plugin_factor_table in DB...")
+    conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS plugin_factor_table (
+                factor      tinytext                NOT NULL,
+                weight      int(11)     DEFAULT 1,
+                PRIMARY KEY (factor)
+            );"""
+    )
+    logging.info("Created plugin_factor_table successfully")
+    conn.execute(
+        "INSERT INTO plugin_factor_table (factor, weight) VALUES ('fairshare', 100000);"
+    )
+    conn.execute(
+        "INSERT INTO plugin_factor_table (factor, weight) VALUES ('queue', 10000);"
+    )
+    conn.commit()
 
     conn.close()

--- a/src/bindings/python/fluxacct/accounting/plugin_factor_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/plugin_factor_subcommands.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+
+
+def view_factor(conn, factor):
+    cur = conn.cursor()
+    try:
+        # get the information pertaining to a plugin weight in the DB
+        cur.execute("SELECT * FROM plugin_factor_table WHERE factor=?", (factor,))
+        rows = cur.fetchall()
+        headers = [description[0] for description in cur.description]
+        if not rows:
+            print("Factor not found in plugin_factor_table")
+        else:
+            # print column names of plugin_factor_table
+            for header in headers:
+                print(header.ljust(18), end=" ")
+            print()
+            for row in rows:
+                for col in list(row):
+                    print(str(col).ljust(18), end=" ")
+                print()
+    except sqlite3.OperationalError as e_database_error:
+        print(e_database_error)
+
+
+def edit_factor(conn, factor, weight=None):
+    try:
+        update_stmt = "UPDATE plugin_factor_table SET weight=? WHERE factor=?"
+        updated_weight = int(weight)  # check that the weight is of type int
+
+        conn.execute(
+            update_stmt,
+            (
+                weight,
+                factor,
+            ),
+        )
+
+        # commit changes
+        conn.commit()
+    except ValueError:
+        raise ValueError("Weight must be an integer")

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -54,6 +54,7 @@ class TestDB(unittest.TestCase):
             "job_usage_factor_table",
             "t_half_life_period_table",
             "queue_table",
+            "plugin_factor_table",
         ]
         self.assertEqual(list_of_tables, expected)
 

--- a/src/bindings/python/fluxacct/accounting/test/test_plugin_factor_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_plugin_factor_subcommands.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import plugin_factor_subcommands as p
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        c.create_db("TestPluginFactorSubcommands.db")
+        global acct_conn
+        global cur
+
+        acct_conn = sqlite3.connect("TestPluginFactorSubcommands.db")
+        cur = acct_conn.cursor()
+
+    # edit the weight for the fairshare factor
+    def test_01_edit_fairshare_factor_successfully(self):
+        p.edit_factor(acct_conn, factor="fairshare", weight=1500)
+        cur.execute("SELECT weight FROM plugin_factor_table WHERE factor='fairshare'")
+        row = cur.fetchone()
+
+        self.assertEqual(row[0], 1500)
+
+    # edit the weight for the queue factor
+    def test_02_edit_queue_factor_successfully(self):
+        p.edit_factor(acct_conn, factor="queue", weight=200)
+        cur.execute("SELECT weight FROM plugin_factor_table WHERE factor='queue'")
+        row = cur.fetchone()
+
+        self.assertEqual(row[0], 200)
+
+    # try to edit a factor with a bad type
+    def test_03_edit_factor_bad_type(self):
+        with self.assertRaises(ValueError):
+            p.edit_factor(acct_conn, factor="fairshare", weight="foo")
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        acct_conn.close()
+        os.remove("TestPluginFactorSubcommands.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -51,6 +51,7 @@ def bulk_update(path):
     data = {}
     bulk_user_data = []
     bulk_q_data = []
+    bulk_factor_data = []
 
     # fetch all rows from association_table (will print out tuples)
     for row in cur.execute(
@@ -89,6 +90,19 @@ def bulk_update(path):
     data = {"data": bulk_q_data}
 
     flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(data)).get()
+
+    # fetch all factors and their associated weights from the plugin_factor_table
+    for row in cur.execute("SELECT * FROM plugin_factor_table"):
+        # create a JSON payload with the results of the query
+        single_factor_data = {
+            "factor": str(row[0]),
+            "weight": int(row[1]),
+        }
+        bulk_factor_data.append(single_factor_data)
+
+    data = {"data": bulk_factor_data}
+
+    flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(data)).get()
 
     flux.Flux().rpc("job-manager.mf_priority.reprioritize")
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -18,6 +18,7 @@ from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import job_archive_interface as jobs
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import queue_subcommands as qu
+from fluxacct.accounting import plugin_factor_subcommands as p
 
 
 def add_path_arg(parser):
@@ -376,6 +377,29 @@ def add_delete_queue_arg(subparsers):
     subparser_delete_queue.add_argument("queue", help="queue name", metavar="QUEUE")
 
 
+def add_view_factor_arg(subparsers):
+    subparser_view_factor = subparsers.add_parser(
+        "view-plugin-factor", help="view a plugin factor and its associated weight"
+    )
+    subparser_view_factor.set_defaults(func="view_factor")
+    subparser_view_factor.add_argument(
+        "factor", type=str, help="factor name", metavar="FACTOR"
+    )
+
+
+def add_edit_factor_arg(subparsers):
+    subparser_edit_factor = subparsers.add_parser(
+        "edit-plugin-factor", help="edit a plugin factor's associated weight"
+    )
+    subparser_edit_factor.set_defaults(func="edit_factor")
+    subparser_edit_factor.add_argument(
+        "factor", type=str, help="factor name", metavar="FACTOR"
+    )
+    subparser_edit_factor.add_argument(
+        "--weight", type=int, help="associated weight", default=None, metavar="WEIGHT"
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -394,6 +418,8 @@ def add_arguments_to_parser(parser, subparsers):
     add_view_queue_arg(subparsers)
     add_edit_queue_arg(subparsers)
     add_delete_queue_arg(subparsers)
+    add_view_factor_arg(subparsers)
+    add_edit_factor_arg(subparsers)
 
 
 def set_db_location(args):
@@ -498,6 +524,10 @@ def select_accounting_function(args, conn, output_file, parser):
             args.max_time_per_job,
             args.priority,
         )
+    elif args.func == "view_factor":
+        p.view_factor(conn, args.factor)
+    elif args.func == "edit_factor":
+        p.edit_factor(conn, args.factor, args.weight)
     else:
         print(parser.print_usage())
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -85,8 +85,9 @@ int64_t priority_calculation (flux_plugin_t *p,
     int fshare_weight, queue_weight;
     struct bank_info *b;
 
-    fshare_weight = 100000;
-    queue_weight = 10000;
+    // fetch associated weights of all of the priority factors
+    fshare_weight = plugin_factors["fairshare"];
+    queue_weight = plugin_factors["queue"];
 
     if (urgency == FLUX_JOB_URGENCY_HOLD)
         return FLUX_JOB_PRIORITY_MIN;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -15,7 +15,8 @@ TESTSCRIPTS = \
 	t1011-job-archive-interface.t \
 	t1012-mf-priority-load.t \
 	t1013-mf-priority-queues.t \
-	t1014-mf-priority-dne.t
+	t1014-mf-priority-dne.t \
+	t1015-mf-priority-weights.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -77,6 +77,13 @@ test_expect_success 'create fake_payload.py' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_fac_data = {
+		"data" : [
+			{"factor": "fairshare", "weight": 100000},
+			{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_fac_data)).get()
 	EOF
 '
 

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -41,7 +41,7 @@ test_expect_success 'send the user information to the plugin' '
 	flux python ${SEND_PAYLOAD} fake_small_no_tie.json
 '
 
-test_expect_success 'add a default queue and send it to the plugin' '
+test_expect_success 'add a default queue and plugin weights and send it to the plugin' '
 	cat <<-EOF >fake_payload.py
 	import flux
 	import json
@@ -58,6 +58,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_fac_data = {
+		"data" : [
+			{"factor": "fairshare", "weight": 100000},
+			{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_fac_data)).get()
 	EOF
 	flux python fake_payload.py
 '

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -42,7 +42,7 @@ test_expect_success 'send the user information to the plugin' '
 	flux python ${SEND_PAYLOAD} fake_small_tie.json
 '
 
-test_expect_success 'add a default queue and send it to the plugin' '
+test_expect_success 'add a default queue and plugin weights and send it to the plugin' '
 	cat <<-EOF >fake_payload.py
 	import flux
 	import json
@@ -59,6 +59,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_fac_data = {
+		"data" : [
+			{"factor": "fairshare", "weight": 100000},
+			{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_fac_data)).get()
 	EOF
 	flux python fake_payload.py
 '

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -43,7 +43,7 @@ test_expect_success 'send the user information to the plugin' '
 	flux python ${SEND_PAYLOAD} fake_small_tie_all.json
 '
 
-test_expect_success 'add a default queue and send it to the plugin' '
+test_expect_success 'add a default queue and plugin weights and send it to the plugin' '
 	cat <<-EOF >fake_payload.py
 	import flux
 	import json
@@ -60,6 +60,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_fac_data = {
+		"data" : [
+			{"factor": "fairshare", "weight": 100000},
+			{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_fac_data)).get()
 	EOF
 	flux python fake_payload.py
 '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -52,7 +52,7 @@ test_expect_success 'update plugin with sample test data' '
 	flux python ${SEND_PAYLOAD} fake_user.json
 '
 
-test_expect_success 'add a default queue and send it to the plugin' '
+test_expect_success 'add a default queue and plugin weights and send it to the plugin' '
 	cat <<-EOF >fake_payload.py
 	import flux
 	import json
@@ -69,6 +69,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_fac_data = {
+		"data" : [
+			{"factor": "fairshare", "weight": 100000},
+			{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_fac_data)).get()
 	EOF
 	flux python fake_payload.py
 '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -167,6 +167,28 @@ test_expect_success 'remove a queue from the queue_table' '
 	grep "Queue not found in queue_table" deleted_queue.out
 '
 
+test_expect_success 'view plugin factor information' '
+	flux account -p ${DB_PATH} view-plugin-factor fairshare > fshare_factor.test &&
+	grep "fairshare          100000" fshare_factor.test
+'
+
+test_expect_success 'edit a plugin factor successfully' '
+	flux account -p ${DB_PATH} edit-plugin-factor fairshare --weight=1234 &&
+	flux account -p ${DB_PATH} view-plugin-factor fairshare > fshare_factor_edited.test &&
+	grep "fairshare          1234" fshare_factor_edited.test
+'
+
+test_expect_success 'try to edit a plugin factor with a bad type' '
+	test_must_fail flux account -p ${DB_PATH} edit-plugin-factor fairshare --weight=foo > bad_type.out 2>&1 &&
+	test_debug "bad_type.out" &&
+	grep "edit-plugin-factor: error: argument --weight: invalid int value:" bad_type.out
+'
+
+test_expect_success 'try to view a plugin factor that does not exist' '
+	flux account -p ${DB_PATH} view-plugin-factor foo > no_such_factor.out &&
+	grep "Factor not found in plugin_factor_table" no_such_factor.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -49,6 +49,13 @@ test_expect_success 'create fake_payload.py' '
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_factor_data = {
+		"data" : [
+				{"factor": "fairshare", "weight": 100000},
+				{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_factor_data)).get()
 	flux.Flux().rpc("job-manager.mf_priority.reprioritize")
 	EOF
 '

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -62,6 +62,13 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	bulk_fac_data = {
+		"data" : [
+			{"factor": "fairshare", "weight": 100000},
+			{"factor": "queue", "weight": 10000}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", json.dumps(bulk_fac_data)).get()
 	EOF
 	flux python fake_payload.py
 '

--- a/t/t1015-mf-priority-weights.t
+++ b/t/t1015-mf-priority-weights.t
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+test_description='Test configuring plugin weights and their effects on priority calculation'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1
+'
+
+test_expect_success 'add a default queue to the DB' '
+	flux account -p ${DB_PATH} add-queue default --priority=100
+'
+
+test_expect_success 'add a user to the DB' '
+	username=$(whoami) &&
+	uid=$(id -u) &&
+	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account1 --shares=1
+'
+
+test_expect_success 'view queue information' '
+	flux account -p ${DB_PATH} view-plugin-factor fairshare > fshare_weight.test &&
+	grep "fairshare          100000" fshare_weight.test &&
+	flux account -p ${DB_PATH} view-plugin-factor queue > queue_weight.test &&
+	grep "queue              10000" queue_weight.test
+'
+
+test_expect_success 'send the user, queue, and plugin factor weight information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job using default fshare and queue factor weights' '
+	jobid1=$(flux mini submit -n1 hostname) &&
+	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
+	cat <<-EOF >job1.expected &&
+	1050000
+	EOF
+	test_cmp job1.expected job1.test
+'
+
+test_expect_success 'edit plugin factor weights to give fairshare all the weight' '
+	flux account -p ${DB_PATH} edit-plugin-factor fairshare --weight=1000 &&
+	flux account -p ${DB_PATH} edit-plugin-factor queue --weight=0 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job using the new fshare and queue factor weights' '
+	jobid2=$(flux mini submit -n1 hostname) &&
+	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
+	cat <<-EOF >job2.expected &&
+	500
+	EOF
+	test_cmp job2.expected job2.test
+'
+
+test_expect_success 'edit plugin factor weights to give queue all the weight' '
+	flux account -p ${DB_PATH} edit-plugin-factor fairshare --weight=0 &&
+	flux account -p ${DB_PATH} edit-plugin-factor queue --weight=1000 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job using the new fshare and queue factor weights' '
+	jobid3=$(flux mini submit -n1 hostname) &&
+	flux job wait-event -f json $jobid3 priority | jq '.context.priority' > job3.test &&
+	cat <<-EOF >job3.expected &&
+	100000
+	EOF
+	test_cmp job3.expected job3.test
+'
+
+test_done


### PR DESCRIPTION
~~_This is a PR built on top of #207, a PR proposing adding a queue factor to priority calculation in the plugin._~~

#### Background

As more and more factors get added to the multi-factor priority plugin, there comes a need for configuring the weight of each factor to be more or less important in the overall calculation of a job's priority. For example, a scheduler operator may want to emphasize the importance of a user/bank's fairshare over what queue a job is submitted in, or vice versa.

Currently, the priority plugin defines the weights for each factor in the `priority_calculation()` function, which means the weights of both the **fairshare** and **queue** factors cannot be changed by a scheduler operator or sys admin.

---

This ~~[WIP]~~ PR looks to add configurable weights to both the flux-accounting DB and the priority plugin by adding a new table to the flux-accounting DB called `plugin_factor_table`. It will store all plugin factors and their associated weights, which are created when the database is first created. Commands to both view and edit these commands are also added, called `view-plugin-factor` and `edit-plugin-factor`, respectively. 

These factors and their weights are included in the bulk update script, where it is then unpacked by the plugin into a map, with the name of the factor as the key, and its associated weight as the value. Its weight is then fetched in `priority_calculation()` when calculating the priority of a user/bank combo's job. 

Both unit tests and sharness tests are added for the new commands and their effects on priority calculation in `t1013-plugin-weights.t`, which adds a user/bank combo who submits jobs under a number of different weight configurations for the various plugin factors.

Fixes #128