### PR TITLE
NEWS: add release notes for `v0.21.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+flux-accounting version 0.21.0 - 2022-12-12
+-------------------------------------------
+
+#### Features
+
+* Add ability to edit the parent bank of a bank (#299)
+
+#### Testsuite
+
+* Do not assume queues default to stopped (#302)
+
+* Stop all queues with `--all` option (#303)
+
 flux-accounting version 0.20.1 - 2022-10-05
 -------------------------------------------
 


### PR DESCRIPTION
After the added feature in #299 and the fixes proposed by @chu11 in #302 and #303, I think it's definitely worth tagging and releasing a new version of flux-accounting. This PR adds release notes for `v0.21.0`.

This PR should not be merged until after #303 has been merged.

Once this lands, I'll create an annotated tag with the following command:

```console
git tag -a v0.21.0 -m "Tag v0.21.0" && git push upstream v0.21.0
```