### PR TITLE
`update-db`: fix command, improve error message/execption clarity

### DIFF
--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -158,8 +158,9 @@ def update_db(path, new_db):
         new_conn.close()
 
         os.remove(new_db)
-    except sqlite3.OperationalError:
-        print(f"Unable to open temporary database file: %s" % new_db)
+    except sqlite3.OperationalError as exc:
+        print(f"Unable to open temporary database file: {new_db}")
+        print(f"Exception: {exc}")
         sys.exit(1)
 
 

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -44,6 +44,77 @@ def est_sqlite_conn(path):
     return conn
 
 
+# gets a final list of columns for the new version of a table, which
+# include any columns added in a newer version or removed from an older version
+def get_cols_list(old_columns, new_columns):
+    cols = []
+
+    for column in new_columns:
+        if column in old_columns and column in new_columns:
+            cols.append(column)
+        elif column in new_columns:
+            cols.append(column)
+
+    return cols
+
+
+# adds a new version of the table to the DB
+def add_tmp_table_to_db(old_cur, table, cols):
+    add_stmt = "CREATE TABLE IF NOT EXISTS " + table[0] + "_tmp" + " ("
+
+    for column in cols:
+        column_name = column[1]
+        column_type = column[2]
+        not_null = column[3]
+        default_value = column[4]
+
+        add_stmt += column_name + " " + column_type + " "
+        if default_value is not None:
+            add_stmt += "DEFAULT " + default_value
+        if not_null == 1:
+            add_stmt += " NOT NULL"
+        # only add a comma if column is not last item in list
+        if column != cols[-1]:
+            add_stmt += ", "
+
+    # look for primary key to add to table; if column[5] > 0, that means
+    # it is either the primary key or one of the values that make up a
+    # primary key
+    primary_keys = ",".join([column[1] for column in cols if column[5] > 0])
+    if len(primary_keys) > 0:
+        add_stmt += ", PRIMARY KEY ("
+        add_stmt += ",".join([column[1] for column in cols if column[5] > 0])
+        add_stmt += ")"
+
+    add_stmt += ");"
+
+    # add new table to DB
+    old_cur.execute(add_stmt)
+
+
+# move all existing rows from the old version of the table to the new version of the table
+def move_existing_rows(old_cur, cols, old_columns, table):
+    # get list of columns to be added to new table that were in old table but not new table
+    existing_cols = [column[1] for column in cols if column in old_columns]
+    insert = "INSERT INTO " + table[0] + "_tmp"
+    values = " (" + (",".join(existing_cols)) + ")"
+    select = " SELECT " + (",".join(existing_cols)) + " FROM " + table[0]
+    final_stmt = insert + values + select
+
+    old_cur.execute(final_stmt)
+
+
+# drops the '_tmp' appended to the new version of the table to match the old table name
+def rename_tmp_table(old_cur, table):
+    # drop old table
+    drop_stmt = "DROP TABLE " + table[0]
+    old_cur.execute(drop_stmt)
+
+    # rename table to match old table
+    alter_stmt = "ALTER TABLE " + table[0] + "_tmp" + " RENAME TO " + table[0]
+    old_cur.execute(alter_stmt)
+
+
 # update_tables() is responsible for adding any new tables that don't yet exist
 # in the old flux-accounting DB. It will look at the table schema for the table
 # that doesn't yet exist and create a "CREATE TABLE ..." statement to add and
@@ -94,12 +165,16 @@ def update_tables(old_conn, old_cur, new_cur):
 
 # update_columns() looks that the existing tables in the old flux-accounting DB
 # to see if any of the tables need to add any additional columns to its tables.
-# If it does, it will issue an "ALTER TABLE ..." statement to add any columns
+# If it does, it will create a new version of the table with any added or removed
+# columns from a newer version of flux-accounting, copy any and all existing rows
+# from the old table, and DROP the old table to be replaced with the new table
 def update_columns(old_conn, old_cur, new_cur):
     print("checking for new columns to add in tables...")
 
     # get all table names from the temporary new database
-    new_cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    new_cur.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    )
     new_tables = new_cur.fetchall()
 
     for table in new_tables:
@@ -111,27 +186,21 @@ def update_columns(old_conn, old_cur, new_cur):
         old_cur.execute("PRAGMA table_info(%s)" % table)
         old_columns = old_cur.fetchall()
 
-        for column in new_columns:
-            if column not in old_columns:
-                # we need to add this column to the DB
-                print("new column found in %s: %s" % (table[0], column[1]))
+        # generate a final columns list, which consist of columns added
+        # in a newer version or removed from an older version
+        cols = get_cols_list(old_columns, new_columns)
 
-                # we need to add this column to the table in the old DB
-                alter_stmt = "ALTER TABLE " + table[0] + " ADD COLUMN "
-                column_name = column[1]
-                column_type = column[2]
-                not_null = column[3]
-                default_value = column[4]
+        # create a new version of table with the updated column list
+        add_tmp_table_to_db(old_cur, table, cols)
 
-                alter_stmt += column_name + " " + column_type
-                if default_value is not None:
-                    alter_stmt += " DEFAULT " + default_value
-                if not_null == 1:
-                    alter_stmt += " NOT NULL"
+        # move elements from the old table to new version of the table
+        move_existing_rows(old_cur, cols, old_columns, table)
 
-                old_cur.execute(alter_stmt)
-                # commit changes
-                old_conn.commit()
+        # rename the new table to match the name of the old table
+        rename_tmp_table(old_cur, table)
+
+        # commit changes
+        old_conn.commit()
 
 
 def update_db(path, new_db):

--- a/t/scripts/check_db_info.py
+++ b/t/scripts/check_db_info.py
@@ -37,7 +37,8 @@ def est_sqlite_conn(path):
 def check_tables(cur):
     cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
     tables = cur.fetchall()
-    print(tables)
+    for table in tables:
+        print(table[0])
 
 
 def check_columns(cur, table_name):
@@ -45,7 +46,8 @@ def check_columns(cur, table_name):
     # get the information of each column in the table from new DB
     cur.execute("PRAGMA table_info(%s)" % table_name)
     columns = cur.fetchall()
-    print(columns)
+    for col in columns:
+        print(col[1])
 
 
 def main():

--- a/t/scripts/modify_accounting_db.py
+++ b/t/scripts/modify_accounting_db.py
@@ -41,6 +41,19 @@ def main():
                                                     org_description tinytext DEFAULT '' NOT NULL,
                                                     PRIMARY KEY (org_name));"""
     )
+
+    # create a new version of the queue_table without max_time_per_job
+    cur.execute("DROP TABLE queue_table")
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS queue_table (
+                queue               tinytext               NOT NULL,
+                min_nodes_per_job   int(11)    DEFAULT 1   NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
+                max_nodes_per_job   int(11)    DEFAULT 1   NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
+                priority            int(11)    DEFAULT 0   NOT NULL    ON CONFLICT REPLACE DEFAULT 0,
+                PRIMARY KEY (queue)
+            );"""
+    )
+
     conn.commit()
     conn.close()
 

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -29,7 +29,7 @@ test_expect_success 'add some users to the DB' '
 	flux account -p ${DB_PATHv1} add-user --username=user5014 --userid=5014 --bank=C
 '
 
-test_expect_success 'create a new flux-accounting DB with an additional table, additional columns in existing tables' '
+test_expect_success 'create a new flux-accounting DB with an additional table, additional columns in existing tables, and a removed column' '
 	flux python ${MODIFY_DB} ${DB_PATHv2}
 '
 
@@ -38,13 +38,40 @@ test_expect_success 'run flux account-update-db' '
 '
 
 test_expect_success 'get all the tables of the old DB and check that new table was added' '
-	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -t > tables.out &&
-	grep "organization" tables.out
+	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -t > tables.test &&
+	cat <<-EOF >tables.expected
+	sqlite_sequence
+	association_table
+	bank_table
+	job_usage_factor_table
+	t_half_life_period_table
+	organization
+	queue_table
+	EOF
+	test_cmp tables.expected tables.test
 '
 
 test_expect_success 'get all the columns of the updated table in the DB and check that new columns were added' '
-	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -c association_table > columns.out &&
-	grep "organization" | grep "yrs_experience" columns.out
+	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -c association_table > association_table_columns.test &&
+	cat <<-EOF >association_table_columns.expected
+	table name: association_table
+	creation_time
+	mod_time
+	username
+	userid
+	bank
+	default_bank
+	shares
+	job_usage
+	fairshare
+	max_running_jobs
+	max_active_jobs
+	max_nodes
+	queues
+	organization
+	yrs_experience
+	EOF
+	test_cmp association_table_columns.expected association_table_columns.test
 '
 
 test_done

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -74,4 +74,16 @@ test_expect_success 'get all the columns of the updated table in the DB and chec
 	test_cmp association_table_columns.expected association_table_columns.test
 '
 
+test_expect_success 'get all the columns from the queue_table and make sure the dropped column does not show up' '
+	flux python ${CHECK_TABLES} -p ${DB_PATHv1} -c queue_table > queue_table_columns.test &&
+	cat <<-EOF >queue_table_columns.expected
+	table name: queue_table
+	queue
+	min_nodes_per_job
+	max_nodes_per_job
+	priority
+	EOF
+	test_cmp queue_table_columns.expected queue_table_columns.test
+'
+
 test_done


### PR DESCRIPTION
#### Problem

As described in #248 and in #250, there are a couple of issues regarding the `update-db` command:

- If there is a problem connecting to the DB in `flux-account-update-db.py`, the script prints a generic error that often times is not representable of the issue at hand
- On fluke (or probably any other machine that contains an installed and configured flux-accounting DB), when attempting to update the accounting DB, the command fails when upgrading to a new version where the new table does not contain columns that existed in previous versions, which resulted in a `duplicate column` error message

---

This [WIP] PR looks to improve the message and exception clarity if/when an error occurs in the `flux account-update-db` command. In addition to printing a `Could not connect to DB` message along with the DB path, it will also print a more specific error about where the command encountered an error.

The other major component to this PR adds support for updating versions of the DB when columns are deleted from tables from version to version. `ALTER TABLE DROP COLUMN column_name` support does not exist until SQLite version 3.35 and later, so I've sort of implemented my own version. In the `flux account-update-db` command, the script now has a number of helper functions that create a new table with an updated column list and transfers existing table data to the new table. A new test is also added to ensure that deleting columns from a table and then updating the DB works as expected.

In addition to adding the new tests, a couple of very minor improvements are made to the helper scripts used in `t1017-update-db.t`. In `check_db_info.py`, the printing of table names and column info are changed to a better format for the sharness tests. In `modify_accounting_db.py`, a number of SQLite statements are added that simulate dropping the `queue_table` and re-adding it with one less column than before, indicating a deleted column from the table in a newer flux-accounting version.

Fixes #248
Fixes #250