### PR TITLE
plugin: allow user/bank information to be loaded late, add job.new callback

### DIFF
--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -70,6 +70,7 @@ def bulk_update(path):
     data = {"data": bulk_user_data}
 
     flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(data)).get()
+    flux.Flux().rpc("job-manager.mf_priority.reprioritize")
 
 
 def main():

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -12,7 +12,8 @@ TESTSCRIPTS = \
 	t1008-mf-priority-update.t \
 	t1009-pop-db.t \
 	t1010-update-usage.t \
-	t1011-job-archive-interface.t
+	t1011-job-archive-interface.t \
+	t1012-mf-priority-load.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -21,12 +21,6 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'try to submit a job when user does not exist in DB' '
-	test_must_fail flux mini submit -n1 hostname > failure.out 2>&1 &&
-	test_debug "cat failure.out" &&
-	grep "user not found in flux-accounting DB" failure.out
-'
-
 test_expect_success 'send an empty payload to make sure unpack fails' '
 	cat <<-EOF >bad_payload.py &&
 	import flux

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin with a single user'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create fake_payload.py' '
+	cat <<-EOF >fake_payload.py
+	import flux
+	import pwd
+	import getpass
+	import json
+
+	username = getpass.getuser()
+	userid = pwd.getpwnam(username).pw_uid
+	# create an array of JSON payloads
+	bulk_update_data = {
+		"data" : [
+			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 1, "max_active_jobs": 3},
+			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 3}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
+	flux.Flux().rpc("job-manager.mf_priority.reprioritize")
+	EOF
+'
+
+test_expect_success 'submitting a job specifying an incorrect bank with no user data results in a job exception' '
+	jobid0=$(flux mini submit --setattr=system.bank=account4 -n1 sleep 60) &&
+	flux python fake_payload.py &&
+	flux job wait-event -v ${jobid0} exception > exception.test &&
+	grep "not a member of account4" exception.test
+'
+
+test_expect_success 'unload and reload mf_priority.so' '
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'submit sleep 60 jobs with no data update' '
+	jobid1=$(flux mini submit -n1 sleep 60)
+'
+
+test_expect_success 'check that submitted job is in state PRIORITY' '
+	test $(flux jobs -no {state} ${jobid1}) = PRIORITY
+'
+
+test_expect_success 'update plugin with sample test data again' '
+	flux python fake_payload.py
+'
+
+test_expect_success 'check that previously held job transitions to RUN' '
+	test $(flux jobs -no {state} ${jobid1}) = RUN
+'
+
+test_expect_success 'submit 2 more sleep jobs' '
+	jobid2=$(flux mini submit -n1 sleep 60) &&
+	jobid3=$(flux mini submit -n1 sleep 60)
+'
+
+test_expect_success 'check flux jobs - should have 1 running job, 2 pending jobs' '
+	test $(flux jobs -no {state} ${jobid1}) = RUN &&
+	test $(flux jobs -no {state} ${jobid2}) = DEPEND &&
+	test $(flux jobs -no {state} ${jobid3}) = DEPEND
+'
+
+test_expect_success 'cancel running jobs one at a time and check that each pending job transitions to RUN' '
+	flux job cancel $jobid1 &&
+	test $(flux jobs -no {state} ${jobid2}) = RUN &&
+	flux job cancel $jobid2 &&
+	test $(flux jobs -no {state} ${jobid3}) = RUN &&
+	flux job cancel $jobid3
+'
+
+test_expect_success 'unload mf_priority.so' '
+	flux jobtap remove mf_priority.so
+'
+
+test_expect_success 'submit a job with no plugin loaded' '
+	jobid4=$(flux mini submit -n 1 sleep 60) &&
+	test $(flux jobs -no {state} ${jobid4}) = PRIORITY
+'
+
+test_expect_success 'reload mf_priority.so with a job still in job.state.priority' '
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
+	test $(flux jobs -no {state} ${jobid4}) = PRIORITY
+'
+
+test_expect_success 'update plugin with sample test data again' '
+	flux python fake_payload.py
+'
+
+test_expect_success 'check that originally pending job transitions to RUN' '
+	test $(flux jobs -no {state} ${jobid4}) = RUN &&
+	flux job cancel $jobid4
+'
+
+test_done


### PR DESCRIPTION
#### Background

The plugin currently rejects jobs in `job.validate` when it cannot find the userid of the user/bank combo submitting the job in its internal map data structure. A suggestion was made in #222 to change this behavior to instead hold the job until the correct information was received. Then, upon a data update via `flux account-priority-update`, the plugin could reprioritize all jobs using `flux_jobtap_reprioritize_all ()` with the newly pushed information and release any jobs still waiting on user/bank information.

---

This PR looks to add support for holding jobs when the user/bank information cannot be found in the plugin's internal map. It removes the rejection in `job.validate` and instead creates a special temporary entry in the users map and sets a special `max_run_jobs` value to let the `job.state.priority` callback know to return `flux_jobtap_priority_unavail ()` on this and future submitted jobs from this user until we get their information from the flux-accounting DB.

It also adds a new callback to the plugin for `job.new`, which does much of the same user/bank lookup as `job.validate`, but this callback also includes the accounting for newly submitted jobs by incrementing the user/bank's active jobs count. Like `job.validate`, it will also create a special entry for user/bank combos when it cannot find the user in its internal map, which subsequently holds the submitted job by returning `flux_jobtap_priority_unavail ()`. The `job.new` callback is inserted to handle the following cases (referenced from flux-core's [manpage](https://github.com/flux-framework/flux-core/blob/master/doc/man7/flux-jobtap-plugins.rst) on jobtap plugins):

- on job submission
- when the job manager is restarted and has reloaded a job from the KVS
- when a new plugin is loaded

A new service is also added to the priority plugin, which, when called, will call `flux_jobtap_reprioritize_all ()` on all jobs. This will attempt to assign a priority to jobs that are currently held due to missing user/bank information.

Finally, this PR adds a second lookup on held jobs due to missing user/bank information in `job.state.priority`. If no user/bank information is found, `flux_jobtap_priority_unavail ()` is returned and the job is held in PRIORITY state. If updated information is found, it will update both the current job's `bank_info` struct so that a valid priority can be calculated for the job as well as update the `cur_active_jobs` and `cur_run_jobs` counters in the internal users map since the job will not transition back to `job.state.depend` or `job.new`.

Basic tests are added in a new sharness test file `t1012-mf-priority-load`. This test file goes through the following scenario:

1. the plugin is loaded but no user/bank information has been sent from the database to the plugin yet
2. a user/bank combo submits a job to the plugin; it gets held since no information about the user/bank was found in the plugin yet
3. information for the user gets pushed to the plugin and the trigger callback gets activated, which runs `flux_jobtap_reprioritize_all ()`
4. the previously held job transitions to RUN state
5. more jobs are submitted to check that the user/bank's `max_run_jobs` is correctly enforced

The test for a successful job rejection in `t1001-mf-priority-basic.t` has also been removed since that is not the behavior of the plugin anymore.

##### TODO

###### fix commit message for "plugin: add job.new callback" ✅
###### add call to "trigger" callback in `flux account-priority-update` ✅
###### change name of sharness test file to match other plugin sharness tests ✅
###### edit commit message for Python black formatter commit ✅