### PR TITLE
NEWS: add release notes for v0.19.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+flux-accounting version 0.19.0 - 2022-09-07
+-------------------------------------------
+
+#### Features
+
+* Add new `plugin.query` callback to multi-factor priority plugin which returns
+internal information about users and banks, active and running job counts, and
+any held jobs at the time of the query (#264)
+
 flux-accounting version 0.18.1 - 2022-08-09
 -------------------------------------------
 


### PR DESCRIPTION
First Tuesday of the month coming up, so add release notes for `v0.19.0` of flux-accounting. Once this PR lands, I'll create an annotated tag with the following command:

```
git tag -a v0.19.0 -m "Tag v0.19.0" && git push upstream v0.19.0
```