### PR TITLE
plugin: change install location

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -4,6 +4,9 @@ AM_CPPFLAGS = -I$(top_srcdir) $(FLUX_CORE_CFLAGS)
 
 AM_CXXFLAGS = $(CODE_COVERAGE_CXXFLAGS) -fPIC -shared
 
-lib_LTLIBRARIES = mf_priority.la
+jobtapdir = \
+  $(fluxlibdir)/job-manager/plugins/
+
+jobtap_LTLIBRARIES = mf_priority.la
 mf_priority_la_SOURCES = mf_priority.cpp
 mf_priority_la_LDFLAGS = $(fluxplugin_ldflags) -module


### PR DESCRIPTION
#### Problem

As noted in #284, mf_priority.so is installed to `$libdir`, but the job manager looks for it in `$libdir/flux/job-manager/plugins`.

---

This PR takes the suggestion from @garlick (and @jameshcorbett) in #284 and changes the install location of the plugin in its Makefile.am. After this PR lands, the following lines should be removed from flux-accounting's `.spec` file:

```
# FIXME: remove these lines when package is fixed
mkdir -p ${RPM_BUILD_ROOT}%{_libdir}/flux/job-manager/plugins
mv ${RPM_BUILD_ROOT}%{_libdir}/mf_priority.so ${RPM_BUILD_ROOT}%{_libdir}/flux/job-manager/plugins/
```

Fixes #284