### PR TITLE
plugin: change behavior for users who have extremely low/zero fairshare

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -554,11 +554,6 @@ static int validate_cb (flux_plugin_t *p,
     cur_active_jobs = bank_it->second.cur_active_jobs;
     max_active_jobs = bank_it->second.max_active_jobs;
 
-    // if a user's fairshare value is 0, that means they shouldn't be able
-    // to run jobs on a system
-    if (fairshare == 0)
-        return flux_jobtap_reject_job (p, args, "user fairshare value is 0");
-
     // if a user/bank has reached their max_active_jobs limit, subsequently
     // submitted jobs will be rejected
     if (max_active_jobs > 0 && cur_active_jobs >= max_active_jobs)
@@ -651,11 +646,6 @@ static int new_cb (flux_plugin_t *p,
 
         b = &bank_it->second;
     }
-
-    // if a user's fairshare value is 0, that means they shouldn't be able
-    // to run jobs on a system
-    if (fairshare == 0)
-        return flux_jobtap_reject_job (p, args, "user fairshare value is 0");
 
     // if a user/bank has reached their max_active_jobs limit, subsequently
     // submitted jobs will be rejected

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -151,35 +151,6 @@ test_expect_success 'reject job when invalid bank format is passed in' '
 	grep "unable to unpack bank arg" invalid_fmt.out
 '
 
-test_expect_success 'create a fake payload with a 0 fairshare key-value pair' '
-	cat <<-EOF >empty_fairshare.py
-	import flux
-	import pwd
-	import getpass
-	import json
-
-	username = getpass.getuser()
-	userid = pwd.getpwnam(username).pw_uid
-	# create an array of JSON payloads
-	bulk_update_data = {
-		"data" : [
-			{"userid": userid, "bank": "account4", "def_bank": "account3", "fairshare": 0.0, "max_running_jobs": 10, "max_active_jobs": 12}
-		]
-	}
-	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()
-	EOF
-'
-
-test_expect_success 'update plugin with sample test data' '
-	flux python empty_fairshare.py
-'
-
-test_expect_success 'submit a job with new bank and 0 fairshare should result in a job rejection' '
-	test_must_fail flux mini submit --setattr=system.bank=account4 hostname > zero_fairshare.out 2>&1 &&
-	test_debug "zero_fairshare.out" &&
-	grep "user fairshare value is 0" zero_fairshare.out
-'
-
 test_expect_success 'pass special key to user/bank struct to nullify information' '
 	cat <<-EOF >null_struct.json
 	{

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -90,7 +90,8 @@ test_expect_success 'submit a job with default urgency' '
 	cat <<-EOF >job1.expected &&
 	45321
 	EOF
-	test_cmp job1.expected job1.test
+	test_cmp job1.expected job1.test &&
+	flux job cancel $jobid
 '
 
 test_expect_success 'submit a job with custom urgency' '
@@ -99,7 +100,8 @@ test_expect_success 'submit a job with custom urgency' '
 	cat <<-EOF >job2.expected &&
 	45320
 	EOF
-	test_cmp job2.expected job2.test
+	test_cmp job2.expected job2.test &&
+	flux job cancel $jobid
 '
 
 test_expect_success 'submit a job with urgency of 0' '
@@ -118,7 +120,8 @@ test_expect_success 'submit a job with urgency of 31' '
 	cat <<-EOF >job4.expected &&
 	4294967295
 	EOF
-	test_cmp job4.expected job4.test
+	test_cmp job4.expected job4.test &&
+	flux job cancel $jobid
 '
 
 test_expect_success 'submit a job with other bank' '
@@ -127,7 +130,8 @@ test_expect_success 'submit a job with other bank' '
 	cat <<-EOF >job5.expected &&
 	11345
 	EOF
-	test_cmp job5.expected job5.test
+	test_cmp job5.expected job5.test &&
+	flux job cancel $jobid
 '
 
 test_expect_success 'submit a job using default bank' '
@@ -136,7 +140,8 @@ test_expect_success 'submit a job using default bank' '
 	cat <<-EOF >job6.expected &&
 	45321
 	EOF
-	test_cmp job6.expected job6.test
+	test_cmp job6.expected job6.test &&
+	flux job cancel $jobid
 '
 
 test_expect_success 'submit a job using a bank the user does not belong to' '
@@ -201,7 +206,8 @@ test_expect_success 'resend user/bank information with valid data and successful
 	cat <<-EOF >job2.expected &&
 	45321
 	EOF
-	test_cmp job2.expected job2.test
+	test_cmp job2.expected job2.test &&
+	flux job cancel $jobid2
 '
 
 test_done


### PR DESCRIPTION
#### Problem 

The multi-factor priority plugin currently rejects jobs from a user who has a fairshare value of exactly 0.0. As discussed in #141, the plugin should instead assign the lowest job priority for the job submitted.

---

This PR removes the job rejection from the plugin when a user has a fairshare value lower than 0.00000 and instead returns `FLUX_JOB_PRIORITY_MIN` when calculating the priority of a job. 

When a fairshare update occurs and updated information is sent to the plugin and jobs are reprioritized, there is potential to update the existing priority for a job and raise its priority to higher than `FLUX_JOB_PRIORITY_MIN`.

The test that checks for a successful job rejection in `t1001-mf-priority-basic.t` is also updated to instead check that the assigned priority is `FLUX_JOB_PRIORITY_MIN`. An updated fairshare value is then sent to the plugin and jobs are reprioritized, bringing the job out of SCHED state and into RUN.

Fixes #141