### PR TITLE
python: add additional exception messages to python commands

### DIFF
--- a/src/cmd/flux-account-export-db.py
+++ b/src/cmd/flux-account-export-db.py
@@ -37,8 +37,9 @@ def est_sqlite_conn(path):
         conn = sqlite3.connect(db_uri, uri=True)
         # set foreign keys constraint
         conn.execute("PRAGMA foreign_keys = 1")
-    except sqlite3.OperationalError:
+    except sqlite3.OperationalError as exc:
         print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
         sys.exit(1)
 
     return conn

--- a/src/cmd/flux-account-pop-db.py
+++ b/src/cmd/flux-account-pop-db.py
@@ -39,8 +39,9 @@ def est_sqlite_conn(path):
         conn = sqlite3.connect(db_uri, uri=True)
         # set foreign keys constraint
         conn.execute("PRAGMA foreign_keys = 1")
-    except sqlite3.OperationalError:
+    except sqlite3.OperationalError as exc:
         print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
         sys.exit(1)
 
     return conn

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -37,8 +37,9 @@ def est_sqlite_conn(path):
         conn = sqlite3.connect(db_uri, uri=True)
         # set foreign keys constraint
         conn.execute("PRAGMA foreign_keys = 1")
-    except sqlite3.OperationalError:
+    except sqlite3.OperationalError as exc:
         print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
         sys.exit(1)
 
     return conn

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -37,8 +37,9 @@ def est_sqlite_conn(path):
         conn = sqlite3.connect(db_uri, uri=True)
         # set foreign keys constraint
         conn.execute("PRAGMA foreign_keys = 1")
-    except sqlite3.OperationalError:
+    except sqlite3.OperationalError as exc:
         print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
         sys.exit(1)
 
     return conn
@@ -236,6 +237,7 @@ def update_db(path, new_db):
         os.remove(new_db)
     except sqlite3.OperationalError as exc:
         print(f"Unable to open temporary database file: {new_db}")
+        print(f"Exception: {exc}")
         sys.exit(1)
     except sqlite3.IntegrityError as exc:
         print(f"Exception: {exc}")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -413,8 +413,9 @@ def establish_sqlite_connection(path):
         conn = sqlite3.connect(db_uri, uri=True)
         # set foreign keys constraint
         conn.execute("PRAGMA foreign_keys = 1")
-    except sqlite3.OperationalError:
+    except sqlite3.OperationalError as exc:
         print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
         sys.exit(1)
 
     return conn


### PR DESCRIPTION
#### Problem

Often times when looking at the error message of one of the Python commands, the message is unclear or does not tell the whole story of what went wrong.

---

This is a small PR that adds additional exception messages to be printed to `STDOUT` when an exception occurs when running one of the flux-accounting Python commands to provide more clarity on what error actually occurred.