### PR TITLE
NEWS: add release notes for v0.16.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+flux-accounting version 0.16.0 - 2022-04-30
+------------------------------------------
+
+#### Fixes
+
+* Fix memory corruption due to use-after-free of the "DNE" bank entry (#233)
+
+#### Features
+
+* Add queue priority to job priority calculation (#207)
+
 flux-accounting version 0.15.0 - 2022-03-31
 -------------------------------------------
 


### PR DESCRIPTION
_Nearing the end of the month, so I figured I'd get this up now to have it ready. :-)_

This PR adds release notes for flux-accounting `v0.16.0`. ~~Leaving [WIP] for now to see if I can get #230 (or any other tiny fixes/features) landed before I release.~~ 

Once this gets merged, I'll create an annotated tag using the following instruction:

```
git tag -a v0.16.0 -m "Tag v0.16.0" && git push upstream v0.16.0
```