### PR TITLE
flux-accounting: miscellaneous fixes, improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 [![Build Status](https://travis-ci.org/flux-framework/flux-accounting.svg?branch=master)](https://travis-ci.org/flux-framework/flux-accounting)
 [![codecov](https://codecov.io/gh/flux-framework/flux-accounting/branch/master/graph/badge.svg)](https://codecov.io/gh/flux-framework/flux-accounting)
 
-_NOTE: The interfaces of flux-accounting are being actively developed and are not yet stable. The Github issue tracker is the primary way to communicate with the developers._
+_NOTE: The interfaces of flux-accounting are being actively developed and are
+not yet stable. The Github issue tracker is the primary way to communicate with
+the developers._
 
 ## flux-accounting
 
-Development for a bank/accounting interface for the Flux resource manager. Writes and saves user account information to persistent storage using Python's SQLite3 API.
+Development for a bank/accounting interface for the Flux resource manager.
+Writes and saves user account information to persistent storage using Python's
+SQLite3 API.
 
 ### Install Instructions
 
@@ -18,7 +22,11 @@ make -j
 make check
 ```
 
-To configure flux-accounting with a specific version of Python, pass the `PYTHON_VERSION` environment variable on the `./configure` line (_note: flux-accounting needs to be configured against the same version of Python as flux-core that it is configured against; this is the default behavior of `./configure` if you choose the same prefix for flux-core and flux-accounting_):
+To configure flux-accounting with a specific version of Python, pass the
+`PYTHON_VERSION` environment variable on the `./configure` line (_note: flux-
+accounting needs to be configured against the same version of Python as
+flux-core that it is configured against; this is the default behavior of
+`./configure` if you choose the same prefix for flux-core and flux-accounting_):
 
 ```console
 PYTHON_VERSION=3.7 ./configure --localstatedir=/var/
@@ -26,31 +34,53 @@ PYTHON_VERSION=3.7 ./configure --localstatedir=/var/
 
 ### Configuring flux-accounting background scripts
 
-There are a number of scripts that run in the background to update both job usage and fairshare values. These require configuration upon setup of flux-accounting. The first thing to configure when first setting up the flux-accounting database is to set the PriorityUsageResetPeriod and PriorityDecayHalfLife parameters. Both of these parameters represent a number of weeks by which to hold usage factors up to the time period where jobs no longer play a factor in calculating a usage factor. If these parameters are not passed when creating the DB, PriorityDecayHalfLife is set to 1 week and PriorityUsageResetPeriod is set to 4 weeks, i.e the flux-accounting database will store up to a month's worth of jobs broken up into one week chunks:
+There are a number of scripts that run in the background to update both job
+usage and fairshare values. These require configuration upon setup of
+flux-accounting. The first thing to configure when first setting up the
+flux-accounting database is to set the PriorityUsageResetPeriod and
+PriorityDecayHalfLife parameters. Both of these parameters represent a number of
+weeks by which to hold usage factors up to the time period where jobs no longer
+play a factor in calculating a usage factor. If these parameters are not passed
+when creating the DB, PriorityDecayHalfLife is set to 1 week and
+PriorityUsageResetPeriod is set to 4 weeks, i.e the flux-accounting database
+will store up to a month's worth of jobs broken up into one week chunks:
 
 ```
 flux account create-db --priority-decay-half-life=2 --priority-usage-reset-period=8
 ```
 
-The other component to load is the multi-factor priority plugin, which can be loaded with `flux jobtap load`:
+The other component to load is the multi-factor priority plugin, which can be
+loaded with `flux jobtap load`:
 
 ```
 flux jobtap load mf_priority.so
 ```
 
-After the DB and job priority plugin are set up, the `update-usage` subcommand should be set up to run as a cron job. This subcommand fetches the most recent job records for every user in the flux-accounting DB and calculates a new job usage value. This subcommand takes one optional argument, `--priority-decay-half-life`, which, like the parameter set in the database creation step above, represents the number of weeks to hold one job usage "chunk." If not specified, this optional argument also defaults to 1 week.
+After the DB and job priority plugin are set up, the `update-usage` subcommand
+should be set up to run as a cron job. This subcommand fetches the most recent
+job records for every user in the flux-accounting DB and calculates a new job
+usage value. This subcommand takes one optional argument,
+`--priority-decay-half-life`, which, like the parameter set in the database
+creation step above, represents the number of weeks to hold one job usage
+"chunk." If not specified, this optional argument also defaults to 1 week.
 
 ```
 flux account update-usage --priority-decay-half-life=2 path/to/job-archive-DB
 ```
 
-After the job usage values are re-calculated and updated, the fairshare values for each user also need to be updated. This can be accomplished by configuring the `flux-update-fshare` script to also run as a cron job. This fetches user account data from the flux-accounting DB and recalculates and writes the updated fairshare values back to the DB.
+After the job usage values are re-calculated and updated, the fairshare values
+for each user also need to be updated. This can be accomplished by configuring
+the `flux-update-fshare` script to also run as a cron job. This fetches user
+account data from the flux-accounting DB and recalculates and writes the updated
+fairshare values back to the DB.
 
 ```
 flux account-update-fshare
 ```
 
-Once the fairshare values for all of the users in the flux-accounting DB get updated, this updated information will be sent to the priority plugin. This script can be also be configured to run as a cron job:
+Once the fairshare values for all of the users in the flux-accounting DB get
+updated, this updated information will be sent to the priority plugin. This
+script can be also be configured to run as a cron job:
 
 ```
 flux account-priority-update
@@ -86,45 +116,42 @@ optional arguments:
                         specify location of output file
 ```
 
-To run the unit tests in a Docker container, you can use `docker build -f <path/to/Dockerfile> .` from the flux-accounting directory:
+To run the unit tests in a Docker container, or launch into an interactive container on your local machine, you can run `docker-run-checks.sh`:
 
 ```
-$ docker build -f accounting/test/docker/ubuntu/Dockerfile.ubuntu .
-Sending build context to Docker daemon  299.9MB
-Step 1/5 : FROM ubuntu:latest
- ---> 1d622ef86b13
-Step 2/5 : LABEL maintainer="Christopher Moussa <moussa1@llnl.gov>"
- ---> Using cache
- ---> bdbc2ff632a5
-Step 3/5 : ADD . src/
- ---> 7da92dbd8852
- .
- .
- .
- Step 5/5 : RUN cd src/   && pip3 install -r requirements.txt   && tox
- .
- .
- .
- Installing collected packages: pytz, numpy, six, python-dateutil, pandas
- Successfully installed numpy-1.19.4 pandas-0.25.3 python-dateutil-2.8.1 pytz-2020.4 six-1.15.0
- .....................................
- ----------------------------------------------------------------------
- Ran 37 tests in 0.516s
+$ ./src/test/docker/docker-run-checks.sh --no-cache --no-home -I --
+Building image el8 for user <username> <userid> group=20
+[+] Building 0.7s (7/7) FINISHED
 
- OK
+.
+.
+.
+
+mounting /Users/moussa1/src/flux-framework/flux-accounting as /usr/src
+[moussa1@docker-desktop src]$
 ```
 
 ### User Account Information
 
-The accounting table in this database stores information like user name and ID, the bank to submit jobs against, the shares allocated to the user, as well as static limits, including max jobs submitted per user at a given time and max wall time per job per user.
+The accounting table in this database stores information like username and
+ID, banks to submit jobs against, allocated shares to the user, as well as
+static limits, including a max number of running jobs at a given time and
+a max number of submitted jobs per user/bank combo.
 
 ### Interacting With the Accounting DB
 
-In order to add, edit, or remove information from the flux-accounting database, you must also have read/write access to the directory that the DB file resides in. The [SQLite documentation](https://sqlite.org/omitted.html) states:
+In order to add, edit, or remove information from the flux-accounting database,
+you must also have read/write access to the directory that the DB file resides
+in. The [SQLite documentation](https://sqlite.org/omitted.html) states:
 
-> Since SQLite reads and writes an ordinary disk file, the only access permissions that can be applied are the normal file access permissions of the underlying operating system.
+> Since SQLite reads and writes an ordinary disk file, the only access
+permissions that can be applied are the normal file access permissions of the
+underlying operating system.
 
-There are two ways you can interact with the tables contained in the Accounting DB. The first way is to launch into an interactive SQLite shell. From there, you can open the database file and interface with any of the tables using SQLite commands:
+There are two ways you can interact with the tables contained in the Accounting
+DB. The first way is to launch into an interactive SQLite shell. From there, you
+can open the database file and interface with any of the tables using SQLite
+commands:
 
 ```
 $ sqlite3 path/to/FluxAccounting.db
@@ -137,7 +164,8 @@ sqlite> .tables
 association_table bank_table
 ```
 
-To get nicely formatted output from queries (like headers for the tables and proper spacing), you can also set the following options in your shell:
+To get nicely formatted output from queries (like headers for the tables and
+proper spacing), you can also set the following options in your shell:
 
 ```
 sqlite> .mode columns
@@ -153,9 +181,13 @@ creation_time  mod_time    deleted     username    bank        shares      max_j
 1605309320     1605309320  0           fluxuser    foo         1           1           60       
 ```
 
-The second way is to use flux-accounting's command line arguments. You can pass in a path to the database file, or it will default to the "compiled-in" path of `${prefix}/var/FluxAccounting.db`.
+The second way is to use flux-accounting's command line arguments. You can pass in
+a path to the database file, or it will default to the "compiled-in" path of
+`${prefix}/var/FluxAccounting.db`.
 
-With flux-accounting's command line tools, you can view a user's account information, add and remove users to the accounting database, and edit an existing user's account information:
+With flux-accounting's command line tools, you can view a user's account
+information, add and remove users to the accounting database, and edit an existing
+user's account information:
 
 ```
 $ flux account view-user fluxuser

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -89,7 +89,6 @@ def create_db(
             CREATE TABLE IF NOT EXISTS association_table (
                 creation_time    bigint(20)                NOT NULL,
                 mod_time         bigint(20)  DEFAULT 0     NOT NULL,
-                deleted          tinyint(4)  DEFAULT 0     NOT NULL,
                 username         tinytext                  NOT NULL,
                 userid           int(11)     DEFAULT 65534 NOT NULL,
                 bank             tinytext                  NOT NULL,

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -62,10 +62,10 @@ class TestDB(unittest.TestCase):
         conn.execute(
             """
             INSERT INTO association_table
-            (creation_time, mod_time, deleted, username, userid,
+            (creation_time, mod_time, username, userid,
             bank, default_bank, shares, queues)
             VALUES
-            (0, 0, 0, "test user", 1234, "test account", "test_account", 0, "")
+            (0, 0, "test user", 1234, "test account", "test_account", 0, "")
             """
         )
         cursor = conn.cursor()

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -101,16 +101,15 @@ def add_user(
         # insert the user values into association_table
         conn.execute(
             """
-            INSERT INTO association_table (creation_time, mod_time, deleted,
-                                           username, userid, bank, default_bank,
-                                           shares, max_running_jobs,
-                                           max_active_jobs, queues)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO association_table (creation_time, mod_time, username,
+                                           userid, bank, default_bank, shares,
+                                           max_running_jobs, max_active_jobs,
+                                           queues)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
                 int(time.time()),
-                0,
                 username,
                 uid,
                 bank,

--- a/src/cmd/flux-account-pop-db.py
+++ b/src/cmd/flux-account-pop-db.py
@@ -77,8 +77,9 @@ def populate_db(path, users=None, banks=None):
                     uid = row[1]
                     bank = row[2]
                     shares = row[3] if row[3] != "" else 1
-                    max_jobs = row[4] if row[4] != "" else 5
-                    qos = row[5]
+                    max_running_jobs = row[4] if row[4] != "" else 5
+                    max_active_jobs = row[5] if row[5] != "" else 7
+                    queues = row[6]
 
                     u.add_user(
                         conn,
@@ -86,8 +87,9 @@ def populate_db(path, users=None, banks=None):
                         bank,
                         uid,
                         shares,
-                        max_jobs,
-                        qos,
+                        max_running_jobs,
+                        max_active_jobs,
+                        queues,
                     )
         except IOError as err:
             print(err)
@@ -100,9 +102,10 @@ def main():
 
         Order of elements required for populating association_table:
 
-        Username,UserID,Bank,Shares,MaxJobs,QOS
+        Username,UserID,Bank,Shares,MaxRunningJobs,MaxActiveJobs,Queues
 
-        [Shares] and [MaxJobs] can be left blank ('') in .csv file for a given row.
+        [Shares], [MaxRunningJobs], and [MaxActiveJobs] can be left blank ('') in
+        the .csv file for a given row.
 
         ----------------
 

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -26,11 +26,11 @@ test_expect_success 'populate flux-accounting DB with banks.csv' '
 
 test_expect_success 'create a users.csv file containing user information' '
 	cat <<-EOF >users.csv
-	user1000,1000,A,1,10,""
-	user1001,1001,A,1,10,""
-	user1002,1002,A,1,10,""
-	user1003,1003,A,1,10,""
-	user1004,1004,A,1,10,""
+	user1000,1000,A,1,10,15,""
+	user1001,1001,A,1,10,15,""
+	user1002,1002,A,1,10,15,""
+	user1003,1003,A,1,10,15,""
+	user1004,1004,A,1,10,15,""
 	EOF
 '
 
@@ -45,11 +45,11 @@ test_expect_success 'check database hierarchy to make sure all banks & users wer
 
 test_expect_success 'create a users.csv file with some missing optional user information' '
 	cat <<-EOF >users_optional_vals.csv
-	user1005,1005,B,1,5,""
-	user1006,1006,B,,,""
-	user1007,1007,B,1,7,""
-	user1008,1008,B,,,""
-	user1009,1009,B,1,9,""
+	user1005,1005,B,1,5,,""
+	user1006,1006,B,,,,""
+	user1007,1007,B,1,7,,""
+	user1008,1008,B,,,,""
+	user1009,1009,B,1,9,,""
 	EOF
 '
 


### PR DESCRIPTION
Not a super high priority item, just some random fixes throughout the project I wanted to get posted.

* The `pop-db` command is updated to include the new `max_active_jobs` and `max_running_jobs` columns from the `association_table`. The outdated `QoS` column is replaced with `Queues`.
* The 'deleted' column in the `association_table` won't be able to actually represent a deleted row from the table
since the row is actually removed from the table itself, so just remove the column from the table.
* Some of the lines in `README.md` go way over ~~60~~ 80 characters, so break up those long lines into multiple lines.
