### PR TITLE
NEWS.md: add release notes for `v0.18.1`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+flux-accounting version 0.18.1 - 2022-08-09
+-------------------------------------------
+
+#### Fixes
+
+* Fix `update-db` command to provide clearer exception messages when
+the command fails to update a flux-accounting database (#258)
+
+#### Features
+
+* Add new tests for the `update-db` command for updating old versions
+of a flux-accounting database (#258)
+
 flux-accounting version 0.18.0 - 2022-08-02
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for `v0.18.1`, a new version which contains fixes and test additions added in #258. After this PR is merged, I can create an annotated tag with the following:

```
git tag -a v0.18.1 -m "Tag v0.18.1" && git push upstream v0.18.1
```