### PR TITLE
plugin: disable queue validation, `default` queue requirement

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -812,6 +812,18 @@ extern "C" int flux_plugin_init (flux_plugin_t *p)
         || flux_jobtap_service_register (p, "reprioritize", reprior_cb, p)
         || flux_jobtap_service_register (p, "rec_q_update", rec_q_cb, p) < 0)
         return -1;
+
+    struct queue_info *q;
+    q = &queues["default"];
+
+    // min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
+    // currently used or enforced in this plugin, so their values have no
+    // effect in queue limit enforcement.
+    q->min_nodes_per_job = 0;
+    q->max_nodes_per_job = 1024;
+    q->max_time_per_job = 64000;
+    q->priority = 1000;
+
     return 0;
 }
 

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -58,11 +58,11 @@ test_expect_success 'stop the queue' '
 	flux queue stop
 '
 
-test_expect_success 'trying to submit a job without specifying a queue should attempt to use default queue' '
-	test_must_fail flux python ${SUBMIT_AS} 5011 -n1 hostname > no_default_queue.out 2>&1 &&
-	test_debug "no_default_queue.out" &&
-	grep "No default queue exists" no_default_queue.out
-'
+# test_expect_success 'trying to submit a job without specifying a queue should attempt to use default queue' '
+# 	test_must_fail flux python ${SUBMIT_AS} 5011 -n1 hostname > no_default_queue.out 2>&1 &&
+# 	test_debug "no_default_queue.out" &&
+# 	grep "No default queue exists" no_default_queue.out
+# '
 
 test_expect_success 'adding a default queue allows users to run jobs without specifying a queue' '
 	flux account -p ${DB_PATH} add-queue default --priority=1000 &&


### PR DESCRIPTION
#### Problem 

The multi-queue design is not fully designed and implemented throughout the various Flux components yet, but the plugin requires that a `default` queue exist in order to submit jobs with the plugin loaded.

---

Disable the validation of queues as well as its use of an associated integer priority with queues passed in from the flux-accounting DB so that a `default` queue does not need to be present in order for users to submit jobs with the multi-factor priority plugin loaded. I just commented out the sections of code that perform this validation, but if we think it would be cleaner to just remove the code altogether, I am OK with that as well.

Disable the tests that check for queue validation error messages and that check for specific job priorities affected by queue priorities. I just commented out the tests that perform these checks and job priority comparisons, but if we think it would be cleaner to just remove the code altogether, I am also OK with that!

Fixes #237