### PR TITLE
[WIP] plugin: add "age" factor to priority calculation

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -354,17 +354,18 @@ static int conf_update_cb (flux_plugin_t *p,
                            flux_plugin_arg_t *args,
                            void *data)
 {
-    int fshare_weight = -1, queue_weight = -1;
+    int fshare_weight = -1, queue_weight = -1, age_weight = -1;
     flux_t *h = flux_jobtap_get_flux (p);
 
     // unpack the various factors to be used in the multi-factor
     // priority calculation
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s?{s?{s?i, s?i}}}",
+                                "{s?{s?{s?i, s?i, s?i}}}",
                                 "conf", "priority_factors",
                                 "fshare_weight", &fshare_weight,
-                                "queue_weight", &queue_weight) < 0) {
+                                "queue_weight", &queue_weight,
+                                "age_weight", &age_weight) < 0) {
         flux_log_error (flux_jobtap_get_flux (p),
                         "mf_priority: conf.update: flux_plugin_arg_unpack: %s",
                         flux_plugin_arg_strerror (args));
@@ -373,6 +374,7 @@ static int conf_update_cb (flux_plugin_t *p,
     // assign unpacked weights into priority_weights map
     priority_weights["fshare_weight"] = fshare_weight;
     priority_weights["queue_weight"] = queue_weight;
+    priority_weights["age_weight"] = age_weight;
 
     return 0;
 }

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -100,8 +100,15 @@ int64_t priority_calculation (flux_plugin_t *p,
     int fshare_weight, queue_weight;
     struct bank_info *b;
 
-    fshare_weight = 100000;
-    queue_weight = 10000;
+    fshare_weight = priority_weights["fshare_weight"];
+    queue_weight = priority_weights["queue_weight"];
+
+    // check values of priority factor weights; if not configured,
+    // these will be set to -1, so just use default weights
+    if (fshare_weight == -1)
+        fshare_weight = 100000;
+    if (queue_weight == -1)
+        queue_weight = 10000;
 
     if (urgency == FLUX_JOB_URGENCY_HOLD)
         return FLUX_JOB_PRIORITY_MIN;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -20,7 +20,8 @@ TESTSCRIPTS = \
 	t1016-export-db.t \
 	t1017-update-db.t \
 	t1018-mf-priority-disable-entry.t \
-	t1019-mf-priority-info-fetch.t
+	t1019-mf-priority-info-fetch.t \
+	t1020-mf-priority-config.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -21,7 +21,8 @@ TESTSCRIPTS = \
 	t1017-update-db.t \
 	t1018-mf-priority-disable-entry.t \
 	t1019-mf-priority-info-fetch.t \
-	t1020-mf-priority-config.t
+	t1020-mf-priority-config.t \
+	t1021-mf-priority-age.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -7,9 +7,11 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -19,6 +21,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'send an empty payload to make sure unpack fails' '

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -7,9 +7,11 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -19,6 +21,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create a group of users with unique fairshare values' '

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -7,9 +7,11 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -19,6 +21,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create a group of users with some ties in fairshare values' '

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -7,9 +7,11 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -19,6 +21,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create a group of users with many ties in fairshare values' '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -7,9 +7,11 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -19,6 +21,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create fake_user.json' '

--- a/t/t1008-mf-priority-update.t
+++ b/t/t1008-mf-priority-update.t
@@ -7,9 +7,11 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -19,6 +21,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create flux-accounting DB' '

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -6,9 +6,11 @@ test_description='Test multi-factor priority plugin and loading user information
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -18,6 +20,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create fake_payload.py' '

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -24,6 +24,14 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >conf.d/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
+'
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '
@@ -82,6 +90,8 @@ test_expect_success 'configure flux with those queues' '
 	[queues.silver]
 	[queues.gold]
 	[queues.foo]
+	[priority_factors]
+	age_factor = 0
 	EOT
 	flux config reload
 '

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -5,8 +5,10 @@ test_description='Test cancelling active jobs with a late user/bank info load'
 . `dirname $0`/sharness.sh
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -16,6 +18,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'submit a number of jobs with no user/bank info loaded to plugin' '

--- a/t/t1015-mf-priority-urgency.t
+++ b/t/t1015-mf-priority-urgency.t
@@ -6,8 +6,10 @@ test_description='Test multi-factor priority plugin order with different --urgen
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -17,6 +19,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create a group of users with the same fairshare value' '

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -6,8 +6,10 @@ test_description='Test rejecting jobs from a user who has been disabled from the
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -17,6 +19,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success 'create flux-accounting DB' '

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -8,9 +8,11 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/plugin_state
 
+mkdir -p config
+
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
+test_under_flux 1 job -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -20,6 +22,14 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'disable age factor in multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	age_weight = 0
+	EOT
+	flux config reload
 '
 
 test_expect_success HAVE_JQ 'flux jobtap query returns basic information' '

--- a/t/t1020-mf-priority-config.t
+++ b/t/t1020-mf-priority-config.t
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin with a single user'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load plugin successfully without configuration' '
+  flux jobtap load ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'create a flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root bankA 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=bankA
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'no configured priority factors will use default weights' '
+	job1=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
+	flux job wait-event -f json $job1 priority | jq '.context.priority' > job1.test &&
+	grep "50000" job1.test &&
+	flux job cancel $job1
+'
+
+test_expect_success 'set up new configuration for multi-factor priority plugin' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	fshare_weight = 1000
+	queue_weight = 100
+	EOT
+	flux config reload
+'
+
+test_expect_success 'successfully submit a job with loaded configuration' '
+	job2=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
+	flux job wait-event -f json $job2 priority | jq '.context.priority' > job2.test &&
+	grep "500" job2.test &&
+	flux job cancel $job2
+'
+
+test_expect_success 'change the configuration for the priority factors' '
+	cat >config/test.toml <<-EOT &&
+	[priority_factors]
+	fshare_weight = 500
+	queue_weight = 100
+	EOT
+	flux config reload
+'
+
+test_expect_success 'successfully submit a job with the new configuration' '
+	job3=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
+	flux job wait-event -f json $job3 priority | jq '.context.priority' > job3.test &&
+	grep "250" job3.test &&
+	flux job cancel $job3
+'
+
+test_done

--- a/t/t1020-mf-priority-config.t
+++ b/t/t1020-mf-priority-config.t
@@ -40,7 +40,7 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 test_expect_success 'no configured priority factors will use default weights' '
 	job1=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
 	flux job wait-event -f json $job1 priority | jq '.context.priority' > job1.test &&
-	grep "50000" job1.test &&
+	grep -c "50[0-9][0-9][0-9]" job1.test &&
 	flux job cancel $job1
 '
 
@@ -49,6 +49,7 @@ test_expect_success 'set up new configuration for multi-factor priority plugin' 
 	[priority_factors]
 	fshare_weight = 1000
 	queue_weight = 100
+	age_weight = 0
 	EOT
 	flux config reload
 '
@@ -65,6 +66,7 @@ test_expect_success 'change the configuration for the priority factors' '
 	[priority_factors]
 	fshare_weight = 500
 	queue_weight = 100
+	age_weight = 0
 	EOT
 	flux config reload
 '

--- a/t/t1021-mf-priority-age.t
+++ b/t/t1021-mf-priority-age.t
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+test_description='Test multi-factor priority plugin with age factor enabled'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load plugin successfully without configuration' '
+  flux jobtap load ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'create a flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root bankA 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=bankA
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'no configured priority factors will use default weights, including age' '
+	job1=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
+	flux job wait-event -f json $job1 priority | jq '.context.priority' > job1.test &&
+  cat job1.test &&
+	grep -c "50[0-9][0-9][0-9]" job1.test &&
+	flux job cancel $job1
+'
+
+test_done


### PR DESCRIPTION
#### Background

As mentioned in #291, there is potential to add another factor to the priority calculation of a job that consists of a job's "age," or how long a job has been submitted and waiting to run. This will help further refine the priority of a job and can help increase a low priority job's position in the queue on a reprioritization of all jobs.

---

This is a [WIP] PR built on top of #295 that adds this new "age" factor to the priority calculation of a job. It unpacks `t_submit` from the job and subtracts it from the current time to calculate a job's age. This factor is then added to the other two factors that are currently used in the multi-factor priority calculation.

With the changes proposed in #295, it is possible to "disable" this factor (or any factor for that matter) by setting its weight to 0 in the TOML config file:

```toml
[priority_factors]
fshare_weight = 1000
queue_weight = 100
age_weight = 0
```

which is what I have done in the existing set of sharness tests, as to avoid having to adjust every test that checks for a specific priority number.

##### TODO

- add tests for age factor