### PR TITLE
plugin: change default values of "DNE" entry to allow multiple jobs to be submitted

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -32,7 +32,7 @@ extern "C" {
 // the plugin does not know about the association who submitted a job and will
 // assign default values to the association until it receives information from
 // flux-accounting
-#define BANK_INFO_MISSING -9
+#define BANK_INFO_MISSING 999
 
 // a queue is specified for a submitted job that flux-accounting does not know
 // about
@@ -650,8 +650,9 @@ static void add_missing_bank_info (flux_plugin_t *p, flux_t *h, int userid)
     b->fairshare = 0.1;
     b->max_run_jobs = BANK_INFO_MISSING;
     b->cur_run_jobs = 0;
-    b->max_active_jobs = 0;
+    b->max_active_jobs = 1000;
     b->cur_active_jobs = 0;
+    b->active = 1;
     b->held_jobs = std::vector<long int>();
 
     if (flux_jobtap_job_aux_set (p,

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -18,6 +18,24 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
+test_expect_success 'submit a number of jobs with no user/bank info loaded to plugin' '
+	jobid1=$(flux mini submit --wait-event=depend hostname) &&
+	jobid2=$(flux mini submit --wait-event=depend hostname) &&
+	jobid3=$(flux mini submit --wait-event=depend hostname)
+'
+
+test_expect_success 'make sure jobs get held in state PRIORITY' '
+	test $(flux jobs -no {state} ${jobid1}) = PRIORITY &&
+	test $(flux jobs -no {state} ${jobid2}) = PRIORITY &&
+	test $(flux jobs -no {state} ${jobid3}) = PRIORITY
+'
+
+test_expect_success 'cancel held jobs' '
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid2 &&
+	flux job cancel $jobid3
+'
+
 test_expect_success 'submit job #1 with no user/bank info loaded to plugin' '
 	jobid1=$(flux mini submit --wait-event=depend hostname)
 '


### PR DESCRIPTION
#### Problem

As noted in #283, when the multi-factor priority plugin encounters a job for which it has no user/bank info, it allows one job to be submitted, but not subsequently submitted jobs. This is because it **does not** set the `active` field (which has a default value of 0) for the "DNE" entry it creates for the user/bank to during the first job submission, which means that any following submitted job would be met with a rejection message explaining that the user is disabled from the database:

```
[Errno 22] user/bank entry has been disabled from flux-accounting DB
```

---

This PR changes some of the default values of the "DNE" entry created for a user/bank when they submit jobs while their information is not loaded from the flux-accounting database. It sets `active` to 1 to prevent them from having their submitted jobs rejected, and changes their job count limits, `max_running_jobs` and `max_active_jobs` to more reasonable values to allow them to submit multiple jobs (999 and 1000, respectively).

A couple of new tests are also added to `t1014-mf-priority-dne.t` to make sure that a user/bank can submit multiple jobs (in this test case, 3 jobs) without having their information loaded to the plugin. The test makes sure that the jobs can be submitted and that they are held in PRIORITY state.

Fixes #283
