### PR TITLE
github: change Ubuntu version for python-lint check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
   python-lint:
     name: python lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
#### Problem

Using ubuntu-latest in the python-lint causes the check to fail with an error message saying that Python `3.6` cannot be found.

---

This PR just switches the version of Ubuntu to match flux-core's Ubuntu version in their `python-lint` check: `20.04`.