### PR TITLE
docs: update README, sharness test descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ the developers._
 
 Development for a bank/accounting interface for the Flux resource manager.
 Writes and saves user account information to persistent storage using Python's
-SQLite3 API.
+SQLite3 API. Calculates fair-share values for users and banks based on
+historical job data. Generates job priority values for users with a multi-factor
+priority plugin.
 
 ### Install Instructions
 
@@ -131,9 +133,9 @@ mounting /Users/moussa1/src/flux-framework/flux-accounting as /usr/src
 [moussa1@docker-desktop src]$
 ```
 
-### User Account Information
+### User and Bank Information
 
-The accounting table in this database stores information like username and
+The accounting tables in this database stores information like username and
 ID, banks to submit jobs against, allocated shares to the user, as well as
 static limits, including a max number of running jobs at a given time and
 a max number of submitted jobs per user/bank combo.
@@ -195,6 +197,14 @@ $ flux account view-user fluxuser
 creation_time    mod_time  deleted  username  bank   shares  max_jobs  max_wall_pj
    1595438356  1595438356        0  fluxuser  foo         1       100           60
 ```
+
+Multiple rows of data can be loaded to the database at once using `.csv` files
+and the `flux account-pop-db` command. Run `flux account-pop-db --help` for
+`.csv` formatting instructions.
+
+User and bank information can also be exported from the database using the
+`flux account-export-db` command, which will extract information from both the
+user and bank tables and place them into `.csv` files.
 
 #### Release
 

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test print-hierarchy command'
+test_description='Test update-fshare command with user and job data'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t1008-mf-priority-update.t
+++ b/t/t1008-mf-priority-update.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test multi-factor priority plugin order with no ties'
+test_description='Test flux account-priority-update command with flux-accounting DB and plugin'
 
 . `dirname $0`/sharness.sh
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test flux-account commands'
+test_description='Test populating a flux-accounting DB with pop-db command and .csv files'
 . `dirname $0`/sharness.sh
 
 DB_PATH=$(pwd)/FluxAccountingTest.db

--- a/t/t1010-update-usage.t
+++ b/t/t1010-update-usage.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test print-hierarchy command'
+test_description='Test flux account update-usage command with user and job data'
 
 . `dirname $0`/sharness.sh
 DB_PATH=$(pwd)/FluxAccountingTest.db

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test multi-factor priority plugin with a single user'
+test_description='Test multi-factor priority plugin and loading user information late'
 
 . `dirname $0`/sharness.sh
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so

--- a/t/t1015-mf-priority-urgency.t
+++ b/t/t1015-mf-priority-urgency.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test multi-factor priority plugin order with no ties'
+test_description='Test multi-factor priority plugin order with different --urgency values'
 
 . `dirname $0`/sharness.sh
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so


### PR DESCRIPTION
#### Background

Some of the sharness tests in the `t/` directory had poor test descriptions because the files were initially copied and pasted from other tests and the descriptions were never updated. The top-level README could also use some updates since the addition of the `pop-db` and `export-db` commands.

---

This PR updates the descriptions of the tests to more accurately reflect what each sharness test is supposed to be covering. It also updates the README.md for the flux-accounting repository and adds additional instructions on importing and exporting database information with `.csv` files.