### PR TITLE
plugin: add new `plugin.query` callback

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -19,7 +19,8 @@ TESTSCRIPTS = \
 	t1015-mf-priority-urgency.t \
 	t1016-export-db.t \
 	t1017-update-db.t \
-	t1018-mf-priority-disable-entry.t
+	t1018-mf-priority-disable-entry.t \
+	t1019-mf-priority-info-fetch.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \
@@ -71,7 +72,9 @@ EXTRA_DIST= \
 	expected/pop_db/db_hierarchy_new_users.expected \
 	expected/job_usage/pre_update.expected \
 	expected/job_usage/post_update1.expected \
-	expected/job_usage/post_update2.expected
+	expected/job_usage/post_update2.expected \
+	expected/plugin_state/internal_state_1.expected \
+	expected/plugin_state/internal_state_3.expected
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output

--- a/t/expected/plugin_state/internal_state_1.expected
+++ b/t/expected/plugin_state/internal_state_1.expected
@@ -1,0 +1,27 @@
+[
+  {
+    "userid": 1001,
+    "banks": [
+      {
+        "bank": "account1",
+        "fairshare": 0.5,
+        "max_run_jobs": 2,
+        "cur_run_jobs": 0,
+        "max_active_jobs": 7,
+        "cur_active_jobs": 0,
+        "held_jobs": [],
+        "active": 1
+      },
+      {
+        "bank": "account2",
+        "fairshare": 0.5,
+        "max_run_jobs": 5,
+        "cur_run_jobs": 0,
+        "max_active_jobs": 7,
+        "cur_active_jobs": 0,
+        "held_jobs": [],
+        "active": 1
+      }
+    ]
+  }
+]

--- a/t/expected/plugin_state/internal_state_3.expected
+++ b/t/expected/plugin_state/internal_state_3.expected
@@ -1,0 +1,42 @@
+[
+  {
+    "userid": 1001,
+    "banks": [
+      {
+        "bank": "account1",
+        "fairshare": 0.5,
+        "max_run_jobs": 2,
+        "cur_run_jobs": 0,
+        "max_active_jobs": 7,
+        "cur_active_jobs": 0,
+        "held_jobs": [],
+        "active": 1
+      },
+      {
+        "bank": "account2",
+        "fairshare": 0.5,
+        "max_run_jobs": 5,
+        "cur_run_jobs": 0,
+        "max_active_jobs": 7,
+        "cur_active_jobs": 0,
+        "held_jobs": [],
+        "active": 1
+      }
+    ]
+  },
+  {
+    "userid": 1002,
+    "banks": [
+      {
+        "bank": "account3",
+        "fairshare": 0.5,
+        "max_run_jobs": 5,
+        "cur_run_jobs": 0,
+        "max_active_jobs": 7,
+        "cur_active_jobs": 0,
+        "held_jobs": [],
+        "active": 1
+      }
+    ]
+  }
+]

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+test_description='Test getting internal state of plugin using flux jobtap query'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/plugin_state
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success HAVE_JQ 'flux jobtap query returns basic information' '
+	flux jobtap query mf_priority.so >query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".name == \"mf_priority.so\"" <query.json &&
+	jq -e ".path == \"${MULTI_FACTOR_PRIORITY}\"" <query.json
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account3 1
+'
+
+test_expect_success 'add a user with two different banks to the DB' '
+	flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=account1 --max-running-jobs=2 &&
+	flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=account2
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success HAVE_JQ 'fetch plugin state' '
+	flux jobtap query mf_priority.so > query_1.json &&
+	jq ".mf_priority_map" query_1.json > internal_state_1.test &&
+	test_cmp ${EXPECTED_FILES}/internal_state_1.expected internal_state_1.test
+'
+
+test_expect_success 'submit max number of jobs under default bank (1 held job due to max_run_jobs limit)' '
+	jobid1=$(flux python ${SUBMIT_AS} 1001 sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} 1001 sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} 1001 sleep 60)
+'
+
+test_expect_success HAVE_JQ 'fetch plugin state and make sure that jobs are reflected in JSON object' '
+	flux jobtap query mf_priority.so > query_2.json &&
+	test_debug "jq -S . <query_2.json" &&
+	jq -e ".mf_priority_map[0].banks[0].held_jobs | length == 1" <query_2.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 2" <query_2.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_2.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3
+'
+
+test_expect_success 'add another user to flux-accounting DB and send it to plugin' '
+	flux account -p ${DB_PATH} add-user --username=user1002 --userid=1002 --bank=account3 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success HAVE_JQ 'fetch plugin state again with multiple users' '
+	flux jobtap query mf_priority.so > query_3.json &&
+	jq ".mf_priority_map" query_3.json > internal_state_3.test &&
+	test_cmp ${EXPECTED_FILES}/internal_state_3.expected internal_state_3.test
+'
+
+test_done


### PR DESCRIPTION
#### Background

As described in #263, it would be useful to have a utility to fetch the internal state of the multi-factor priority plugin to look at the current data it has on users, banks, and their current running and active jobs. This would be helpful when looking at jobs currently held because of a jobs limit or to see what users or banks are currently in the plugin.

---

This PR adds a new `plugin.query` callback that returns all the internal data that the plugin has about its users, banks, and their running and active job counts at the time of the query in a JSON object. It includes data such as:

- all the users/banks it has received from the flux-accounting DB via `flux account-priority-update`
- current fair-share values, `max_run_jobs` and `max_active_jobs` counts for each user/bank
- any held job IDs for each user/bank

Fixes #263