### PR TITLE
testsuite: do not assume queues default to stopped

### DIFF
--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -154,4 +154,8 @@ test_expect_success 'reload mf_priority.so and update it with the sample test da
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 
+test_expect_success 'cancel final job' '
+	flux job cancel $jobid6
+'
+
 test_done

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -83,7 +83,8 @@ test_expect_success 'configure flux with those queues' '
 	[queues.gold]
 	[queues.foo]
 	EOT
-	flux config reload
+	flux config reload &&
+	flux queue stop
 '
 
 test_expect_success 'submit a job using a queue the user does not belong to' '


### PR DESCRIPTION
Problem: In t1013-mf-priority-queues.t, newly created job queues
are assumed to be stopped due to a call to `flux queue stop` earlier
in the tests.  A queue defaulting to stopped cannot be assumed.

Add an additional call to flux queue stop after the job queues
are created.

See investigation in https://github.com/flux-framework/flux-core/pull/4776