### PR TITLE
NEWS: add release notes for v0.20.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+flux-accounting version 0.20.1 - 2022-10-05
+-------------------------------------------
+
+#### Fixes
+
+* Change `update-db` command to create temporary database in `/tmp` instead
+of current working directory (#288)
+
 flux-accounting version 0.20.0 - 2022-10-04
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for `v0.20.1`, which contains fixes for the errors described in #285. 

Once this PR lands, I'll create an annotated tag with the following command:

```
git tag -a v0.20.1 -m "Tag v0.20.1" && git push upstream v0.20.1
```