### PR TITLE
plugin: add check before deleting held job ID

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -777,7 +777,9 @@ static int inactive_cb (flux_plugin_t *p,
             flux_jobtap_raise_exception (p, jobid, "mf_priority",
                                          0, "failed to remove job dependency");
 
-        b->held_jobs.erase (b->held_jobs.begin ());
+        // check that there is in fact a job ID to be removed from the list
+        if (b->held_jobs.begin () != b->held_jobs.end ())
+            b->held_jobs.erase (b->held_jobs.begin ());
     }
 
     return 0;


### PR DESCRIPTION
#### Problem

The `job.state.inactive` callback attempts to remove a job ID from the list of held jobs regardless if there is actually a job ID to be removed, which can cause unexpected behavior if there are no job IDs in the list.

---

This PR adds a check just before the `erase ()` call to make sure that the ID exists in the list before attempting to remove it. If the list is empty, don't attempt to remove a job ID.

Fixes #249