### PR TITLE
python: improve bank command bindings, test names and descriptions

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -61,18 +61,23 @@ def print_sub_banks(conn, bank, indent=""):
             print_sub_banks(conn, row[0], indent + " ")
 
 
+def validate_parent_bank(cur, parent_bank):
+    try:
+        cur.execute("SELECT shares FROM bank_table WHERE bank=?", (parent_bank,))
+        row = cur.fetchone()
+        if row is None:
+            raise ValueError("Parent bank not found in bank table")
+    except sqlite3.OperationalError as e_database_error:
+        print(e_database_error)
+
+
 def add_bank(conn, bank, shares, parent_bank=""):
     cur = conn.cursor()
-    # if the parent bank is not "", that means the bank
-    # trying to be added wants to be placed under a parent bank
+
+    # if the parent bank is not "", that means the bank trying
+    # to be added wants to be placed under an existing parent bank
     if parent_bank != "":
-        try:
-            cur.execute("SELECT shares FROM bank_table WHERE bank=?", (parent_bank,))
-            row = cur.fetchone()
-            if row is None:
-                raise Exception("Parent bank not found in bank table")
-        except sqlite3.OperationalError as e_database_error:
-            print(e_database_error)
+        validate_parent_bank(cur, parent_bank)
 
     # insert the bank values into the database
     try:

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -191,7 +191,7 @@ def edit_bank(conn, bank, shares):
     # if user tries to edit a shares value <= 0,
     # raise an exception
     if int(shares) <= 0:
-        raise Exception("New shares amount must be >= 0")
+        raise ValueError("New shares amount must be >= 0")
     try:
         # edit value in bank_table
         conn.execute(

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -13,6 +13,12 @@ import sqlite3
 
 from fluxacct.accounting import user_subcommands as u
 
+###############################################################
+#                                                             #
+#                      Helper Functions                       #
+#                                                             #
+###############################################################
+
 # helper function to print user information in a table format
 def print_user_rows(cur, rows, bank):
     print("\nUsers Under Bank {bank_name}:\n".format(bank_name=bank))
@@ -69,6 +75,13 @@ def validate_parent_bank(cur, parent_bank):
             raise ValueError("Parent bank not found in bank table")
     except sqlite3.OperationalError as e_database_error:
         print(e_database_error)
+
+
+###############################################################
+#                                                             #
+#                   Subcommand Functions                      #
+#                                                             #
+###############################################################
 
 
 def add_bank(conn, bank, shares, parent_bank=""):

--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -19,10 +19,9 @@ from fluxacct.accounting import create_db as c
 
 
 class TestAccountingCLI(unittest.TestCase):
-    # create accounting, job-archive databases
+    # create test flux-accounting database
     @classmethod
     def setUpClass(self):
-        # create example accounting database
         c.create_db("TestBankSubcommands.db")
         global acct_conn
         global cur
@@ -33,22 +32,20 @@ class TestAccountingCLI(unittest.TestCase):
             print(f"Unable to open test database file", file=sys.stderr)
             sys.exit(-1)
 
-    # let's add a top-level account using the add-bank
-    # subcommand
+    # add a top-level account using add_bank()
     def test_01_add_bank_success(self):
         b.add_bank(acct_conn, bank="root", shares=100)
         cur.execute("SELECT * FROM bank_table WHERE bank='root'")
         rows = cur.fetchall()
         self.assertEqual(len(rows), 1)
 
-    # let's make sure if we try to add it a second time,
-    # it fails gracefully
+    # check for an IntegrityError when trying to add a duplicate bank
     def test_02_add_dup_bank(self):
         b.add_bank(acct_conn, bank="root", shares=100)
         self.assertRaises(sqlite3.IntegrityError)
 
     # trying to add a sub account with an invalid parent bank
-    # name should result in a failure
+    # name should result in a ValueError
     def test_03_add_with_invalid_parent_bank(self):
         with self.assertRaises(ValueError) as context:
             b.add_bank(
@@ -60,9 +57,8 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertTrue("Parent bank not found in bank table" in str(context.exception))
 
-    # now let's add a couple sub accounts whose parent is 'root'
-    # and whose total shares equal root's allocation (100 shares)
-    def test_04_add_subaccounts(self):
+    # add a couple sub accounts whose parent is 'root'
+    def test_04_add_sub_banks(self):
         b.add_bank(acct_conn, bank="sub_account_1", parent_bank="root", shares=50)
         cur.execute("SELECT * FROM bank_table WHERE bank='sub_account_1'")
         rows = cur.fetchall()
@@ -80,7 +76,7 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(rows[0][0], 0)
 
-    # disabling a parent bank should remove all of its sub banks
+    # disabling a parent bank should disable all of its sub banks
     def test_06_disable_parent_bank(self):
         b.delete_bank(acct_conn, bank="root")
         b.delete_bank(acct_conn, bank="sub_account_2")
@@ -115,8 +111,8 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(cursor.fetchone()[0], 50)
 
-    # trying to edit a bank value <= 0 should raise
-    # an exception
+    # trying to edit a bank's shares <= 0 should raise
+    # a ValueError
     def test_08_edit_bank_value_fail(self):
         with self.assertRaises(ValueError) as context:
             b.add_bank(acct_conn, bank="bad_bank", shares=10)

--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -50,7 +50,7 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to add a sub account with an invalid parent bank
     # name should result in a failure
     def test_03_add_with_invalid_parent_bank(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             b.add_bank(
                 acct_conn,
                 bank="bad_subaccount",
@@ -118,7 +118,7 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to edit a bank value <= 0 should raise
     # an exception
     def test_08_edit_bank_value_fail(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             b.add_bank(acct_conn, bank="bad_bank", shares=10)
             b.edit_bank(acct_conn, bank="bad_bank", shares=-1)
 


### PR DESCRIPTION
This is a minor cleanup PR of the bank commands and unit tests. It cleans up the `add_bank()` function by moving some validation to a helper function and changes a couple of the exceptions that get raised in the `validate_parent_bank()` helper function and `edit_bank()` function from a general Python exception to a `ValueError`.

It also looks to clean up some of the test names and descriptions of the unit tests for the bank functions, as some of them are poorly worded (thanks to me! 😆) and could use some improvement. 