### PR TITLE
database: add `project_table`, `projects` column to association_table

### DIFF
--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -17,7 +17,8 @@ TESTSCRIPTS = \
 	test/test_example.py \
 	test/test_job_archive_interface.py \
 	test/test_user_subcommands.py \
-	test/test_queue_subcommands.py
+	test/test_queue_subcommands.py \
+	test/test_project_subcommands.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS)

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -3,6 +3,7 @@ acctpy_PYTHON = \
 	user_subcommands.py \
 	bank_subcommands.py \
 	queue_subcommands.py \
+	project_subcommands.py \
 	job_archive_interface.py \
 	create_db.py
 

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -101,6 +101,8 @@ def create_db(
                 max_active_jobs  int(11)     DEFAULT 7              NOT NULL    ON CONFLICT REPLACE DEFAULT 7,
                 max_nodes        int(11)     DEFAULT 2147483647     NOT NULL    ON CONFLICT REPLACE DEFAULT 2147483647,
                 queues           tinytext    DEFAULT ''             NOT NULL    ON CONFLICT REPLACE DEFAULT '',
+                projects         tinytext    DEFAULT '*'            NOT NULL    ON CONFLICT REPLACE DEFAULT '*',
+                default_project  tinytext    DEFAULT '*'            NOT NULL    ON CONFLICT REPLACE DEFAULT '*',
                 PRIMARY KEY   (username, bank)
         );"""
     )

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -177,4 +177,18 @@ def create_db(
             );"""
     )
 
+    # Projects Table
+    # stores projects
+    logging.info("Creating project_table in DB...")
+    conn.execute(
+        """
+            CREATE TABLE IF NOT EXISTS project_table (
+                project_id          integer    PRIMARY KEY AUTOINCREMENT,
+                project             tinytext               NOT NULL,
+                usage               real       DEFAULT 0.0 NOT NULL
+            );"""
+    )
+    conn.execute("INSERT INTO project_table (project) VALUES ('*')")
+    conn.commit()
+
     conn.close()

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sqlite3
+
+
+def view_project(conn, project):
+    cur = conn.cursor()
+    try:
+        # get the information pertaining to a project in the DB
+        cur.execute("SELECT * FROM project_table where project=?", (project,))
+        rows = cur.fetchall()
+        headers = [description[0] for description in cur.description]
+        if not rows:
+            print("Project not found in project_table")
+        else:
+            # print column names of project_table
+            for header in headers:
+                print(header.ljust(18), end=" ")
+            print()
+            for row in rows:
+                for col in list(row):
+                    print(str(col).ljust(18), end=" ")
+                print()
+    except sqlite3.OperationalError as e_database_error:
+        print(e_database_error)
+
+
+def add_project(conn, project):
+    try:
+        insert_stmt = "INSERT INTO project_table (project) VALUES (?)"
+        conn.execute(
+            insert_stmt,
+            (project,),
+        )
+
+        conn.commit()
+    # make sure entry is unique
+    except sqlite3.IntegrityError as integrity_error:
+        print(integrity_error)
+
+
+def delete_project(conn, project):
+    cursor = conn.cursor()
+
+    # look for any rows in the association_table that reference this project
+    select_stmt = "SELECT * FROM association_table WHERE projects LIKE ?"
+    cursor.execute(select_stmt, ("%" + project + "%",))
+    rows = cursor.fetchall()
+    if len(rows) > 0:
+        print(
+            """WARNING: user(s) in the assocation_table still reference this project.
+                 Make sure to edit user rows to account for this deleted project."""
+        )
+
+    delete_stmt = "DELETE FROM project_table WHERE project=?"
+    cursor.execute(delete_stmt, (project,))
+
+    conn.commit()

--- a/src/bindings/python/fluxacct/accounting/test/test_create_db.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_create_db.py
@@ -54,6 +54,7 @@ class TestDB(unittest.TestCase):
             "job_usage_factor_table",
             "t_half_life_period_table",
             "queue_table",
+            "project_table",
         ]
         self.assertEqual(list_of_tables, expected)
 

--- a/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import project_subcommands as p
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        c.create_db("TestProjectSubcommands.db")
+        global acct_conn
+        global cur
+
+        acct_conn = sqlite3.connect("TestProjectSubcommands.db")
+        cur = acct_conn.cursor()
+
+    # add a valid project to project_table
+    def test_01_add_valid_projects(self):
+        p.add_project(acct_conn, project="project_1")
+        cur.execute("SELECT * FROM project_table WHERE project='project_1'")
+        rows = cur.fetchall()
+
+        self.assertEqual(len(rows), 1)
+
+    # let's make sure if we try to add it a second time,
+    # it fails gracefully
+    def test_02_add_dup_project(self):
+        p.add_project(acct_conn, project="project_1")
+        self.assertRaises(sqlite3.IntegrityError)
+
+    # remove a project currently in the project_table
+    def test_03_delete_project(self):
+        p.delete_project(acct_conn, project="project_1")
+        cur.execute("SELECT * FROM project_table WHERE project='project_1'")
+        rows = cur.fetchall()
+
+        self.assertEqual(len(rows), 0)
+
+    # add a user to the accounting DB without specifying a default project
+    def test_04_default_project_unspecified(self):
+        u.add_user(acct_conn, username="user5001", uid=5001, bank="A")
+        cur.execute(
+            "SELECT default_project FROM association_table WHERE username='user5001' AND bank='A'"
+        )
+        rows = cur.fetchall()
+
+        self.assertEqual(rows[0][0], "*")
+
+    # add a user to the accounting DB by specifying a default project
+    def test_05_default_project_specified(self):
+        p.add_project(acct_conn, project="project_1")
+        u.add_user(
+            acct_conn, username="user5002", uid=5002, bank="A", projects="project_1"
+        )
+        cur.execute(
+            "SELECT default_project FROM association_table WHERE username='user5002' AND bank='A'"
+        )
+        rows = cur.fetchall()
+
+        self.assertEqual(rows[0][0], "project_1")
+
+        # make sure "*" is also added to the user's project list
+        cur.execute(
+            "SELECT projects FROM association_table WHERE username='user5002' AND bank='A'"
+        )
+        rows = cur.fetchall()
+
+        self.assertEqual(rows[0][0], "project_1,*")
+
+    # edit a user's default project
+    def test_06_edit_default_project(self):
+        u.edit_user(acct_conn, username="user5002", bank="A", default_project="*")
+        cur.execute(
+            "SELECT default_project FROM association_table WHERE username='user5002' AND bank='A'"
+        )
+        rows = cur.fetchall()
+
+        self.assertEqual(rows[0][0], "*")
+
+        # make sure projects list gets edited correctly
+        u.edit_user(acct_conn, username="user5002", bank="A", projects="project_1")
+        cur.execute(
+            "SELECT projects FROM association_table WHERE username='user5002' AND bank='A'"
+        )
+        rows = cur.fetchall()
+
+        self.assertEqual(rows[0][0], "project_1,*")
+
+    # editing a user's project list with a bad project name should raise a ValueError
+    def test_07_edit_projects_list_bad_name(self):
+        u.edit_user(acct_conn, username="user5002", bank="A", projects="foo")
+        self.assertRaises(ValueError)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        acct_conn.close()
+        os.remove("TestProjectSubcommands.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -94,6 +94,12 @@ def add_add_user_arg(subparsers):
         default="",
         metavar="QUEUES",
     )
+    subparser_add_user.add_argument(
+        "--projects",
+        help="projects the user is allowed to submit jobs under",
+        default="*",
+        metavar="PROJECTS",
+    )
 
 
 def add_delete_user_arg(subparsers):
@@ -156,6 +162,18 @@ def add_edit_user_arg(subparsers):
         help="queues the user is allowed to run jobs in",
         default=None,
         metavar="QUEUES",
+    )
+    subparser_edit_user.add_argument(
+        "--projects",
+        help="projects the user is allowed to submit jobs under",
+        default=None,
+        metavar="PROJECTS",
+    )
+    subparser_edit_user.add_argument(
+        "--default-project",
+        help="default projects the user submits jobs under when no project is specified",
+        default=None,
+        metavar="DEFAULT_PROJECT",
     )
 
 
@@ -442,6 +460,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.max_active_jobs,
             args.max_nodes,
             args.queues,
+            args.projects,
         )
     elif args.func == "delete_user":
         u.delete_user(conn, args.username, args.bank)
@@ -456,6 +475,8 @@ def select_accounting_function(args, conn, output_file, parser):
             args.max_active_jobs,
             args.max_nodes,
             args.queues,
+            args.projects,
+            args.default_project,
         )
     elif args.func == "view_job_records":
         jobs.output_job_records(

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -18,6 +18,7 @@ from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import job_archive_interface as jobs
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import queue_subcommands as qu
+from fluxacct.accounting import project_subcommands as p
 
 
 def add_path_arg(parser):
@@ -394,6 +395,39 @@ def add_delete_queue_arg(subparsers):
     subparser_delete_queue.add_argument("queue", help="queue name", metavar="QUEUE")
 
 
+def add_add_project_arg(subparsers):
+    subparser_add_project = subparsers.add_parser(
+        "add-project", help="add a new project"
+    )
+
+    subparser_add_project.set_defaults(func="add_project")
+    subparser_add_project.add_argument(
+        "project", help="project name", metavar="PROJECT"
+    )
+
+
+def add_view_project_arg(subparsers):
+    subparser_view_project = subparsers.add_parser(
+        "view-project", help="view project information"
+    )
+
+    subparser_view_project.set_defaults(func="view_project")
+    subparser_view_project.add_argument(
+        "project", help="project name", metavar="PROJECT"
+    )
+
+
+def add_delete_project_arg(subparsers):
+    subparser_delete_project = subparsers.add_parser(
+        "delete-project", help="remove a project"
+    )
+
+    subparser_delete_project.set_defaults(func="delete_project")
+    subparser_delete_project.add_argument(
+        "project", help="project name", metavar="PROJECT"
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -412,6 +446,9 @@ def add_arguments_to_parser(parser, subparsers):
     add_view_queue_arg(subparsers)
     add_edit_queue_arg(subparsers)
     add_delete_queue_arg(subparsers)
+    add_add_project_arg(subparsers)
+    add_view_project_arg(subparsers)
+    add_delete_project_arg(subparsers)
 
 
 def set_db_location(args):
@@ -520,6 +557,12 @@ def select_accounting_function(args, conn, output_file, parser):
             args.max_time_per_job,
             args.priority,
         )
+    elif args.func == "add_project":
+        p.add_project(conn, args.project)
+    elif args.func == "view_project":
+        p.view_project(conn, args.project)
+    elif args.func == "delete_project":
+        p.delete_project(conn, args.project)
     else:
         print(parser.print_usage())
 

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -46,6 +46,7 @@ test_expect_success 'get all the tables of the old DB and check that new table w
 	bank_table
 	job_usage_factor_table
 	t_half_life_period_table
+	project_table
 	organization
 	queue_table
 	EOF
@@ -70,6 +71,8 @@ test_expect_success 'get all the columns of the updated table in the DB and chec
 	max_active_jobs
 	max_nodes
 	queues
+	projects
+	default_project
 	organization
 	yrs_experience
 	EOF


### PR DESCRIPTION
As discussed in #247 and in #253, there is need to support projects within flux-accounting, or the ability for multiple users from different banks to all work on the same project. One of the first requirements is to be able to add projects to a table to keep track of as well as list projects that a user belongs to in the `association_table`.

---

This is a [WIP] PR that adds a new table to the flux-accounting database: `project_table`, a table storing project names. Its schema consists of the following:

```sql
CREATE TABLE IF NOT EXISTS project_table (
        project_id          integer    PRIMARY KEY AUTOINCREMENT,
        project             tinytext               NOT NULL
);
```

A new column is also added to the `association_table`: `projects`, which stores all of the projects that a user is allowed to specify when running jobs. A default value (`*`) is added as a default project for all users when they are added to the flux-accounting DB:

```sql
projects         tinytext    DEFAULT '*'            NOT NULL    ON CONFLICT REPLACE DEFAULT '*'
```

A couple of new commands to interact with the `project_table` are also added that allows an admin to add, view, and remove project information from the table. A helper function is also added to the `add-user` and `edit-user` commands to validate the projects specified for a user/bank row in the `association_table` so that a user does not get added to a project that does not exist in the `project_table`.

When removing a project from the `project_table`, a quick check is performed in the `association_table` to see if any user/bank rows still reference this project; if so, a warning message is printed notifying the admin that the project being deleted is still being referenced, and thus those user rows should be edited to account for the deletion. 

Both unit tests and sharness tests are added to test both the functions that interact with the `project_table` and the `add-project`, `view-project`, and `delete-project` commands.

Since I am still a little unfamiliar with our current use of projects (currently known as WCKeys), I'll pose a couple questions here that might help add some more useful functionality or change my current PR to be better:

- are deleting projects common on our current machines? When projects get deleted, do any users who still reference that project also get edited automatically to no longer reference that project, or are admins also responsible for changing those user rows?
- do projects have a `job_usage` value? i.e is it common on our current machines to calculate a usage value for all of the jobs that run under a specific project? I know @ryanday36 mentioned in #247 that it does not affect and is not included in fairshare, but I figured I could get a little more clarification in case I should add another column to the `project_table` to include a usage value.

Fixes #253