### PR TITLE
NEWS: add release notes for v0.20.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,31 @@
+flux-accounting version 0.20.0 - 2022-10-04
+-------------------------------------------
+
+#### Fixes
+
+* Add additional exception messages to Python commands (#267)
+
+* Improve dependency message for running jobs limit (#269)
+
+* Clean up user subcommand functions (#271)
+
+* Clean up bank subcommand functions (#275)
+
+* Disable queue validation in multi-factor priority plugin on unknown queue,
+no configured "default" queue after flux-core queue changes (#281)
+
+* Change default values of "DNE" entry to allow multiple jobs to be submitted
+(#286)
+
+* Change install location of multi-factor priority plugin (#287)
+
+#### Features
+
+* Add database schema version to flux-accounting DB (#274)
+
+* Add automatic DB upgrade to `flux account-priority-update` command if
+flux-accounting database is out of date (#274)
+
 flux-accounting version 0.19.0 - 2022-09-07
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.20.0`. The other outstanding PR's in this repository should not be critical to land for this release as they are minor cleanups/fixes, or they still warrant some further thinking or discussion. :-)

Once this lands, I'll create an annotated tag with:

```
git tag -a v0.20.0 -m "Tag v0.20.0" && git push upstream v0.20.0
``` 