### PR TITLE
plugin: record bank name to jobspec when user submits under default bank

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -30,6 +30,7 @@ TESTSCRIPTS = \
 	t1026-flux-account-perms.t \
 	t1027-mf-priority-issue376.t \
 	t1028-mf-priority-issue385.t \
+	t1029-mf-priority-default-bank.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+test_description='test adding default bank to jobspec in multi-factor priority plugin'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account -p ${DB_PATH} add-bank root 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
+	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=account1 &&
+	flux account -p ${DB_PATH} add-user --username=user1001 --userid=1001 --bank=account2
+'
+
+test_expect_success 'submit a job before plugin has any flux-accounting information' '
+	jobid=$(flux python ${SUBMIT_AS} 1002 hostname) &&
+	flux job wait-event -vt 60 $jobid depend &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "depend" eventlog.out
+'
+
+test_expect_success 'add user to flux-accounting DB and update plugin' '
+	flux account -p ${DB_PATH} add-user --username=user1002 --userid=1002 --bank=account1 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'check that bank was added to jobspec' '
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "{\"attributes.system.bank\":\"account1\"}" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'successfully submit a job under a specified bank' '
+	jobid=$(flux python ${SUBMIT_AS} 1001 --setattr=system.bank=account2 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid jobspec > jobspec.out &&
+	grep "account2" jobspec.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'successfully submit a job under a default bank' '
+	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "{\"attributes.system.bank\":\"account1\"}" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'update the default bank for the user' '
+	flux account -p ${DB_PATH} edit-user user1001 --default-bank=account2 &&
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'successfully submit a job under the new default bank' '
+	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
+	flux job wait-event -f json $jobid priority &&
+	flux job info $jobid eventlog > eventlog.out &&
+	grep "{\"attributes.system.bank\":\"account2\"}" eventlog.out &&
+	flux job cancel $jobid
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Described in #272, currently, when an association submits a job under their default bank, the bank name is not recorded anywhere in the jobspec. Only when an association specifies the bank they want to submit jobs under (i.e `flux mini submit --setattr=system.bank=my_bank`) does the bank name get recorded. It was proposed in that issue to record the bank name in the PRIORITY event of a job even when a user does not specify a bank when they submit a job (i.e they use their default bank).

---

This PR records the bank name in the jobspec during the PRIORITY event when an association submits a job under their default bank. It makes use of the `jobspec-update` event to post the `bank` key-value pair. This event takes place just before the integer priority for the job is calculated. This event should take place if the association was not known to the flux-accounting DB/priority plugin at the time of job submission; in the latter case, when all pending jobs are reprioritized after a plugin update, the default bank is looked up and then added to the jobspec. 

In the case where the default bank is known at the time of job submission, it adds the bank name via `jobspec-update` under `attributes.system.bank` during `job.new`.

Some sharness tests are also added to a new test file, `t1029-mf-priority-bank.t`, that test this functionality, making sure the bank name can be found in the eventlog of a job when jobs are submitted under a default bank as well as when an association does not yet exist in the flux-accounting DB.