### PR TITLE
edit-bank: add ability to edit parent bank

### DIFF
--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -111,9 +111,33 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(cursor.fetchone()[0], 50)
 
+    # edit a bank's parent bank
+    def test_08_edit_parent_bank_success(self):
+        b.add_bank(acct_conn, bank="A", parent_bank="root", shares=1)
+        b.add_bank(acct_conn, bank="B", parent_bank="root", shares=1)
+
+        # set bank's parent bank to A
+        b.add_bank(acct_conn, bank="C", parent_bank="A", shares=1)
+
+        # change bank's parent bank to B
+        b.edit_bank(acct_conn, bank="C", parent_bank="B")
+
+        cursor = acct_conn.cursor()
+        cursor.execute("SELECT parent_bank FROM bank_table WHERE bank='C'")
+
+        self.assertEqual(cursor.fetchone()[0], "B")
+
+    # trying to edit a bank's parent bank to a bank that does not
+    # exist should raise a ValueError
+    def test_09_edit_parent_bank_failure(self):
+        with self.assertRaises(ValueError) as context:
+            b.edit_bank(acct_conn, bank="C", parent_bank="foo")
+
+        self.assertTrue("Parent bank not found in bank table" in str(context.exception))
+
     # trying to edit a bank's shares <= 0 should raise
     # a ValueError
-    def test_08_edit_bank_value_fail(self):
+    def test_10_edit_bank_value_fail(self):
         with self.assertRaises(ValueError) as context:
             b.add_bank(acct_conn, bank="bad_bank", shares=10)
             b.edit_bank(acct_conn, bank="bad_bank", shares=-1)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -292,6 +292,11 @@ def add_edit_bank_arg(subparsers):
         help="new shares value",
         metavar="SHARES",
     )
+    subparser_edit_bank.add_argument(
+        "--parent-bank",
+        help="parent bank",
+        metavar="PARENT BANK",
+    )
 
 
 def add_update_usage_arg(subparsers):
@@ -531,7 +536,7 @@ def select_accounting_function(args, conn, output_file, parser):
     elif args.func == "delete_bank":
         b.delete_bank(conn, args.bank)
     elif args.func == "edit_bank":
-        b.edit_bank(conn, args.bank, args.shares)
+        b.edit_bank(conn, args.bank, args.shares, args.parent_bank)
     elif args.func == "update_usage":
         jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
         jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -46,6 +46,8 @@ EXTRA_DIST= \
 	expected/print_hierarchy/before_delete.expected \
 	expected/print_hierarchy/after_delete.expected \
 	expected/print_hierarchy/after_bank_delete.expected \
+	expected/print_hierarchy/before_parent_bank_change.expected \
+	expected/print_hierarchy/after_parent_bank_change.expected \
 	expected/update_fshare/post_fshare_update.expected \
 	expected/update_fshare/pre_fshare_update.expected \
 	expected/test_dbs/out_of_insert_order.db \

--- a/t/expected/print_hierarchy/after_parent_bank_change.expected
+++ b/t/expected/print_hierarchy/after_parent_bank_change.expected
@@ -1,0 +1,11 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1                   0
+ B                                                         1                   0
+  B                             user5013                   1                   0                 0.5
+ C                                                         1                   0
+  C                             user5014                   1                   0                 0.5
+ D                                                         1                   0
+ E                                                         1                   0
+  F                                                        1                   0
+   F                            user1001                   1                   0                 0.5
+   F                            user1002                   1                   0                 0.5

--- a/t/expected/print_hierarchy/before_parent_bank_change.expected
+++ b/t/expected/print_hierarchy/before_parent_bank_change.expected
@@ -1,0 +1,11 @@
+Account                         Username           RawShares            RawUsage           Fairshare
+root                                                       1                   0
+ B                                                         1                   0
+  B                             user5013                   1                   0                 0.5
+ C                                                         1                   0
+  C                             user5014                   1                   0                 0.5
+ D                                                         1                   0
+  F                                                        1                   0
+   F                            user1001                   1                   0                 0.5
+   F                            user1002                   1                   0                 0.5
+ E                                                         1                   0

--- a/t/t1000-print-hierarchy.t
+++ b/t/t1000-print-hierarchy.t
@@ -125,4 +125,26 @@ test_expect_success 'print hierarchy again and check that deleted bank or users 
     test_cmp ${EXPECTED_FILES}/after_bank_delete.expected after_bank_delete.test
 '
 
+test_expect_success 'add some sub banks and some users' '
+    flux account -p ${DB_PATH} add-bank --parent-bank=root D 1 &&
+    flux account -p ${DB_PATH} add-bank --parent-bank=root E 1 &&
+    flux account -p ${DB_PATH} add-bank --parent-bank=D F 1 &&
+    flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=F &&
+    flux account -p ${DB_PATH} add-user --username=user1002 --userid=1002 --bank=F
+'
+
+test_expect_success 'check hierarchy before changing parent bank of F' '
+    flux account-shares -p ${DB_PATH} > before_parent_bank_change.test &&
+    test_cmp ${EXPECTED_FILES}/before_parent_bank_change.expected before_parent_bank_change.test
+'
+
+test_expect_success 'change parent bank of F' '
+    flux account -p ${DB_PATH} edit-bank F --parent-bank=E
+'
+
+test_expect_success 'check hierarchy after changing parent bank of F' '
+    flux account-shares -p ${DB_PATH} > after_parent_bank_change.test &&
+    test_cmp ${EXPECTED_FILES}/after_parent_bank_change.expected after_parent_bank_change.test
+'
+
 test_done


### PR DESCRIPTION
#### Problem

As described in #298, the parent bank of a bank cannot be edited, so in order to move a bank and its users, it must be deleted and re-created under the new parent bank. The `edit-bank` command should be extended to allow the parent bank to be edited.

---

This is a small PR that extends the `edit-bank` command to allow edits of a parent bank. This would remove the need to delete and then re-add a bank and all of its users under the new parent bank. 

A couple of unit test and sharness tests are also added to make sure it works as expected. The unit tests make sure that a bank's parent bank can be changed, and trying to edit a bank's parent bank to one that does not exist raises a `ValueError`. The sharness test adds a bank and some users before editing the parent bank to confirm that the users are also moved to the new parent bank in the hierarchy displayed by the `flux account-shares` command.

Fixes #298