### PR TITLE
flux-accounting: add DB schema version to flux-accounting DB

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -1,4 +1,5 @@
 db_dir = "@X_LOCALSTATEDIR@/lib/flux/"
 db_path = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
+db_schema_version = 20
 
-__all__ = ["db_dir", "db_path"]
+__all__ = ["db_dir", "db_path", "db_schema_version"]

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -16,6 +16,8 @@ import pathlib
 import math
 import time
 
+import fluxacct.accounting
+
 
 def add_usage_columns_to_table(
     conn, table_name, priority_usage_reset_period=None, priority_decay_half_life=None
@@ -81,6 +83,9 @@ def create_db(
     except sqlite3.OperationalError as exception:
         logging.error(exception)
         sys.exit(1)
+
+    # set version number of database
+    conn.execute("PRAGMA user_version = %d" % (fluxacct.accounting.db_schema_version))
 
     # Association Table
     logging.info("Creating association_table in DB...")

--- a/src/cmd/flux-account-export-db.py
+++ b/src/cmd/flux-account-export-db.py
@@ -42,6 +42,17 @@ def est_sqlite_conn(path):
         print(f"Exception: {exc}")
         sys.exit(1)
 
+    # check version of database; if not up to date, output message
+    # and exit
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version")
+    db_version = cur.fetchone()[0]
+    if db_version < fluxacct.accounting.db_schema_version:
+        print(
+            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+        )
+        sys.exit(1)
+
     return conn
 
 

--- a/src/cmd/flux-account-pop-db.py
+++ b/src/cmd/flux-account-pop-db.py
@@ -44,6 +44,17 @@ def est_sqlite_conn(path):
         print(f"Exception: {exc}")
         sys.exit(1)
 
+    # check version of database; if not up to date, output message
+    # and exit
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version")
+    db_version = cur.fetchone()[0]
+    if db_version < fluxacct.accounting.db_schema_version:
+        print(
+            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+        )
+        sys.exit(1)
+
     return conn
 
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -593,6 +593,17 @@ def main():
 
     conn = establish_sqlite_connection(path)
 
+    # check version of database; if not up to date, output message
+    # and exit
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version")
+    db_version = cur.fetchone()[0]
+    if db_version < 20:
+        print(
+            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+        )
+        sys.exit(1)
+
     output_file = set_output_file(args)
 
     try:


### PR DESCRIPTION
This is a small PR that adds a schema version number to the flux-accounting database. This integer version number represents the version of the most current DB schema and will only change when the schema of the DB changes from one version to the next. It is defined with the other `fluxacct` package variables, `db_dir` and `db_path` in the project's `__init__.py.in` file.

A check has also been added to the flux accounting commands that looks at the version number of the database the command is trying to connect to. If the version number is less than the version number defined in `__init__.py.in`, a message will be output saying that the DB is out of date and should be updated with `flux account-update-db`. This command will now do two additional things:

1) if the DB is out of date, it will update the version number of the DB after it has completed updating all existing tables and columns, and/or

2) will add a version number to an existing flux-accounting DB that may not have a schema version number associated with it.

The `flux account-priority-update` command also now has a check to check the schema version of the flux-accounting DB. If it is out of date, it automatically calls flux `account-update-db` to update the database before sending the DB information to the multi-factor priority plugin. If for some reason the update fails, it prints out the exception message(s) from the update and aborts both the DB update and _before_ sending the information to the multi-factor priority plugin. 

Fixes #270

##### TODO

- add tests for checking DB schema version