### PR TITLE
testsuite: stop all queues with --all option

### DIFF
--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -67,7 +67,7 @@ then
 fi
 
 test $RANK -ne 0 || flux admin cleanup-push <<-EOT
-	flux queue stop
+	flux queue stop --all
 	flux job cancelall -f --states RUN
 	flux queue idle
 EOT

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -84,7 +84,7 @@ test_expect_success 'configure flux with those queues' '
 	[queues.foo]
 	EOT
 	flux config reload &&
-	flux queue stop
+	flux queue stop --all
 '
 
 test_expect_success 'submit a job using a queue the user does not belong to' '


### PR DESCRIPTION
Problem: flux-core PR 4776 added the ability for queues to be individually started and stopped.  As an update, starting/stopping all queues with the `flux queue` command now requires the --all option to be specified, otherwise a warning is output.

To avoid the warning, update all callers to specify --all when multiple queues are started or stopped.

This is similar to https://github.com/flux-framework/flux-sched/pull/992

***This should not be merged until https://github.com/flux-framework/flux-core/pull/4776 is merged***