### PR TITLE
flux-account: add DB export command

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,4 +128,5 @@ dist_fluxcmd_SCRIPTS = \
 	cmd/flux-account-update-fshare \
 	cmd/flux-account-priority-update.py \
 	cmd/flux-account-shares \
-	cmd/flux-account-pop-db.py
+	cmd/flux-account-pop-db.py \
+	cmd/flux-account-export-db.py

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -98,7 +98,7 @@ def create_db(
                 fairshare        real        DEFAULT 0.5            NOT NULL,
                 max_running_jobs int(11)     DEFAULT 5              NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
                 max_active_jobs  int(11)     DEFAULT 7              NOT NULL    ON CONFLICT REPLACE DEFAULT 7,
-                max_nodes        int(11)     DEFAULT 2147483647     NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
+                max_nodes        int(11)     DEFAULT 2147483647     NOT NULL    ON CONFLICT REPLACE DEFAULT 2147483647,
                 queues           tinytext    DEFAULT ''             NOT NULL    ON CONFLICT REPLACE DEFAULT '',
                 PRIMARY KEY   (username, bank)
         );"""

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -62,7 +62,7 @@ def add_user(
     shares=1,
     max_running_jobs=5,
     max_active_jobs=7,
-    max_nodes=5,
+    max_nodes=2147483647,
     queues="",
 ):
 

--- a/src/cmd/flux-account-export-db.py
+++ b/src/cmd/flux-account-export-db.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import argparse
+import csv
+import os
+import sqlite3
+import sys
+
+from argparse import RawDescriptionHelpFormatter
+
+import fluxacct.accounting
+
+
+def set_db_loc(args):
+    path = args.path if args.path else fluxacct.accounting.db_path
+
+    return path
+
+
+def est_sqlite_conn(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        sys.exit(1)
+
+    return conn
+
+
+def export_db_info(path, users=None, banks=None):
+    conn = est_sqlite_conn(path)
+    cur = conn.cursor()
+
+    try:
+        select_users_stmt = """
+            SELECT username, userid, bank, shares, max_running_jobs, max_active_jobs,
+            max_nodes, queues FROM association_table
+        """
+        cur.execute(select_users_stmt)
+        table = cur.fetchall()
+
+        # open a .csv file for writing
+        users_filepath = users if users else "users.csv"
+        users_file = open(users_filepath, "w")
+        with users_file:
+            writer = csv.writer(users_file)
+
+            for row in table:
+                writer.writerow(row)
+
+        select_banks_stmt = """
+            SELECT bank, parent_bank, shares FROM bank_table
+        """
+        cur.execute(select_banks_stmt)
+        table = cur.fetchall()
+
+        banks_filepath = banks if banks else "banks.csv"
+        banks_file = open(banks_filepath, "w")
+        with banks_file:
+            writer = csv.writer(banks_file)
+
+            for row in table:
+                writer.writerow(row)
+    except IOError as err:
+        print(err)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Extract flux-accounting database information into two .csv files.
+
+        Order of columns extracted from association_table:
+
+        Username,UserID,Bank,Shares,MaxRunningJobs,MaxActiveJobs,MaxNodes,Queues
+
+        If no custom path is specified, this will create a file in the
+        current working directory called users.csv.
+
+        ----------------
+
+        Order of columns extracted from bank_table:
+
+        Bank,ParentBank,Shares
+
+        If no custom path is specified, this will create a file in the
+        current working directory called banks.csv.
+
+        Use these two files to populate a new flux-accounting DB with:
+
+        flux account-pop-db -p path/to/db -b banks.csv -u users.csv
+        """,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-p", "--path", dest="path", help="specify location of database file"
+    )
+    parser.add_argument(
+        "-u", "--users", help="path to a .csv file containing user information"
+    )
+    parser.add_argument(
+        "-b", "--banks", help="path to a .csv file containing bank information"
+    )
+
+    args = parser.parse_args()
+
+    path = set_db_loc(args)
+
+    export_db_info(path, args.users, args.banks)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -85,7 +85,7 @@ def add_add_user_arg(subparsers):
     subparser_add_user.add_argument(
         "--max-nodes",
         help="max number of nodes a user can have across all of their running jobs",
-        default=5,
+        default=2147483647,
         metavar="MAX_NODES",
     )
     subparser_add_user.add_argument(

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -16,7 +16,8 @@ TESTSCRIPTS = \
 	t1012-mf-priority-load.t \
 	t1013-mf-priority-queues.t \
 	t1014-mf-priority-dne.t \
-	t1015-mf-priority-urgency.t
+	t1015-mf-priority-urgency.t \
+	t1016-export-db.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1016-export-db.t
+++ b/t/t1016-export-db.t
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+test_description='Test flux-account commands'
+. `dirname $0`/sharness.sh
+
+DB_PATHv1=$(pwd)/FluxAccountingTestv1.db
+DB_PATHv2=$(pwd)/FluxAccountingTestv2.db
+EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/pop_db
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTestv1.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATHv1} add-bank root 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root A 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root B 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root C 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root D 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=D E 1
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=D F 1
+'
+
+test_expect_success 'add some users to the DB' '
+	flux account -p ${DB_PATHv1} add-user --username=user5011 --userid=5011 --bank=A &&
+	flux account -p ${DB_PATHv1} add-user --username=user5012 --userid=5012 --bank=A &&
+	flux account -p ${DB_PATHv1} add-user --username=user5013 --userid=5013 --bank=B &&
+	flux account -p ${DB_PATHv1} add-user --username=user5014 --userid=5014 --bank=C
+'
+
+test_expect_success 'export DB information into .csv files' '
+	flux account-export-db -p ${DB_PATHv1}
+'
+
+test_expect_success 'compare banks.csv' '
+	cat <<-EOF >banks_expected.csv
+	root,,1
+	A,root,1
+	B,root,1
+	C,root,1
+	D,root,1
+	E,D,1
+	F,D,1
+	EOF
+	test_cmp -b banks_expected.csv banks.csv
+'
+
+test_expect_success 'compare users.csv' '
+	cat <<-EOF >users_expected.csv
+	user5011,5011,A,1,5,7,2147483647,
+	user5012,5012,A,1,5,7,2147483647,
+	user5013,5013,B,1,5,7,2147483647,
+	user5014,5014,C,1,5,7,2147483647,
+	EOF
+	test_cmp -b users_expected.csv users.csv
+'
+
+test_expect_success 'create a new flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTestv2.db create-db
+'
+
+test_expect_success 'import information into new DB' '
+	flux account-pop-db -p ${DB_PATHv2} -b banks.csv &&
+	flux account-pop-db -p ${DB_PATHv2} -u users.csv
+'
+
+test_expect_success 'compare DB hierarchies to make sure they are the same' '
+	flux account-shares -p ${DB_PATHv1} > db1.test &&
+	flux account-shares -p ${DB_PATHv2} > db2.test &&
+	test_cmp db1.test db2.test
+'
+
+test_expect_success 'specify a different filename for exported users and banks .csv files' '
+	flux account-export-db -p ${DB_PATHv2} --users foo.csv --banks bar.csv &&
+	test_cmp -b users_expected.csv foo.csv &&
+	test_cmp -b banks_expected.csv bar.csv
+'
+
+test_done


### PR DESCRIPTION
#### Background

As mentioned in #215, there will be a need for supporting the ability to update the flux-accounting database when a new version of the database is released so that the existing DB does not have to be completely re-created and have all values re-inserted. This will be especially important when new columns are added to an already existing table or a new table is added.

---

This PR adds a new command to flux-accounting: `export-db`, which allows an admin to export information from the `association_table` and `bank_table` in the flux-accounting DB into two `.csv` files. This can be used to then import user and bank information into a new flux-accounting DB. Custom paths and filenames can be specified for these two files, or, if left default, will just create the two `.csv` files in the current working directory named `banks.csv` and `users.csv`.

The exported DB information will only contain the absolutely necessary data for each row: from the `association_table`:

**username, userid, banks, shares, max_running_jobs, max_active_jobs, max_nodes, queues**. 

From the `bank_table`: 

**bank, parent bank, shares**. 

This will hopefully ensure that when a database needs to be updated, we avoid "missing column" errors and such.

A sharness test is also added to exercise this command in conjunction with the `pop-db` command to migrate database information from one flux-accounting DB to another.

I also added a tiny commit at the beginning of this PR to fix the default values for `max_nodes` in the `add-user` command and `association_table`. 