### PR TITLE
plugin: disable user/bank entry in priority plugin when row gets deleted in DB

### DIFF
--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -56,7 +56,7 @@ def bulk_update(path):
     for row in cur.execute(
         """SELECT userid, bank, default_bank,
            fairshare, max_running_jobs, max_active_jobs,
-           queues FROM association_table"""
+           queues, active FROM association_table"""
     ):
         # create a JSON payload with the results of the query
         single_user_data = {
@@ -67,6 +67,7 @@ def bulk_update(path):
             "max_running_jobs": int(row[4]),
             "max_active_jobs": int(row[5]),
             "queues": str(row[6]),
+            "active": int(row[7]),
         }
         bulk_user_data.append(single_user_data)
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -541,6 +541,12 @@ static int validate_cb (flux_plugin_t *p,
                                      "user/default bank entry does not exist");
     }
 
+    // if user/bank entry was disabled, reject job with a message saying the
+    // entry has been disabled
+    if (bank_it->second.active == 0)
+        return flux_jobtap_reject_job (p, args, "user/bank entry has been "
+                                       "disabled from flux-accounting DB");
+
     // fetch priority associated with passed-in queue (or default queue)
     bank_it->second.queue_factor = get_queue_info (queue, bank_it);
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -47,6 +47,7 @@ struct bank_info {
     std::vector<long int> held_jobs;
     std::vector<std::string> queues;
     int queue_factor;
+    int active;
 };
 
 struct queue_info {
@@ -218,6 +219,7 @@ static void rec_update_cb (flux_t *h,
     json_t *data, *jtemp = NULL;
     json_error_t error;
     int num_data = 0;
+    int active = 1;
     std::stringstream s_stream;
 
     if (flux_request_unpack (msg, NULL, "{s:o}", "data", &data) < 0) {
@@ -238,14 +240,15 @@ static void rec_update_cb (flux_t *h,
         json_t *el = json_array_get(data, i);
 
         if (json_unpack_ex (el, &error, 0,
-                            "{s:i, s:s, s:s, s:F, s:i, s:i, s:s}",
+                            "{s:i, s:s, s:s, s:F, s:i, s:i, s:s, s:i}",
                             "userid", &uid,
                             "bank", &bank,
                             "def_bank", &def_bank,
                             "fairshare", &fshare,
                             "max_running_jobs", &max_running_jobs,
                             "max_active_jobs", &max_active_jobs,
-                            "queues", &queues) < 0)
+                            "queues", &queues,
+                            "active", &active) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
         struct bank_info *b;
@@ -254,6 +257,7 @@ static void rec_update_cb (flux_t *h,
         b->fairshare = fshare;
         b->max_run_jobs = max_running_jobs;
         b->max_active_jobs = max_active_jobs;
+        b->active = active;
 
         // split queues comma-delimited string and add it to b->queues vector
         split_string (queues, b);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -18,7 +18,8 @@ TESTSCRIPTS = \
 	t1014-mf-priority-dne.t \
 	t1015-mf-priority-urgency.t \
 	t1016-export-db.t \
-	t1017-update-db.t
+	t1017-update-db.t \
+	t1018-mf-priority-disable-entry.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+test_description='Test rejecting jobs from a user who has been disabled from the flux-accounting DB'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1
+'
+
+test_expect_success 'add a user with two different banks to the DB' '
+	username=$(whoami) &&
+	uid=$(id -u) &&
+	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account1 --shares=1 &&
+	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account2 --shares=1
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job successfully under default bank' '
+	jobid1=$(flux mini submit -n1 hostname) &&
+	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
+	cat <<-EOF >job1.expected &&
+	10050000
+	EOF
+	test_cmp job1.expected job1.test
+'
+
+test_expect_success 'submit a job successfully under second bank' '
+	jobid2=$(flux mini submit --setattr=system.bank=account2 -n1 hostname) &&
+	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
+	cat <<-EOF >job2.expected &&
+	10050000
+	EOF
+	test_cmp job2.expected job2.test
+'
+
+test_expect_success 'disable second user/bank entry and update plugin' '
+	flux account -p ${DB_PATH} delete-user $username account2 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'try to submit job under second user/bank entry' '
+	test_must_fail flux mini submit --setattr=system.bank=account2 -n1 hostname > deleted_entry1.out 2>&1 &&
+	test_debug "cat deleted_entry1.out" &&
+	grep "user/bank entry has been disabled from flux-accounting DB" deleted_entry1.out
+'
+
+test_expect_success 're-add second user/bank entry and update-plugin' '
+	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account2 --shares=1 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job successfully under second bank' '
+	jobid3=$(flux mini submit --setattr=system.bank=account2 -n1 hostname) &&
+	flux job wait-event -f json $jobid3 priority | jq '.context.priority' > job3.test &&
+	cat <<-EOF >job3.expected &&
+	10050000
+	EOF
+	test_cmp job3.expected job3.test
+'
+
+test_expect_success 'disable first (and default) bank entry for user (will update the plugin with a new default bank)' '
+	flux account -p ${DB_PATH} delete-user $username account1 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'try to submit job under new default user/bank entry' '
+	jobid4=$(flux mini submit -n1 hostname) &&
+	flux job wait-event -f json $jobid4 priority | jq '.context.priority' > job4.test &&
+	cat <<-EOF >job4.expected &&
+	10050000
+	EOF
+	test_cmp job4.expected job4.test
+'
+
+test_expect_success 'disabling a user while they have an active job should not kill the job' '
+	jobid5=$(flux mini submit -n1 sleep 60) &&
+	flux account -p ${DB_PATH} delete-user $username account2 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
+	test $(flux jobs -no {state} ${jobid5}) = RUN &&
+	flux job cancel $jobid5
+'
+
+test_expect_success 'trying to submit a job now should result in a job rejection' '
+	test_must_fail flux mini submit --setattr=system.bank=account2 -n1 hostname > deleted_entry2.out 2>&1 &&
+	test_debug "cat deleted_entry2.out" &&
+	grep "user/bank entry has been disabled from flux-accounting DB" deleted_entry2.out
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As mentioned in #232, we need a method for "disabling" a user/bank entry in the plugin's internal map when a user gets removed from a bank in the flux-accounting DB. Since entries don't get deleted in the internal map, a user can technically still run jobs under a bank they no longer belong to.

----

This is a small PR built on top of #239 that adds the `active` column to the group of user/bank information sent to the priority plugin, where it is then checked in `validate_cb ()` when a user/bank association submits a job. If the `active` column shows `0`, then that means the user/bank association is disabled from the flux-accounting DB, and thus disabled from running jobs.

A small sharness test is also added to exercise this check, where a user is added to two different banks in the flux-accounting DB and can successfully submit jobs under each bank. When the user gets removed from one bank and tries to submit a job under that bank, the job is rejected with an appropriate message saying that the association has been removed from the DB. Note that if a user is disabled (and the information is sent from the DB to the plugin) while they still have active jobs, the active jobs are still allowed to finish. Subsequently submitted jobs will be rejected, however.

Fixes #232