### PR TITLE
association_table: add `max_nodes` column

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -87,18 +87,19 @@ def create_db(
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS association_table (
-                creation_time    bigint(20)                NOT NULL,
-                mod_time         bigint(20)  DEFAULT 0     NOT NULL,
-                username         tinytext                  NOT NULL,
-                userid           int(11)     DEFAULT 65534 NOT NULL,
-                bank             tinytext                  NOT NULL,
-                default_bank     tinytext                  NOT NULL,
-                shares           int(11)     DEFAULT 1     NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
-                job_usage        real        DEFAULT 0.0   NOT NULL,
-                fairshare        real        DEFAULT 0.5   NOT NULL,
-                max_running_jobs int(11)     DEFAULT 5     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
-                max_active_jobs  int(11)     DEFAULT 7     NOT NULL    ON CONFLICT REPLACE DEFAULT 7,
-                queues           tinytext    DEFAULT ''    NOT NULL    ON CONFLICT REPLACE DEFAULT '',
+                creation_time    bigint(20)                         NOT NULL,
+                mod_time         bigint(20)  DEFAULT 0              NOT NULL,
+                username         tinytext                           NOT NULL,
+                userid           int(11)     DEFAULT 65534          NOT NULL,
+                bank             tinytext                           NOT NULL,
+                default_bank     tinytext                           NOT NULL,
+                shares           int(11)     DEFAULT 1              NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
+                job_usage        real        DEFAULT 0.0            NOT NULL,
+                fairshare        real        DEFAULT 0.5            NOT NULL,
+                max_running_jobs int(11)     DEFAULT 5              NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
+                max_active_jobs  int(11)     DEFAULT 7              NOT NULL    ON CONFLICT REPLACE DEFAULT 7,
+                max_nodes        int(11)     DEFAULT 2147483647     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
+                queues           tinytext    DEFAULT ''             NOT NULL    ON CONFLICT REPLACE DEFAULT '',
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -62,6 +62,7 @@ def add_user(
     shares=1,
     max_running_jobs=5,
     max_active_jobs=7,
+    max_nodes=5,
     queues="",
 ):
 
@@ -104,8 +105,8 @@ def add_user(
             INSERT INTO association_table (creation_time, mod_time, username,
                                            userid, bank, default_bank, shares,
                                            max_running_jobs, max_active_jobs,
-                                           queues)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                           max_nodes, queues)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -117,6 +118,7 @@ def add_user(
                 shares,
                 max_running_jobs,
                 max_active_jobs,
+                max_nodes,
                 queues,
             ),
         )
@@ -166,6 +168,7 @@ def edit_user(
     shares=None,
     max_running_jobs=None,
     max_active_jobs=None,
+    max_nodes=None,
     queues=None,
 ):
     params = locals()
@@ -176,6 +179,7 @@ def edit_user(
         "shares",
         "max_running_jobs",
         "max_active_jobs",
+        "max_nodes",
         "queues",
     ]
     for field in editable_fields:

--- a/src/cmd/flux-account-pop-db.py
+++ b/src/cmd/flux-account-pop-db.py
@@ -79,7 +79,8 @@ def populate_db(path, users=None, banks=None):
                     shares = row[3] if row[3] != "" else 1
                     max_running_jobs = row[4] if row[4] != "" else 5
                     max_active_jobs = row[5] if row[5] != "" else 7
-                    queues = row[6]
+                    max_nodes = row[6] if row[6] != "" else 5
+                    queues = row[7]
 
                     u.add_user(
                         conn,
@@ -89,6 +90,7 @@ def populate_db(path, users=None, banks=None):
                         shares,
                         max_running_jobs,
                         max_active_jobs,
+                        max_nodes,
                         queues,
                     )
         except IOError as err:
@@ -102,10 +104,10 @@ def main():
 
         Order of elements required for populating association_table:
 
-        Username,UserID,Bank,Shares,MaxRunningJobs,MaxActiveJobs,Queues
+        Username,UserID,Bank,Shares,MaxRunningJobs,MaxActiveJobs,MaxNodes,Queues
 
-        [Shares], [MaxRunningJobs], and [MaxActiveJobs] can be left blank ('') in
-        the .csv file for a given row.
+        [Shares], [MaxRunningJobs], [MaxActiveJobs], and [MaxNodes] can be left
+        blank ('') in the .csv file for a given row.
 
         ----------------
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -83,6 +83,12 @@ def add_add_user_arg(subparsers):
         metavar="max_active_jobs",
     )
     subparser_add_user.add_argument(
+        "--max-nodes",
+        help="max number of nodes a user can have across all of their running jobs",
+        default=5,
+        metavar="MAX_NODES",
+    )
+    subparser_add_user.add_argument(
         "--queues",
         help="queues the user is allowed to run jobs in",
         default="",
@@ -138,6 +144,12 @@ def add_edit_user_arg(subparsers):
         help="max number of both pending and running jobs",
         default=7,
         metavar="max_active_jobs",
+    )
+    subparser_edit_user.add_argument(
+        "--max-nodes",
+        help="max number of nodes a user can have across all of their running jobs",
+        default=5,
+        metavar="MAX_NODES",
     )
     subparser_edit_user.add_argument(
         "--queues",
@@ -427,6 +439,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.shares,
             args.max_running_jobs,
             args.max_active_jobs,
+            args.max_nodes,
             args.queues,
         )
     elif args.func == "delete_user":
@@ -440,6 +453,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.shares,
             args.max_running_jobs,
             args.max_active_jobs,
+            args.max_nodes,
             args.queues,
         )
     elif args.func == "view_job_records":

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -26,11 +26,11 @@ test_expect_success 'populate flux-accounting DB with banks.csv' '
 
 test_expect_success 'create a users.csv file containing user information' '
 	cat <<-EOF >users.csv
-	user1000,1000,A,1,10,15,""
-	user1001,1001,A,1,10,15,""
-	user1002,1002,A,1,10,15,""
-	user1003,1003,A,1,10,15,""
-	user1004,1004,A,1,10,15,""
+	user1000,1000,A,1,10,15,5,""
+	user1001,1001,A,1,10,15,5,""
+	user1002,1002,A,1,10,15,5,""
+	user1003,1003,A,1,10,15,5,""
+	user1004,1004,A,1,10,15,5,""
 	EOF
 '
 
@@ -45,11 +45,11 @@ test_expect_success 'check database hierarchy to make sure all banks & users wer
 
 test_expect_success 'create a users.csv file with some missing optional user information' '
 	cat <<-EOF >users_optional_vals.csv
-	user1005,1005,B,1,5,,""
-	user1006,1006,B,,,,""
-	user1007,1007,B,1,7,,""
-	user1008,1008,B,,,,""
-	user1009,1009,B,1,9,,""
+	user1005,1005,B,1,5,,5,""
+	user1006,1006,B,,,,5,""
+	user1007,1007,B,1,7,,,""
+	user1008,1008,B,,,,5,""
+	user1009,1009,B,1,9,,,""
 	EOF
 '
 


### PR DESCRIPTION
#### Background

Described in #121, there is a need for supporting a `max_nodes` limit on user/bank associations. More specifically, this limit will enforce a maximum number of nodes a user/bank association can have across all of their running jobs at any given time.

---

This is a small PR that simply adds the `max_nodes` column to the `association_table` in the flux-accounting database. It also adds `max_nodes` as an optional argument to the `add-user` and `edit-user` commands.