### PR TITLE
ci: pin click package to 8.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         pip install -r requirements.txt
     - name: Lint with black
       run: |
-        pip install black==20.8b1
+        pip install --upgrade black==20.8b1 click==8.0.2
         # return the status of running black formatter
         black . --check
 


### PR DESCRIPTION
#### Problem

A recent release of `click` breaks the version of `black` used in flux-accounting's GitHub Actions as noted by this issue thread:

https://github.com/psf/black/issues/2964

---

Pin the `click` package to 8.0.2 to prevent the break (reference: https://stackoverflow.com/questions/71673404)

I think since this PR modifies GitHub actions, it might need a manual merge? 