### PR TITLE
[WIP] plugin: rework `inactive_cb ()`, `priority_cb ()`, and more

### DIFF
--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -170,7 +170,7 @@ test_expect_success 'update max_active_jobs limit' '
 				"bank": "account3",
 				"def_bank": "account3",
 				"fairshare": 0.45321,
-				"max_running_jobs": 3,
+				"max_running_jobs": 2,
 				"max_active_jobs": 5,
 				"queues": ""
 			}
@@ -203,11 +203,7 @@ test_expect_success 'cancel one of the active jobs' '
 
 test_expect_success 'newly submitted job should now be accepted since user is under their max_active_jobs limit' '
 	jobid7=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
-	flux job wait-event -f json $jobid7 priority | jq '.context.priority' > job7.test &&
-	cat <<-EOF >job7.expected &&
-	45321
-	EOF
-	test_cmp job7.expected job7.test
+	test $(flux jobs -no {state} ${jobid7}) = DEPEND
 '
 
 test_expect_success 'cancel all remaining active jobs' '


### PR DESCRIPTION
#### Problem

As described in issue #262, a number of jobs were stuck in `DEPEND` state on fluke due to a `max-running-jobs-limit`: a limit that determines how many _running_ jobs a user can have at any given time. While digging through the plugin and trying to come up with a reproducer, a number of sub-issues popped up that could be a cause of this issue. 

##### sub-issue 1

When a job held in `DEPEND` state transitions to inactive before running, it still decrements the `cur_running_job` count for the user/bank combo, which results in incorrect job counts.

##### sub-issue 2

When a job held in `DEPEND` state transitions to inactive before running and there is more than one held job, it still releases a currently held job even if there are already a max number of running jobs already running.

##### sub-issue 3

When a job held in `DEPEND state` transitions to inactive before running and is not the first held job in the user/bank's list of held jobs, it still releases the first held job even if there are already a max number of running jobs already running.

The changes proposed in this PR look to fix some of the issues reported on fluke about jobs being stuck in `DEPEND` state without having any running jobs to correctly release them.

---

The bulk of this PR re-works the `inactive_cb ()` to check the job ID of the job that transitioned to inactive. It checks that the `held_jobs` list is greater than 0, and if it is, looks for the job ID in the list of held jobs. If it finds itself in the list of held jobs, it only decrements the `cur_active_jobs` count, removes itself from the list of held jobs, and `return`s. Otherwise, it determines that this job transitioned from `RUN` state, so it decrements both `cur_active_jobs` and `cur_run_jobs`.

Another addition to the plugin is checking for both `cur_run_jobs` and `cur_active_jobs` in `priority_cb ()` (when a job enters `job.state.priority`. These checks will enforce limits on jobs that have been submitted by a user/bank combo whose information has not yet been sent from the flux-accounting database to the plugin's internal map. When the user/bank's information has been sent in an update and `reprioritize_all ()` is called on all pending jobs and each job re-enters `job.state.priority`, these limits are checked. If the limit has been hit, it will raise an exception on the job.

Some of the values of a user's "DNE" entry (created when a user/bank combo submits a job before their information has been loaded from the flux-accounting DB to the plugin) of the plugin's internal map have also been adjusted to hopefully better values, especially the `active` field, which should be set to 1 instead of 0.

As a result of some of the plugin rework, one section of the limits sharness test, `t1005-max-jobs-limit.t` has been reworked. One of the sections in the test increases the `max_active_jobs` count of a user and submits a max number of active jobs.
This incorrectly tests that the last submitted job receives a priority from the plugin, when it really should be held in `DEPEND` state. This PR changes the test that checks for an integer priority for the last submitted job to instead check that the job is in `DEPEND` state.