### PR TITLE
`update-db`: use tempfile module for temporary flux-accounting DB during upgrade

### DIFF
--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -158,4 +158,9 @@ test_expect_success 'successfully call a flux account command after the old DB h
 	flux account -p ${OLD_DB} add-bank root 1
 '
 
+test_expect_success 'call update-db from the / directory to make sure command works' '
+	cd / &&
+	flux account-update-db -p ${OLD_DB}
+'
+
 test_done


### PR DESCRIPTION
#### Problem

As noted in #285, the `update-db` command fails during an automatic update because it is trying to create a temporary flux-accounting database in the broker's current working directory, which is `/`. The `update-db` command's behavior creates this temporary database in the current working directory, which causes problems if the directory does not have the correct permissions.

---

This PR uses the `tempfile` module to create a temporary directory inside `/tmp/` to store the temporary flux-accounting DB that gets created during an update. After the update is completed, the directory is cleaned up and removed. This should prevent the temporary database from attempting to be created wherever the command is running from, which might not have the necessary permissions.

Fixes #285 