### PR TITLE
flux-account: add new `update-db` command

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,4 +129,5 @@ dist_fluxcmd_SCRIPTS = \
 	cmd/flux-account-priority-update.py \
 	cmd/flux-account-shares \
 	cmd/flux-account-pop-db.py \
-	cmd/flux-account-export-db.py
+	cmd/flux-account-export-db.py \
+	cmd/flux-account-update-db.py

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import argparse
+import os
+import sqlite3
+import sys
+
+from argparse import RawDescriptionHelpFormatter
+
+import fluxacct.accounting
+from fluxacct.accounting import create_db as c
+
+
+def set_db_loc(args):
+    path = args.old_db if args.old_db else fluxacct.accounting.db_path
+
+    return path
+
+
+def est_sqlite_conn(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        sys.exit(1)
+
+    return conn
+
+
+# update_tables() is responsible for adding any new tables that don't yet exist
+# in the old flux-accounting DB. It will look at the table schema for the table
+# that doesn't yet exist and create a "CREATE TABLE ..." statement to add and
+# commit to the old flux-accounting DB
+def update_tables(old_conn, old_cur, new_cur):
+    print("checking for new tables...")
+
+    # get all tables from old database
+    old_cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    old_tables = old_cur.fetchall()
+
+    # get all tables from the temporary new database
+    new_cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    new_tables = new_cur.fetchall()
+
+    for table in new_tables:
+        if table not in old_tables:
+            # we need to add this table to the DB
+            print("new table found: %s" % table[0])
+
+            # get schema information about new table to add
+            new_cur.execute("PRAGMA table_info(%s)" % table)
+            new_columns = new_cur.fetchall()
+
+            add_stmt = "CREATE TABLE IF NOT EXISTS " + table[0] + "("
+
+            for column in new_columns:
+                column_name = column[1]
+                column_type = column[2]
+                not_null = column[3]
+                default_value = column[4]
+
+                add_stmt += column_name + " " + column_type + " "
+                if default_value is not None:
+                    add_stmt += "DEFAULT " + default_value + " "
+                if not_null == 1:
+                    add_stmt += "NOT NULL, "
+
+            # look for primary key in new table to add
+            for column in new_columns:
+                if column[5] == 1:
+                    add_stmt += "PRIMARY KEY (" + column[1] + "));"
+
+            # add table to old DB
+            old_cur.execute(add_stmt)
+            old_conn.commit()
+
+
+# update_columns() looks that the existing tables in the old flux-accounting DB
+# to see if any of the tables need to add any additional columns to its tables.
+# If it does, it will issue an "ALTER TABLE ..." statement to add any columns
+def update_columns(old_conn, old_cur, new_cur):
+    print("checking for new columns to add in tables...")
+
+    # get all table names from the temporary new database
+    new_cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    new_tables = new_cur.fetchall()
+
+    for table in new_tables:
+        # get the information of each column in the table from new DB
+        new_cur.execute("PRAGMA table_info(%s)" % table)
+        new_columns = new_cur.fetchall()
+
+        # get the information of each column in the same table from old DB
+        old_cur.execute("PRAGMA table_info(%s)" % table)
+        old_columns = old_cur.fetchall()
+
+        for column in new_columns:
+            if column not in old_columns:
+                # we need to add this column to the DB
+                print("new column found in %s: %s" % (table[0], column[1]))
+
+                # we need to add this column to the table in the old DB
+                alter_stmt = "ALTER TABLE " + table[0] + " ADD COLUMN "
+                column_name = column[1]
+                column_type = column[2]
+                not_null = column[3]
+                default_value = column[4]
+
+                alter_stmt += column_name + " " + column_type
+                if default_value is not None:
+                    alter_stmt += " DEFAULT " + default_value
+                if not_null == 1:
+                    alter_stmt += " NOT NULL"
+
+                old_cur.execute(alter_stmt)
+                # commit changes
+                old_conn.commit()
+
+
+def update_db(path, new_db):
+    old_conn = est_sqlite_conn(path)
+    old_cur = old_conn.cursor()
+
+    try:
+        # we should only pass a new DB if we are testing the flux
+        # account-update-db command; normally, no value should be passed for
+        # new_db
+        if not new_db:
+            new_db = "tmpFluxAccounting.db"
+            c.create_db(new_db)
+
+        new_conn = sqlite3.connect("file:%s?mode=rw" % new_db, uri=True)
+        new_cur = new_conn.cursor()
+
+        update_tables(old_conn, old_cur, new_cur)
+
+        update_columns(old_conn, old_cur, new_cur)
+
+        # close connections to DB's and remove temporary database
+        old_conn.close()
+        new_conn.close()
+
+        os.remove(new_db)
+    except sqlite3.OperationalError:
+        print(f"Unable to open temporary database file: %s" % new_db)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Update a flux-accounting database with any new tables or
+        columns in any of the existing tables.
+        """,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-p", "--path", dest="old_db", help="specify location of database file"
+    )
+    parser.add_argument(
+        "-n",
+        "--new-db",
+        dest="new_db",
+        help="(testing only) specify location of new template database file",
+    )
+
+    args = parser.parse_args()
+
+    old_db = set_db_loc(args)
+
+    update_db(old_db, args.new_db)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -17,7 +17,8 @@ TESTSCRIPTS = \
 	t1013-mf-priority-queues.t \
 	t1014-mf-priority-dne.t \
 	t1015-mf-priority-urgency.t \
-	t1016-export-db.t
+	t1016-export-db.t \
+	t1017-update-db.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/scripts/check_db_info.py
+++ b/t/scripts/check_db_info.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import sys
+import argparse
+import os
+
+from argparse import RawDescriptionHelpFormatter
+
+
+def est_sqlite_conn(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        sys.exit(1)
+
+    return conn
+
+
+def check_tables(cur):
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = cur.fetchall()
+    print(tables)
+
+
+def check_columns(cur, table_name):
+    print("table name:", table_name)
+    # get the information of each column in the table from new DB
+    cur.execute("PRAGMA table_info(%s)" % table_name)
+    columns = cur.fetchall()
+    print(columns)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Check the tables in a DB and/or the columns in a table in a DB.
+        """,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-p", "--path", dest="db_path", help="specify location of database file"
+    )
+    parser.add_argument(
+        "-t",
+        nargs="?",
+        const=True,
+        dest="table",
+        help="check tables of database",
+    )
+    parser.add_argument(
+        "-c",
+        dest="table_name",
+        help="check columns of TABLE",
+    )
+
+    args = parser.parse_args()
+
+    conn = est_sqlite_conn(args.db_path)
+    cur = conn.cursor()
+
+    if args.table:
+        check_tables(cur)
+    if args.table_name:
+        check_columns(cur, args.table_name)
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/t/scripts/modify_accounting_db.py
+++ b/t/scripts/modify_accounting_db.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+import sys
+
+import fluxacct.accounting
+from fluxacct.accounting import create_db as c
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("You must pass a path to the flux-accounting DB")
+        sys.exit(-1)
+
+    filename = sys.argv[1]
+    c.create_db(filename)
+    conn = sqlite3.connect(filename)
+    cur = conn.cursor()
+
+    # add two new columns to the association_table in the flux-accounting DB
+    cur.execute(
+        "ALTER TABLE association_table ADD COLUMN organization text DEFAULT '' NOT NULL"
+    )
+    cur.execute(
+        "ALTER TABLE association_table ADD COLUMN yrs_experience int(11) DEFAULT 0 NOT NULL"
+    )
+
+    # add a new table to the flux-accounting DB
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS organization (org_name        tinytext            NOT NULL,
+                                                    org_number      int(11)  DEFAULT 0  NOT NULL,
+                                                    num_members     int(11)  DEFAULT 0  NOT NULL,
+                                                    org_description tinytext DEFAULT '' NOT NULL,
+                                                    PRIMARY KEY (org_name));"""
+    )
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+test_description='Test flux account-update-db command'
+. `dirname $0`/sharness.sh
+
+DB_PATHv1=$(pwd)/FluxAccountingTestv1.db
+DB_PATHv2=$(pwd)/FluxAccountingTestv2.db
+MODIFY_DB=${SHARNESS_TEST_SRCDIR}/scripts/modify_accounting_db.py
+CHECK_TABLES=${SHARNESS_TEST_SRCDIR}/scripts/check_db_info.py
+
+test_expect_success 'create a flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTestv1.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATHv1} add-bank root 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root A 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root B 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root C 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=root D 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=D E 1 &&
+	flux account -p ${DB_PATHv1} add-bank --parent-bank=D F 1
+'
+
+test_expect_success 'add some users to the DB' '
+	flux account -p ${DB_PATHv1} add-user --username=user5011 --userid=5011 --bank=A &&
+	flux account -p ${DB_PATHv1} add-user --username=user5012 --userid=5012 --bank=A &&
+	flux account -p ${DB_PATHv1} add-user --username=user5013 --userid=5013 --bank=B &&
+	flux account -p ${DB_PATHv1} add-user --username=user5014 --userid=5014 --bank=C
+'
+
+test_expect_success 'create a new flux-accounting DB with an additional table, additional columns in existing tables' '
+	flux python ${MODIFY_DB} ${DB_PATHv2}
+'
+
+test_expect_success 'run flux account-update-db' '
+	flux account-update-db -p ${DB_PATHv1} --new-db ${DB_PATHv2}
+'
+
+test_expect_success 'get all the tables of the old DB and check that new table was added' '
+	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -t > tables.out &&
+	grep "organization" tables.out
+'
+
+test_expect_success 'get all the columns of the updated table in the DB and check that new columns were added' '
+	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -c association_table > columns.out &&
+	grep "organization" | grep "yrs_experience" columns.out
+'
+
+test_done


### PR DESCRIPTION
#### Background

Noted in #215, there is a need for supporting the ability to update the flux-accounting database when a new version of the database is released so that the existing DB does not have to be completely re-created and have all values re-inserted. This will be especially important when new columns are added to an already existing table or a new table is added. There currently exists both `export-db` and `pop-db` commands to export and import database information into `.csv` files, but these commands also involve creation of a new DB to migrate this information. It would be nice to have support to just update the database that currently resides on a system with any new potential tables or columns after a new release of flux-accounting.

---

This is a [WIP] PR that adds a new command to flux-accounting: `update-db`, which will look at the DB schema of the database currently residing on a system and update it to add any missing tables or add any missing columns within each of the tables. It does so by creating a temporary database to compare schema; it will then compare tables and then iterate through each table and compare columns. After the iteration is done, the temporary database is removed. For testing purposes, there is an optional argument for the `update-db` command to specify a path for the temporary database; if not specified (which should be the norm and is noted in the description of the command), the temporary database is created and removed from the current working directory.

Two helper scripts are added to the `t/` directory to help with testing:

**modify_accounting_db.py** is a helper script that adds two columns to the association_table and a new table to the flux-accounting DB for testing the functionality of the flux account-update-db command.

**check_db_info.py** is a helper script that checks the names of the tables in a flux-accounting DB or the names of the columns within a table in a flux-accounting DB.

The sharness test file `t1017-export-db.t` uses these two helper scripts to modify a flux-accounting DB to simulate a newer DB being released with an additional table and two additional columns added to one of the existing tables. The test runs the `update-db` command and makes sure the missing table and columns are added to the flux-accounting DB successfully.

Fixes #215