### PR TITLE
t1017: condense `update-db` tests with old DBs

### DIFF
--- a/t/scripts/db_integrity_check.py
+++ b/t/scripts/db_integrity_check.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+import sys
+import sqlite3
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(f"Usage: integrity_check DATABASE_PATH")
+
+    db_uri = sys.argv[1]
+
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        cur = conn.cursor()
+    except sqlite3.OperationalError as exc:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(exc)
+        sys.exit(1)
+
+    cur.execute("PRAGMA integrity_check")
+    result = cur.fetchone()[0]
+    print("result:", result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Background

`t1017-update-db.t` has separate tests that run the `update-db` command on previous versions of flux-accounting DBs starting with `v0.10.0`. They are all separate tests, but they run the same set of commands and it really lengthens the amount of lines in the test file.

---

This is a small PR that just condenses all of the tests that run the `update-db` command on old versions of flux-accounting databases into a for-loop that iterates through the directory containing the DBs and updates them. I looked to https://github.com/flux-framework/flux-core/blob/3c367a3a15e888857cab2e8dbf2704e97861a494/t/t2219-job-manager-restart.t#L57-L66 for some guidance on how to do this. :-)

Fixes #260