### PR TITLE
flux-accounting: add `etc/` directory, `rc1` script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,3 +14,6 @@ CODE_COVERAGE_IGNORE_PATTERN = \
     "/usr/lib/*"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
+
+dist_fluxrc1_SCRIPTS = \
+    etc/01-flux-account-priority-update

--- a/etc/01-flux-account-priority-update
+++ b/etc/01-flux-account-priority-update
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if test $(flux getattr rank) -eq 0 \
+    && flux jobtap list | grep -q mf_priority.so; then
+     flux account-priority-update || true
+fi


### PR DESCRIPTION
_I'm posting this as an early work-in-progress, as I'm not sure I have everything required to add an `rc1` script to flux-accounting just yet, but I figured I would post it now._

#### Problem

As noted in #221, when the multi-factor priority plugin is re-loaded after a `systemctl restart flux`, `flux account-priority-update` has to be run again in order to re-populate the plugin with the user/bank information from the flux-accounting database. A suggestion was made to see if the data sent to the plugin could be initiated automatically so that the `flux account-priority-update` command does not have to be manually run again.

---

This PR adds an `etc/` directory to flux-accounting and adds an `rc1` script named `01-flux-account-priority-update`, which will attempt to populate a loaded multi-factor priority plugin with user/bank information from the flux-accounting DB on a system start or restart.

In the `Makefile.am`, `01-flux-account-priority-update` gets added to `dist_fluxrc1_SCRIPTS`, that when installed, is located in `/usr/etc/flux/rc1.d/`. I did some dummy testing in an interactive Docker container where I created a flux-accounting DB, loaded the plugin, and then ran `01-flux-account-priority-update` to ensure the information did in fact get sent and I could submit jobs. 

I just had a couple of questions as I am pretty unfamiliar with rc scripts, so I apologize in advance if the following questions are dumb 😅 :

1) I imagine the script could check that the priority plugin is loaded before it calls `flux account-priority-update`? Is there a way to do that in `bash`?

2) The `flux account-priority-update` command in the script doesn't have a path passed to it, so it will attempt to use the default path for the flux-accounting DB, located in `/var/lib/flux/`. Is that okay? 

3) Is it typical to add tests for these scripts? Maybe sharness tests?