### PR TITLE
add-user: add bank validation

### DIFF
--- a/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
@@ -15,6 +15,7 @@ import sqlite3
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import project_subcommands as p
 
 
@@ -53,6 +54,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # add a user to the accounting DB without specifying a default project
     def test_04_default_project_unspecified(self):
+        b.add_bank(acct_conn, bank="A", shares=1)
         u.add_user(acct_conn, username="user5001", uid=5001, bank="A")
         cur.execute(
             "SELECT default_project FROM association_table WHERE username='user5001' AND bank='A'"

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -242,6 +242,12 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(cur.fetchone()[0], "A")
 
+    # adding a user to a nonexistent bank should raise a ValueError
+    def test_13_add_user_to_nonexistent_bank(self):
+        u.add_user(acct_conn, username="test_user4", bank="foo")
+
+        self.assertRaises(ValueError)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -18,6 +18,7 @@ import sys
 from unittest import mock
 
 from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import create_db as c
 
 
@@ -37,6 +38,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # add a valid user to association_table
     def test_01_add_valid_user(self):
+        b.add_bank(acct_conn, bank="acct", shares=10)
         u.add_user(
             acct_conn,
             username="fluxuser",
@@ -77,6 +79,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # add a user with the same username but a different bank
     def test_03_add_duplicate_user(self):
+        b.add_bank(acct_conn, bank="other_acct", shares=10)
         u.add_user(
             acct_conn,
             username="dup_user",
@@ -149,6 +152,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # check for a new user's default bank
     def test_07_check_default_bank_new_user(self):
+        b.add_bank(acct_conn, bank="test_bank", shares=10)
         u.add_user(
             acct_conn,
             username="test_user1",
@@ -164,6 +168,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # check for an existing user's default bank
     def test_08_check_default_bank_existing_user(self):
+        b.add_bank(acct_conn, bank="other_test_bank", shares=10)
         u.add_user(
             acct_conn,
             username="test_user1",
@@ -200,6 +205,8 @@ class TestAccountingCLI(unittest.TestCase):
     # disable a user who belongs to multiple banks; make sure that the default_bank
     # is updated to the next earliest associated bank
     def test_11_disable_user_default_bank_row(self):
+        b.add_bank(acct_conn, bank="A", shares=1)
+        b.add_bank(acct_conn, bank="B", shares=1)
         u.add_user(acct_conn, username="test_user2", bank="A")
         u.add_user(acct_conn, username="test_user2", bank="B")
         cur = acct_conn.cursor()

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -67,6 +67,15 @@ def validate_project(conn, projects):
     return ",".join(project_list)
 
 
+def validate_bank(conn, bank):
+    cur = conn.cursor()
+
+    cur.execute("SELECT bank FROM bank_table WHERE bank=?", (bank,))
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError('Bank "%s" does not exist in bank_table' % bank)
+
+
 def set_default_project(projects):
     if projects != "*":
         project_list = projects.split(",")
@@ -201,6 +210,13 @@ def add_user(
     cur = conn.cursor()
 
     userid = set_uid(username, uid)
+
+    # validate the bank specified if one was passed in
+    try:
+        validate_bank(conn, bank)
+    except ValueError as err:
+        print(err)
+        return -1
 
     # set default bank for user
     default_bank = set_default_bank(cur, username, bank)

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -264,6 +264,11 @@ test_expect_success 'edit the default project of a user' '
 	grep -f projects_list.expected edited_default_project.test
 '
 
+test_expect_success 'trying to add a user to a nonexistent bank should raise a ValueError' '
+	flux account -p ${DB_PATH} add-user --username=user5019 --bank=foo > nonexistent_bank.out &&
+	grep "Bank \"foo\" does not exist in bank_table" nonexistent_bank.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

As noted in #276, the `add-user` command does not validate the bank specified when adding a user to the flux-accounting database. So, a user can be added to a bank that does not exist in the `bank_table`.

---

This is a small PR that adds a validation helper function that looks at the bank being specified when adding a user. If the bank does not exist in the `bank_table`, it raises a ValueError with a message saying that the bank does not exist in the database, and does not add the user.

Both a unit test and sharness test are added to ensure that a non-existent bank in fact does raise a `ValueError` and prevents a user from being added to the flux-accounting database. 