### PR TITLE
plugin: add project validation and annotation

### DIFF
--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -71,12 +71,14 @@ def bulk_update(path):
     data = {}
     bulk_user_data = []
     bulk_q_data = []
+    bulk_p_data = []
 
     # fetch all rows from association_table (will print out tuples)
     for row in cur.execute(
         """SELECT userid, bank, default_bank,
            fairshare, max_running_jobs, max_active_jobs,
-           queues, active FROM association_table"""
+           queues, active, projects, default_project
+           FROM association_table"""
     ):
         # create a JSON payload with the results of the query
         single_user_data = {
@@ -88,6 +90,8 @@ def bulk_update(path):
             "max_active_jobs": int(row[5]),
             "queues": str(row[6]),
             "active": int(row[7]),
+            "projects": str(row[8]),
+            "def_project": str(row[9]),
         }
         bulk_user_data.append(single_user_data)
 
@@ -110,6 +114,18 @@ def bulk_update(path):
     data = {"data": bulk_q_data}
 
     flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(data)).get()
+
+    # fetch all rows from project_table
+    for row in cur.execute("SELECT project FROM project_table"):
+        # create a JSON payload with the results of the query
+        single_p_data = {
+            "project": str(row[0]),
+        }
+        bulk_p_data.append(single_p_data)
+
+    data = {"data": bulk_p_data}
+
+    flux.Flux().rpc("job-manager.mf_priority.rec_project_update", data).get()
 
     flux.Flux().rpc("job-manager.mf_priority.reprioritize")
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -183,15 +183,17 @@ static int get_queue_info (
 }
 
 
-static void split_string (char *queues, struct bank_info *b)
+static void split_string_and_push_back (char *list,
+                                        std::vector<std::string> *vec)
 {
     std::stringstream s_stream;
 
-    s_stream << queues; // create string stream from string
+    s_stream << list; // create string stream from string
+
     while (s_stream.good ()) {
         std::string substr;
         getline (s_stream, substr, ','); // get string delimited by comma
-        b->queues.push_back (substr);
+        vec->push_back (substr);
     }
 }
 
@@ -531,7 +533,7 @@ static void rec_update_cb (flux_t *h,
 
         // split queues comma-delimited string and add it to b->queues vector
         b->queues.clear ();
-        split_string (queues, b);
+        split_string_and_push_back (queues, &b->queues);
 
         users_def_bank[uid] = def_bank;
     }

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -462,6 +462,36 @@ static bank_info_result get_bank_info (int userid, char *bank)
 }
 
 
+static int update_jobspec_project (flux_plugin_t *p, int userid, char *bank)
+{
+    std::string project;
+
+    // look up user/bank info based on unpacked information
+    bank_info_result lookup_result = get_bank_info (userid, bank);
+
+    if (lookup_result.first == BANK_USER_NOT_FOUND
+        || lookup_result.first == BANK_INVALID
+        || lookup_result.first == BANK_NO_DEFAULT)
+        return -1;
+
+    // set bank_info to the struct that holds the user/bank information
+    // and get user's default project
+    auto bank_info = lookup_result.second->second;
+    project = bank_info.def_project;
+
+    if (!project.empty ()) {
+        // post jobspec-update event
+        if (flux_jobtap_jobspec_update_pack (p,
+                                             "{s:s}",
+                                             "attributes.system.project",
+                                             project.c_str ()) < 0)
+            return -1;
+    }
+
+    return 0;
+}
+
+
 /******************************************************************************
  *                                                                            *
  *                               Callbacks                                    *

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -99,7 +99,11 @@ EXTRA_DIST= \
 	expected/job_usage/post_update1.expected \
 	expected/job_usage/post_update2.expected \
 	expected/plugin_state/internal_state_1.expected \
-	expected/plugin_state/internal_state_3.expected
+	expected/plugin_state/internal_state_3.expected \
+	expected/sample_payloads/same_fairshare.json \
+	expected/sample_payloads/small_no_tie.json \
+	expected/sample_payloads/small_tie_all.json \
+	expected/sample_payloads/small_tie.json
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -32,6 +32,7 @@ TESTSCRIPTS = \
 	t1028-mf-priority-issue385.t \
 	t1029-mf-priority-default-bank.t \
 	t1030-mf-priority-update-queue.t \
+	t1031-mf-priority-projects.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/expected/plugin_state/internal_state_1.expected
+++ b/t/expected/plugin_state/internal_state_1.expected
@@ -10,7 +10,11 @@
         "max_active_jobs": 7,
         "cur_active_jobs": 0,
         "held_jobs": [],
-        "active": 1
+        "active": 1,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*"
       },
       {
         "bank": "account2",
@@ -20,7 +24,11 @@
         "max_active_jobs": 7,
         "cur_active_jobs": 0,
         "held_jobs": [],
-        "active": 1
+        "active": 1,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*"
       }
     ]
   }

--- a/t/expected/plugin_state/internal_state_3.expected
+++ b/t/expected/plugin_state/internal_state_3.expected
@@ -10,7 +10,11 @@
         "max_active_jobs": 7,
         "cur_active_jobs": 0,
         "held_jobs": [],
-        "active": 1
+        "active": 1,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*"
       },
       {
         "bank": "account2",
@@ -20,7 +24,11 @@
         "max_active_jobs": 7,
         "cur_active_jobs": 0,
         "held_jobs": [],
-        "active": 1
+        "active": 1,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*"
       }
     ]
   },
@@ -35,7 +43,11 @@
         "max_active_jobs": 7,
         "cur_active_jobs": 0,
         "held_jobs": [],
-        "active": 1
+        "active": 1,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*"
       }
     ]
   }

--- a/t/expected/sample_payloads/same_fairshare.json
+++ b/t/expected/sample_payloads/same_fairshare.json
@@ -1,0 +1,89 @@
+{
+  "data" : [
+    {
+      "userid": 5011,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5012,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5013,
+      "bank": "account1",
+      "def_bank":
+      "account1",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5021,
+      "bank": "account2",
+      "def_bank": "account2",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5022,
+      "bank": "account2",
+      "def_bank": "account2",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5031,
+      "bank": "account3",
+      "def_bank": "account3",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5032,
+      "bank": "account3",
+      "def_bank": "account3",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    }
+  ]
+}

--- a/t/expected/sample_payloads/small_no_tie.json
+++ b/t/expected/sample_payloads/small_no_tie.json
@@ -1,0 +1,88 @@
+{
+  "data" : [
+    {
+      "userid": 5011,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.285714,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5012,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.142857,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5013,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.428571,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5021,
+      "bank": "account2",
+      "def_bank": "account2",
+      "fairshare": 0.714286,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5022,
+      "bank": "account2", 
+      "def_bank": "account2",
+      "fairshare": 0.571429,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5031,
+      "bank": "account3",
+      "def_bank": "account3",
+      "fairshare": 1.0,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5032,
+      "bank": "account3",
+      "def_bank": "account3",
+      "fairshare": 0.857143,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    }
+  ]
+}

--- a/t/expected/sample_payloads/small_tie.json
+++ b/t/expected/sample_payloads/small_tie.json
@@ -1,0 +1,100 @@
+{
+  "data" : [
+    {
+      "userid": 5011,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5012,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5013,
+      "bank": "account1",
+      "def_bank": "account1",
+      "fairshare": 0.75,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5021,
+      "bank": "account2",
+      "def_bank": "account2",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5022,
+      "bank": "account2",
+      "def_bank": "account2",
+      "fairshare": 0.5,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5023,
+      "bank": "account2",
+      "def_bank": "account2",
+      "fairshare": 0.75,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5031,
+      "bank": "account3",
+      "def_bank": "account3",
+      "fairshare": 1.0,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    },
+    {
+      "userid": 5032,
+      "bank": "account3",
+      "def_bank": "account3",
+      "fairshare": 0.875,
+      "max_running_jobs": 5,
+      "max_active_jobs": 7,
+      "queues": "",
+      "active": 1,
+      "projects": "*",
+      "def_project": "*"
+    }
+  ]
+}

--- a/t/expected/sample_payloads/small_tie_all.json
+++ b/t/expected/sample_payloads/small_tie_all.json
@@ -1,0 +1,112 @@
+{
+  "data" : [
+      {
+        "userid": 5011,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.666667,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5012,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.666667,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5013,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 1,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5021,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.666667,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5022,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.666667,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5023,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 1,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5031,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 0.666667,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5032,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 0.666667,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      },
+      {
+        "userid": 5033,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 1,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
+      }
+  ]
+}

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -51,7 +51,10 @@ test_expect_success 'create fake_payload.py' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 10,
 				"max_active_jobs": 12,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			},
 			{
 				"userid": userid,
@@ -60,7 +63,10 @@ test_expect_success 'create fake_payload.py' '
 				"fairshare": 0.11345,
 				"max_running_jobs": 10,
 				"max_active_jobs": 12,
-				"queues": "standby"
+				"queues": "standby",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -167,7 +173,10 @@ test_expect_success 'pass special key to user/bank struct to nullify information
 				"fairshare": 0.45321,
 				"max_running_jobs": -1,
 				"max_active_jobs": 12,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -195,7 +204,10 @@ test_expect_success 'resend user/bank information with valid data and successful
 				"fairshare": 0.45321,
 				"max_running_jobs": 2,
 				"max_active_jobs": 4,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -6,6 +6,7 @@ test_description='Test multi-factor priority plugin order with no ties'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+SMALL_NO_TIE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_no_tie.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
@@ -21,24 +22,8 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create a group of users with unique fairshare values' '
-	cat <<-EOF >fake_small_no_tie.json
-	{
-		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
-		]
-	}
-	EOF
-'
-
 test_expect_success 'send the user information to the plugin' '
-	flux python ${SEND_PAYLOAD} fake_small_no_tie.json
+	flux python ${SEND_PAYLOAD} ${SMALL_NO_TIE}
 '
 
 test_expect_success 'add a default queue and send it to the plugin' '

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -6,6 +6,7 @@ test_description='Test multi-factor priority plugin with some ties'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+SMALL_TIE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_tie.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
@@ -21,25 +22,8 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create a group of users with some ties in fairshare values' '
-	cat <<-EOF >fake_small_tie.json
-	{
-		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
-		]
-	}
-	EOF
-'
-
 test_expect_success 'send the user information to the plugin' '
-	flux python ${SEND_PAYLOAD} fake_small_tie.json
+	flux python ${SEND_PAYLOAD} ${SMALL_TIE}
 '
 
 test_expect_success 'add a default queue and send it to the plugin' '

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -6,6 +6,7 @@ test_description='Test multi-factor priority plugin with many ties'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+SMALL_TIE_ALL=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_tie_all.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
@@ -21,26 +22,8 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create a group of users with many ties in fairshare values' '
-	cat <<-EOF >fake_small_tie_all.json
-	{
-	    "data" : [
-	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
-	    ]
-	}
-	EOF
-'
-
 test_expect_success 'send the user information to the plugin' '
-	flux python ${SEND_PAYLOAD} fake_small_tie_all.json
+	flux python ${SEND_PAYLOAD} ${SMALL_TIE_ALL}
 '
 
 test_expect_success 'add a default queue and send it to the plugin' '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -32,7 +32,10 @@ test_expect_success 'create fake_user.json' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 2,
 				"max_active_jobs": 4,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			},
 			{
 				"userid": 5011,
@@ -41,7 +44,10 @@ test_expect_success 'create fake_user.json' '
 				"fairshare": 0.11345,
 				"max_running_jobs": 1,
 				"max_active_jobs": 2,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -123,7 +129,10 @@ test_expect_success 'increase the max jobs count of the user' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 3,
 				"max_active_jobs": 4,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -172,7 +181,10 @@ test_expect_success 'update max_active_jobs limit' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 3,
 				"max_active_jobs": 5,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -229,7 +241,10 @@ test_expect_success 'create another user with the same limits in multiple banks'
 				"fairshare": 0.45321,
 				"max_running_jobs": 1,
 				"max_active_jobs": 2,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			},
 			{
 				"userid": 5012,
@@ -238,7 +253,10 @@ test_expect_success 'create another user with the same limits in multiple banks'
 				"fairshare": 0.11345,
 				"max_running_jobs": 1,
 				"max_active_jobs": 2,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -32,8 +32,30 @@ test_expect_success 'create fake_payload.py' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 1, "max_active_jobs": 3},
-			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 3}
+			{
+				"userid": userid,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 1,
+				"max_active_jobs": 3,
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
+			},
+			{
+				"userid": userid,
+				"bank": "account2",
+				"def_bank": "account3",
+				"fairshare": 0.11345,
+				"max_running_jobs": 1,
+				"max_active_jobs": 3,
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
+			}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -63,7 +63,10 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 				"fairshare": 0.45321,
 				"max_running_jobs": 10,
 				"max_active_jobs": 12,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}

--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -55,7 +55,7 @@ test_expect_success 'add user to flux-accounting DB and update plugin' '
 test_expect_success 'check that bank was added to jobspec' '
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
-	grep "{\"attributes.system.bank\":\"account1\"}" eventlog.out &&
+	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
 	flux job cancel $jobid
 '
 
@@ -75,7 +75,7 @@ test_expect_success 'successfully submit a job under a default bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
-	grep "{\"attributes.system.bank\":\"account1\"}" eventlog.out &&
+	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
 	flux job cancel $jobid
 '
 
@@ -88,7 +88,7 @@ test_expect_success 'successfully submit a job under the new default bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
-	grep "{\"attributes.system.bank\":\"account2\"}" eventlog.out &&
+	grep "\"attributes.system.bank\":\"account2\"" eventlog.out &&
 	flux job cancel $jobid
 '
 

--- a/t/t1031-mf-priority-projects.t
+++ b/t/t1031-mf-priority-projects.t
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+test_description='test validating and setting project names in priority plugin'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1
+'
+
+test_expect_success 'add projects to the DB' '
+	flux account -p ${DB_PATH} add-project projectA &&
+	flux account -p ${DB_PATH} add-project projectB &&
+	flux account -p ${DB_PATH} add-project projectC
+'
+
+test_expect_success 'submit jobs under two different users before plugin gets updated' '
+	job_project_star=$(flux python ${SUBMIT_AS} 5001 hostname) &&
+	job_project_A=$(flux python ${SUBMIT_AS} 5002 hostname) &&
+	flux job wait-event -vt 60 $job_project_star depend &&
+	flux job wait-event -vt 60 $job_project_A depend
+'
+
+# if a user is added to the DB without specifying any projects, a default
+# project "*" is added for the user automatically, and jobs submitted without
+# specifying a project will fall under "*" - this is the case for the first
+# added user; every user who is added to the DB belongs to the "*" project,
+# but will only run jobs under "*"  if they do not already have another default
+# project.
+#
+# if a user is added to the DB with a specified project name, any job submitted
+# without specifying a project name will fall under that project name - this is
+# the case for the second user.
+test_expect_success 'add those users to flux-accounting DB and to plugin; jobs transition to RUN' '
+	flux account -p ${DB_PATH} add-user \
+		--username=user1 \
+		--userid=5001 \
+		--bank=account1 &&
+	flux account -p ${DB_PATH} add-user \
+		--username=user2 \
+		--userid=5002 \
+		--bank=account1 \
+		--projects=projectA &&
+	flux account-priority-update -p ${DB_PATH} &&
+	flux job wait-event -vt 60 $job_project_star alloc &&
+	flux job wait-event -vt 60 $job_project_A alloc
+'
+
+test_expect_success 'check that first submitted job has project "*" listed in eventlog' '
+	flux job info $job_project_star eventlog > eventlog.out &&
+	grep "\"attributes.system.project\":\"\*\"" eventlog.out &&
+	flux job cancel $job_project_star
+'
+
+test_expect_success 'check that second submitted job has project "projectA" listed in eventlog' '
+	flux job info $job_project_A eventlog > eventlog.out &&
+	grep "\"attributes.system.project\":\"projectA\"" eventlog.out &&
+	flux job cancel $job_project_A
+'
+
+test_expect_success 'add a user with a list of projects to the DB' '
+	flux account -p ${DB_PATH} add-user \
+		--username=user3 \
+		--userid=5003 \
+		--bank=account1 \
+		--projects="projectA,projectB"
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'successfully submit a job under a valid project' '
+	jobid=$(flux python ${SUBMIT_AS} 5003 --setattr=system.project=projectA hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid jobspec > jobspec.out &&
+	grep "projectA" jobspec.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'submit a job under a project that does not exist' '
+	test_must_fail flux python ${SUBMIT_AS} 5003 --setattr=system.project=projectFOO \
+		hostname > project_dne.out 2>&1 &&
+	test_debug "cat project_dne.out" &&
+	grep "project does not exist: projectFOO" project_dne.out
+'
+
+test_expect_success 'submit a job under a project that user does not belong to' '
+	test_must_fail flux python ${SUBMIT_AS} 5003 --setattr=system.project=projectC \
+		hostname > project_invalid.out 2>&1 &&
+	test_debug "cat project_invalid.out" &&
+	grep "project not valid for user: projectC" project_invalid.out
+'
+
+test_expect_success 'successfully submit a job under a default project' '
+	jobid=$(flux python ${SUBMIT_AS} 5003 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "\"attributes.system.project\":\"projectA\"" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'successfully submit a job under a secondary project' '
+	jobid=$(flux python ${SUBMIT_AS} 5003 --setattr=system.project=projectB hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid jobspec > jobspec.out &&
+	grep "projectB" jobspec.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'update the default project for user and submit job under new default' '
+	flux account -p ${DB_PATH} edit-user user3 --default-project=projectB &&
+	flux account-priority-update -p ${DB_PATH} &&
+	jobid=$(flux python ${SUBMIT_AS} 5003 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "\"attributes.system.project\":\"projectB\"" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'add a user without specifying any projects (will add a default project of "*")' '
+	flux account -p ${DB_PATH} add-user --username=user4 --userid=5004 --bank=account1 &&
+	flux account-priority-update -p ${DB_PATH} &&
+	jobid=$(flux python ${SUBMIT_AS} 5004 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "\"attributes.system.project\":\"\*\"" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'add a new default project to the new user and update the plugin' '
+	flux account -p ${DB_PATH} edit-user user4 --projects=projectA --default-project=projectA &&
+	flux account-priority-update -p ${DB_PATH} &&
+	jobid=$(flux python ${SUBMIT_AS} 5004 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "\"attributes.system.project\":\"projectA\"" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Background

Mentioned in #293, there is a requirement to be able to associate jobs with "projects," which allow multiple users who belong in different banks to submit jobs under one entity. Currently, the flux-accounting database supports adding projects and adding associations to certain projects, but this information is not relayed to the multi-factor priority plugin, so there is no way to associate a job with a project.

---

This PR adds project support in the priority plugin. The two big components that make up this PR are 1) providing some validation for projects if one is specified during `job.validate`, and 2) updating the jobspec with the project name in the PRIORITY event of a job.

Projects (along with the default project) for each association are now sent via `flux account-priority-update` to the plugin's internal map, where they are unpacked and stored in each association's `bank_info` object. The project information for each association is also added to the information returned in the `plugin.query` callback.

When an association specifies a project during job submission with `--setattr=system.project=my_project`, the project name is checked to both exist and be a valid project for the user to submit jobs under. Failure in either of these checks results in a job rejection with an appropriate message as to why the job was rejected.

If a user/bank submits a job under a default project, a `jobspec-update` event is posted under `attributes.system.project` in the PRIORITY event to add the user/bank's default project. The project name can then be found in the job's eventlog:

```json
{"timestamp": 1666106606.9670131,"name":"jobspec-update","context":{"attributes.system.project":"my_default_project"}}
```