### PR TITLE
testsuite: adjust queue tests for flux-core changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,6 @@ adl_RECURSIVE_EVAL([$localstatedir], acct_db_path)
 AS_VAR_SET(acct_db_path, $acct_db_path)
 AC_SUBST(acct_db_path)
 
-AC_CONFIG_MACRO_DIR([config])
 X_AC_EXPAND_INSTALL_DIRS
 
 fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic"

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -34,6 +34,29 @@ test_size_large() {
 
 
 #
+#  Like test_must_fail(), but additionally allow process to be
+#   terminated by SIGKILL or SIGTERM
+#
+test_must_fail_or_be_terminated() {
+    "$@"
+    exit_code=$?
+    # Allow death by SIGTERM or SIGKILL
+    if test $exit_code = 143 -o $exit_code = 137; then
+        return 0
+    elif test $exit_code = 0; then
+        echo >&2 "test_must_fail: command succeeded: $*"
+        return 1
+    elif test $exit_code -gt 129 -a $exit_code -le 192; then
+        echo >&2 "test_must_fail: died by non-SIGTERM signal: $*"
+        return 1
+    elif test $exit_code = 127; then
+        echo >&2 "test_must_fail: command not found: $*"
+        return 1
+    fi
+    return 0
+}
+
+#
 #  Tests using test_under_flux() and which load their own modules should
 #   ensure those modules are unloaded at the end of the test for proper
 #   cleanup and test coverage (also as a general principle, module unload
@@ -64,15 +87,113 @@ check_module_list() {
 }
 
 #
-#  Reinvoke a test file under a flux comms instance
+#  Generate configuration for test bootstrap and print args for flux-start
+#  Usage:  args=$(make_bootstrap_config workdir sockdir size)
 #
-#  Usage: test_under_flux <size>
+make_bootstrap_config() {
+    local workdir=$1
+    local sockdir=$2
+    local size=$3
+    local fakehosts="fake[0-$(($size-1))]"
+    local full="0-$(($size-1))"
+
+    mkdir $workdir/conf.d
+    mkdir $workdir/state
+    flux keygen --name testcert $workdir/cert
+    cat >$workdir/conf.d/bootstrap.toml <<-EOT
+	[bootstrap]
+	    curve_cert = "$workdir/cert"
+	    default_bind = "ipc://$sockdir/tbon-%h"
+	    default_connect = "ipc://$sockdir/tbon-%h"
+	    hosts = [
+	        { host = "$fakehosts" },
+	    ]
+	EOT
+    flux R encode --hosts=$fakehosts -r$full >$workdir/R
+    cat >$workdir/conf.d/resource.toml <<-EOT2
+	[resource]
+	    path = "$workdir/R"
+	    noverify = true
+	EOT2
+    echo "--test-hosts=$fakehosts -o,-c$workdir/conf.d"
+    echo "--test-exit-mode=${TEST_UNDER_FLUX_EXIT_MODE:-leader}"
+    echo "--test-exit-timeout=${TEST_UNDER_FLUX_EXIT_TIMEOUT:-0}"
+    echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$full}"
+    echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
+    echo "-o,-Stbon.fanout=${TEST_UNDER_FLUX_FANOUT:-$size}"
+    echo "-o,-Stbon.zmqdebug=1"
+    echo "-o,-Sstatedir=$workdir/state"
+}
+
+#
+#  Remove any outer trash-directory wrapper used by "system"
+#   personality test_under_flux() tests.
+#
+remove_trashdir_wrapper() {
+    local trashdir=$(dirname $SHARNESS_TRASH_DIRECTORY)
+    case $trashdir in
+        */trash-directory.[!/]*) rm -rf $trashdir
+    esac
+}
+
+#
+#  Reinvoke a test file under a flux instance
+#
+#  Usage: test_under_flux <size> [personality] [flux-start-options]
+#
+#  where personality is one of:
+#
+#  full (default)
+#    Run with all services.
+#    The default broker rc scripts are executed.
+#
+#  minimal
+#    Run with only built-in services.
+#    No broker rc scripts are executed.
+#
+#  job
+#    Load minimum services needed to run jobs.
+#    Fake resources are loaded into the resource module.
+#    Environment variables:
+#    - TEST_UNDER_FLUX_CORES_PER_RANK
+#        Set the number of fake cores per fake node (default: 2).
+#    - TEST_UNDER_FLUX_NO_JOB_EXEC
+#        If set, skip loading job-exec module (default: load job-exec).
+#    - TEST_UNDER_FLUX_SCHED_SIMPLE_MODE
+#        Change mode argument to sched-simple (default: limited=8)
+#
+#  kvs
+#    Load minimum services needed for kvs.
+#
+#  system
+#    Like full, but bootstrap with a generated config file.
+#    Environment variables:
+#    - TEST_UNDER_FLUX_EXIT_MODE
+#        Set the flux-start exit mode (default: leader)
+#    - TEST_UNDER_FLUX_EXIT_TIMEOUT
+#        Set the flux-start exit timeout (default: 0)
+#    - TEST_UNDER_FLUX_QUORUM
+#        Set the broker.quorum attribute (default: 0-<highest_rank>)
+#    - TEST_UNDER_FLUX_START_MODE
+#        Set the flux-start start mode (default: all)
+#    - TEST_UNDER_FLUX_FANOUT
+#        Set the TBON fanout (default: size (flat))
 #
 test_under_flux() {
     size=${1:-1}
     personality=${2:-full}
+
+    #  Note: args > 2 are passed along as extra arguments
+    #   to flux-start below using "$@", so shift up to the
+    #   the first two arguments away:
+    #
+    test $# -eq 1 && shift || shift 2
+
     log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
+        if test "$TEST_UNDER_FLUX_PERSONALITY" = "system"; then
+            test "$debug" = "t" || cleanup remove_trashdir_wrapper
+        fi
         test "$debug" = "t" || cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
         flux_module_list > module-list.initial
         cleanup check_module_list
@@ -98,6 +219,16 @@ test_under_flux() {
     if test "$personality" = "minimal"; then
         RC1_PATH=""
         RC3_PATH=""
+    elif test "$personality" = "system"; then
+        # Pre-create broker rundir so we know it in advance and
+        # make_bootstrap_config() can use it for ipc:// socket paths.
+        BROKER_RUNDIR=$(mktemp --directory --tmpdir flux-system-XXXXXX)
+        sysopts=$(make_bootstrap_config \
+          $SHARNESS_TRASH_DIRECTORY $BROKER_RUNDIR $size)
+        # Place the re-executed test script trash within the first invocation's
+        # trash to preserve config files for broker restart in test
+        flags="${flags} --root=$SHARNESS_TRASH_DIRECTORY"
+        unset root
     elif test "$personality" != "full"; then
         RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
         RC3_PATH=$FLUX_SOURCE_DIR/t/rc/rc3-$personality
@@ -107,6 +238,11 @@ test_under_flux() {
         unset RC1_PATH
         unset RC3_PATH
     fi
+
+    if test -n "$root"; then
+        flags="${flags} --root=$root"
+    fi
+
     if test -n "$FLUX_TEST_VALGRIND" ; then
         VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
         valgrind="--wrap=libtool,e"
@@ -123,11 +259,16 @@ test_under_flux() {
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
+    TEST_UNDER_FLUX_PERSONALITY="${personality:-default}" \
       exec flux start --test-size=${size} \
+                      ${BROKER_RUNDIR+--test-rundir=${BROKER_RUNDIR}} \
+                      ${BROKER_RUNDIR+--test-rundir-cleanup} \
                       ${RC1_PATH+-o -Sbroker.rc1_path=${RC1_PATH}} \
                       ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
+                      ${sysopts} \
                       ${logopts} \
                       ${valgrind} \
+                      "$@" \
                      "sh $0 ${flags}"
 }
 
@@ -240,5 +381,24 @@ fi
 #  job of an existing RM.
 for var in $(env | grep ^PMI); do unset ${var%%=*}; done
 for var in $(env | grep ^SLURM); do unset ${var%%=*}; done
+
+# Sanitize Flux environment variables that should not be inherited by
+#  tests
+unset FLUX_SHELL_RC_PATH
+unset FLUX_RC_EXTRA
+unset FLUX_CONF_DIR
+unset FLUX_JOB_CC
+unset FLUX_F58_FORCE_ASCII
+
+# Individual tests that need to force local URI resolution should set
+#  this specifically. In general it breaks other URI tests:
+unset FLUX_URI_RESOLVE_LOCAL
+
+# Set XDG_CONFIG_DIRS and XDG_CONFIG_HOME to a nonexistent directory to
+#  avoid system or user configuration influencing tests for utilities
+#  that use flux.util.UtilConfig or other config classes utilizing
+#  the XDG base directory specification.
+export XDG_CONFIG_DIRS=/noexist
+export XDG_CONFIG_HOME=/noexist
 
 # vi: ts=4 sw=4 expandtab

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -94,13 +94,13 @@ test_expect_success 'configure flux with those queues' '
 
 test_expect_success 'submit a job using a queue the user does not belong to' '
 	test_must_fail flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account2 \
-		--setattr=system.queue=expedite -n1 hostname > unavail_queue.out 2>&1 &&
+		--queue=expedite -n1 hostname > unavail_queue.out 2>&1 &&
 	test_debug "unavail_queue.out" &&
 	grep "Queue not valid for user: expedite" unavail_queue.out
 '
 
 test_expect_success 'submit a job using a nonexistent queue' '
-	test_must_fail flux python ${SUBMIT_AS} 5011 --setattr=system.queue=foo \
+	test_must_fail flux python ${SUBMIT_AS} 5011 --queue=foo \
 		-n1 hostname > bad_queue.out 2>&1 &&
 	test_debug "bad_queue.out" &&
 	grep "Queue does not exist: foo" bad_queue.out
@@ -108,7 +108,7 @@ test_expect_success 'submit a job using a nonexistent queue' '
 
 test_expect_success 'submit a job using standby queue, which should not increase job priority' '
 	jobid1=$(flux python ${SUBMIT_AS} 5011 --job-name=standby \
-		--setattr=system.bank=account1 --setattr=system.queue=standby -n1 hostname) &&
+		--setattr=system.bank=account1 --queue=standby -n1 hostname) &&
 	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
 	cat <<-EOF >job1.expected &&
 	50000
@@ -118,7 +118,7 @@ test_expect_success 'submit a job using standby queue, which should not increase
 
 test_expect_success 'submit a job using expedite queue, which should increase priority' '
 	jobid2=$(flux python ${SUBMIT_AS} 5011 --job-name=expedite \
-		--setattr=system.bank=account1 --setattr=system.queue=expedite -n1 hostname) &&
+		--setattr=system.bank=account1 --queue=expedite -n1 hostname) &&
 	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	100050000
@@ -127,9 +127,9 @@ test_expect_success 'submit a job using expedite queue, which should increase pr
 '
 
 test_expect_success 'submit a job using the rest of the available queues' '
-	jobid3=$(flux python ${SUBMIT_AS} 5011 --job-name=bronze --setattr=system.queue=bronze -n1 hostname) &&
-	jobid4=$(flux python ${SUBMIT_AS} 5011 --job-name=silver --setattr=system.queue=silver -n1 hostname) &&
-	jobid5=$(flux python ${SUBMIT_AS} 5011 --job-name=gold --setattr=system.queue=gold -n1 hostname)
+	jobid3=$(flux python ${SUBMIT_AS} 5011 --job-name=bronze --queue=bronze -n1 hostname) &&
+	jobid4=$(flux python ${SUBMIT_AS} 5011 --job-name=silver --queue=silver -n1 hostname) &&
+	jobid5=$(flux python ${SUBMIT_AS} 5011 --job-name=gold --queue=gold -n1 hostname)
 '
 
 test_expect_success 'check order of job queue' '
@@ -157,7 +157,7 @@ test_expect_success 'unload mf_priority.so' '
 '
 
 test_expect_success 'submit a job to a nonexistent queue with no plugin information loaded' '
-	jobid6=$(flux python ${SUBMIT_AS} 5011 --setattr=system.queue=foo -n1 hostname) &&
+	jobid6=$(flux python ${SUBMIT_AS} 5011 --queue=foo -n1 hostname) &&
 	test $(flux jobs -no {state} ${jobid6}) = PRIORITY
 '
 


### PR DESCRIPTION
Problem: flux-accounting's `t1013-mf-priority-queues.t` test was failing in CI for flux-framework/flux-core#4627.

The job manager is made more picky about the queue config by that PR.  It's no longer possible to submit a job for a queue that is not in a `[queues]` configuration,  as the job manager now rejects it at submission.

There was also a failing test which checked that flux-accounting assigned a default queue if one was configured.  This is now handled at ingest by the "frobnicator" so flux-accounting should not need to assign defaults.  I removed the test (and another related one that was already commented out).  I'll open another issue to track changes that might be needed in flux-accounting for these queue changes.

There are a couple of minor cleanups here as well.