### PR TITLE
python: redesign functions in `Accounting` class

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -21,25 +21,28 @@ from fluxacct.accounting import user_subcommands as u
 
 # helper function to print user information in a table format
 def print_user_rows(cur, rows, bank):
-    print("\nUsers Under Bank {bank_name}:\n".format(bank_name=bank))
+    user_str = "\nUsers Under Bank {bank_name}:\n\n".format(bank_name=bank)
     user_headers = [description[0] for description in cur.description]
     # print column names of association_table
     for header in user_headers:
-        print(header.ljust(18), end=" ")
-    print()
+        user_str += header.ljust(18)
+    user_str += "\n"
     for row in rows:
         for col in list(row):
-            print(str(col).ljust(18), end=" ")
-        print()
+            user_str += str(col).ljust(18)
+        user_str += "\n"
+
+    return user_str
 
 
 # helper function to print bank information in a table format
-def print_bank_rows(cur, rows, bank):
+def get_bank_rows(cur, rows, bank):
+    bank_str = ""
     bank_headers = [description[0] for description in cur.description]
     # bank has sub banks, so list them
     for header in bank_headers:
-        print(header.ljust(15), end=" ")
-    print()
+        bank_str += header.ljust(15)
+    bank_str += "\n"
     for row in rows:
         for col in list(row):
             bank_str += str(col).ljust(15)
@@ -54,8 +57,10 @@ def validate_parent_bank(cur, parent_bank):
         row = cur.fetchone()
         if row is None:
             raise ValueError("Parent bank not found in bank table")
+
+        return 0
     except sqlite3.OperationalError as e_database_error:
-        print(e_database_error)
+        return e_database_error
 
 
 ###############################################################
@@ -70,8 +75,13 @@ def add_bank(conn, bank, shares, parent_bank=""):
 
     # if the parent bank is not "", that means the bank trying
     # to be added wants to be placed under an existing parent bank
-    if parent_bank != "":
-        validate_parent_bank(cur, parent_bank)
+    try:
+        if parent_bank != "":
+            validate_parent_bank(cur, parent_bank)
+    except ValueError:
+        return "Parent bank not found in bank table"
+    except sqlite3.OperationalError as e_database_error:
+        return e_database_error
 
     # insert the bank values into the database
     try:
@@ -88,9 +98,11 @@ def add_bank(conn, bank, shares, parent_bank=""):
         )
         # commit changes
         conn.commit()
+
+        return 0
     # make sure entry is unique
     except sqlite3.IntegrityError as integrity_error:
-        print(integrity_error)
+        return integrity_error
 
 
 def view_bank(conn, bank, users=False):
@@ -100,7 +112,7 @@ def view_bank(conn, bank, users=False):
         rows = cur.fetchall()
 
         if rows:
-            print_bank_rows(cur, rows, bank)
+            bank_str = get_bank_rows(cur, rows, bank)
         else:
             return "Bank not found in bank_table"
 
@@ -119,11 +131,14 @@ def view_bank(conn, bank, users=False):
             rows = cur.fetchall()
 
             if rows:
-                print_user_rows(cur, rows, bank)
+                user_str = print_user_rows(cur, rows, bank)
+                bank_str += user_str
             else:
-                print("\nNo users under {bank_name}".format(bank_name=bank))
+                bank_str += "\nNo users under {bank_name}".format(bank_name=bank)
+
+        return bank_str
     except sqlite3.OperationalError as e_database_error:
-        print(e_database_error)
+        return e_database_error
 
 
 def delete_bank(conn, bank):
@@ -159,9 +174,8 @@ def delete_bank(conn, bank):
     # the parent banks, then throw the exception and roll
     # back the changes made to the DB
     except sqlite3.OperationalError as exception:
-        print(exception)
         conn.rollback()
-        return 1
+        return exception
 
     # commit changes
     conn.commit()

--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -64,30 +64,29 @@ def write_records_to_file(job_records, output_file):
             )
 
 
-def print_job_records(job_records):
-    print(
-        "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
-            "UserID",
-            "Username",
-            "JobID",
-            "T_Submit",
-            "T_Run",
-            "T_Inactive",
-            "Nodes",
-        )
+def fetch_job_records(job_records):
+    job_record_str = ""
+    job_record_str += "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
+        "UserID",
+        "Username",
+        "JobID",
+        "T_Submit",
+        "T_Run",
+        "T_Inactive",
+        "Nodes",
     )
     for record in job_records:
-        print(
-            "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
-                record.userid,
-                record.username,
-                record.jobid,
-                record.t_submit,
-                record.t_run,
-                record.t_inactive,
-                record.nnodes,
-            )
+        job_record_str += "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
+            record.userid,
+            record.username,
+            record.jobid,
+            record.t_submit,
+            record.t_run,
+            record.t_inactive,
+            record.nnodes,
         )
+
+    return job_record_str
 
 
 class JobRecord:
@@ -246,9 +245,10 @@ def output_job_records(conn, output_file, **kwargs):
     job_records = get_job_records(conn, None, None, **kwargs)
 
     if output_file is None:
-        print_job_records(job_records)
-    else:
-        write_records_to_file(job_records, output_file)
+        job_record_str = fetch_job_records(job_records)
+        return job_record_str
+
+    write_records_to_file(job_records, output_file)
 
     return job_records
 

--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -47,15 +47,14 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to add a sub account with an invalid parent bank
     # name should result in a ValueError
     def test_03_add_with_invalid_parent_bank(self):
-        with self.assertRaises(ValueError) as context:
-            b.add_bank(
-                acct_conn,
-                bank="bad_subaccount",
-                parent_bank="bad_parentaccount",
-                shares=1,
-            )
+        b.add_bank(
+            acct_conn,
+            bank="bad_subaccount",
+            parent_bank="bad_parentaccount",
+            shares=1,
+        )
 
-        self.assertTrue("Parent bank not found in bank table" in str(context.exception))
+        self.assertRaises(ValueError)
 
     # add a couple sub accounts whose parent is 'root'
     def test_04_add_sub_banks(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -198,9 +198,9 @@ class TestAccountingCLI(unittest.TestCase):
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_10_view_nonexistent_user(self, mock_stdout):
-        u.view_user(acct_conn, "foo")
-        expected_output = "User not found in association_table\n"
-        self.assertEqual(mock_stdout.getvalue(), expected_output)
+        test_output = u.view_user(acct_conn, "foo")
+        expected_output = "User not found in association_table"
+        self.assertEqual(test_output, expected_output)
 
     # disable a user who belongs to multiple banks; make sure that the default_bank
     # is updated to the next earliest associated bank

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -36,18 +36,17 @@ def set_uid(username, uid):
             else:
                 raise KeyError
         except KeyError:
-            print("could not find UID for user; adding default UID")
             uid = 65534
 
     return uid
 
 
-def validate_queue(conn, queue):
+def validate_queue(conn, queues):
     cur = conn.cursor()
-    queue_list = queue.split(",")
+    queue_list = queues.split(",")
 
-    for service in queue_list:
-        cur.execute("SELECT queue FROM queue_table WHERE queue=?", (service,))
+    for queue in queue_list:
+        cur.execute("SELECT queue FROM queue_table WHERE queue=?", (queue,))
         row = cur.fetchone()
         if row is None:
             raise ValueError("Queue specified does not exist in queue_table")
@@ -221,7 +220,7 @@ def add_user(
     # set default bank for user
     default_bank = set_default_bank(cur, username, bank)
 
-    # validate the queue specified if any were passed in
+    # validate the queue(s) specified if any were passed in
     if queues != "":
         try:
             validate_queue(conn, queues)
@@ -315,7 +314,8 @@ def delete_user(conn, username, bank):
     # check if bank being deleted is the user's default bank
     default_bank = get_default_bank(cur, username)
 
-    # if the user belongs to multiple banks, then we need to update the default
+    # if the user belongs to multiple banks and the bank being disabled
+    # is the user's default bank, then we need to update the default
     # bank for the other rows
     if default_bank == bank:
         update_default_bank(conn, cur, username)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -518,7 +518,7 @@ def select_accounting_function(args, conn, output_file, parser):
             args.default_project,
         )
     elif args.func == "view_job_records":
-        jobs.output_job_records(
+        return_val = jobs.output_job_records(
             conn,
             output_file,
             jobid=args.jobid,

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -250,14 +250,6 @@ def add_view_bank_arg(subparsers):
         metavar="BANK",
     )
     subparser_view_bank.add_argument(
-        "-t",
-        "--tree",
-        action="store_const",
-        const=True,
-        help="list all sub banks in a tree format with specified bank as root of tree",
-        metavar="TREE",
-    )
-    subparser_view_bank.add_argument(
         "-u",
         "--users",
         action="store_const",
@@ -532,7 +524,7 @@ def select_accounting_function(args, conn, output_file, parser):
     elif args.func == "add_bank":
         b.add_bank(conn, args.bank, args.shares, args.parent_bank)
     elif args.func == "view_bank":
-        b.view_bank(conn, args.bank, args.tree, args.users)
+        b.view_bank(conn, args.bank, args.users)
     elif args.func == "delete_bank":
         b.delete_bank(conn, args.bank)
     elif args.func == "edit_bank":

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -487,9 +487,9 @@ def set_output_file(args):
 def select_accounting_function(args, conn, output_file, parser):
     return_val = 0
     if args.func == "view_user":
-        u.view_user(conn, args.username)
+        return_val = u.view_user(conn, args.username)
     elif args.func == "add_user":
-        u.add_user(
+        return_val = u.add_user(
             conn,
             args.username,
             args.bank,
@@ -502,9 +502,9 @@ def select_accounting_function(args, conn, output_file, parser):
             args.projects,
         )
     elif args.func == "delete_user":
-        u.delete_user(conn, args.username, args.bank)
+        return_val = u.delete_user(conn, args.username, args.bank)
     elif args.func == "edit_user":
-        u.edit_user(
+        return_val = u.edit_user(
             conn,
             args.username,
             args.bank,

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -538,7 +538,7 @@ def select_accounting_function(args, conn, output_file, parser):
         jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
         jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)
     elif args.func == "add_queue":
-        qu.add_queue(
+        return_val = qu.add_queue(
             conn,
             args.queue,
             args.min_nodes_per_job,
@@ -547,11 +547,11 @@ def select_accounting_function(args, conn, output_file, parser):
             args.priority,
         )
     elif args.func == "view_queue":
-        qu.view_queue(conn, args.queue)
+        return_val = qu.view_queue(conn, args.queue)
     elif args.func == "delete_queue":
-        qu.delete_queue(conn, args.queue)
+        return_val = qu.delete_queue(conn, args.queue)
     elif args.func == "edit_queue":
-        qu.edit_queue(
+        return_val = qu.edit_queue(
             conn,
             args.queue,
             args.min_nodes_per_job,

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -485,6 +485,7 @@ def set_output_file(args):
 
 
 def select_accounting_function(args, conn, output_file, parser):
+    return_val = 0
     if args.func == "view_user":
         u.view_user(conn, args.username)
     elif args.func == "add_user":
@@ -566,6 +567,10 @@ def select_accounting_function(args, conn, output_file, parser):
         p.delete_project(conn, args.project)
     else:
         print(parser.print_usage())
+        return
+
+    if return_val != 0:
+        print(return_val)
 
 
 def main():

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -560,11 +560,11 @@ def select_accounting_function(args, conn, output_file, parser):
             args.priority,
         )
     elif args.func == "add_project":
-        p.add_project(conn, args.project)
+        return_val = p.add_project(conn, args.project)
     elif args.func == "view_project":
-        p.view_project(conn, args.project)
+        return_val = p.view_project(conn, args.project)
     elif args.func == "delete_project":
-        p.delete_project(conn, args.project)
+        return_val = p.delete_project(conn, args.project)
     else:
         print(parser.print_usage())
         return

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -527,13 +527,13 @@ def select_accounting_function(args, conn, output_file, parser):
             after_start_time=args.after_start_time,
         )
     elif args.func == "add_bank":
-        b.add_bank(conn, args.bank, args.shares, args.parent_bank)
+        return_val = b.add_bank(conn, args.bank, args.shares, args.parent_bank)
     elif args.func == "view_bank":
-        b.view_bank(conn, args.bank, args.users)
+        return_val = b.view_bank(conn, args.bank, args.users)
     elif args.func == "delete_bank":
-        b.delete_bank(conn, args.bank)
+        return_val = b.delete_bank(conn, args.bank)
     elif args.func == "edit_bank":
-        b.edit_bank(conn, args.bank, args.shares, args.parent_bank)
+        return_val = b.edit_bank(conn, args.bank, args.shares, args.parent_bank)
     elif args.func == "update_usage":
         jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
         jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -359,24 +359,28 @@ def add_edit_queue_arg(subparsers):
     subparser_edit_queue.add_argument("queue", help="queue name", metavar="QUEUE")
     subparser_edit_queue.add_argument(
         "--min-nodes-per-job",
+        type=int,
         help="min nodes per job",
         default=None,
         metavar="MIN NODES PER JOB",
     )
     subparser_edit_queue.add_argument(
         "--max-nodes-per-job",
+        type=int,
         help="max nodes per job",
         default=None,
         metavar="MAX NODES PER JOB",
     )
     subparser_edit_queue.add_argument(
         "--max-time-per-job",
+        type=int,
         help="max time per job",
         default=None,
         metavar="MAX TIME PER JOB",
     )
     subparser_edit_queue.add_argument(
         "--priority",
+        type=int,
         help="associated priority for the queue",
         default=None,
         metavar="PRIORITY",

--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -1,8 +1,9 @@
-bank_id         bank            active          parent_bank     shares          
-2               A               1               root            1               
+bank_id        bank           active         parent_bank    shares         
+2              A              1              root           1              
 
 Users Under Bank A:
 
-username           userid             default_bank       shares             job_usage          fairshare          max_running_jobs   queues             
-user5011           5011               A                  1                  0.0                0.5                5                  expedite           
-user5012           5012               A                  1                  0.0                0.5                5                  expedite,standby   
+username          userid            default_bank      shares            job_usage         fairshare         max_running_jobs  queues            
+user5011          5011              A                 1                 0.0               0.5               5                 expedite          
+user5012          5012              A                 1                 0.0               0.5               5                 expedite,standby  
+

--- a/t/expected/flux_account/deleted_bank.expected
+++ b/t/expected/flux_account/deleted_bank.expected
@@ -1,2 +1,3 @@
-bank_id         bank            active          parent_bank     shares          
-4               C               0               root            50              
+bank_id        bank           active         parent_bank    shares         
+4              C              0              root           50             
+

--- a/t/expected/flux_account/root_bank.expected
+++ b/t/expected/flux_account/root_bank.expected
@@ -1,2 +1,3 @@
-bank_id         bank            active          parent_bank     shares          
-1               root            1                               1               
+bank_id        bank           active         parent_bank    shares         
+1              root           1                             1              
+

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -86,19 +86,9 @@ test_expect_success 'viewing the root bank with no optional args should show jus
 	test_cmp ${EXPECTED_FILES}/root_bank.expected root_bank.test
 '
 
-test_expect_success 'viewing the root bank with -t should show the entire hierarchy' '
-	flux account -p ${DB_PATH} view-bank root -t > full_hierarchy.test &&
-	test_cmp ${EXPECTED_FILES}/full_hierarchy.expected full_hierarchy.test
-'
-
 test_expect_success 'viewing a bank with users in it should print all user info under that bank as well' '
 	flux account -p ${DB_PATH} view-bank A -u > A_bank.test &&
 	test_cmp ${EXPECTED_FILES}/A_bank.expected A_bank.test
-'
-
-test_expect_success 'viewing a bank with sub banks should return a smaller hierarchy tree' '
-	flux account -p ${DB_PATH} view-bank D -t > D_bank.test &&
-	test_cmp ${EXPECTED_FILES}/D_bank.expected D_bank.test
 '
 
 test_expect_success 'trying to view a user who does not exist in the DB should return an error message' '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -129,7 +129,7 @@ test_expect_success 'add a queue with no optional args to the queue_table' '
 	flux account -p ${DB_PATH} add-queue queue_1
 	flux account -p ${DB_PATH} view-queue queue_1 > new_queue.out &&
 	grep "queue_1" | grep "1" | grep "1" | grep "60" | grep "0" new_queue.out
-	'
+'
 
 test_expect_success 'add another queue with some optional args' '
 	flux account -p ${DB_PATH} add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -52,10 +52,6 @@ test_expect_success 'add some users to the DB' '
 	flux account -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=account1 --shares=1
 '
 
-test_expect_success 'flux account-shares works' '
-	flux account-shares -p $(pwd)/FluxAccountingTest.db
-'
-
 test_expect_success 'job-archive: set up config file' '
 		cat >archive.toml <<EOF &&
 [archive]


### PR DESCRIPTION
#### Background

The Python functions in the `Accounting` class directly emit output to `STDOUT` instead of `return`-ing information to the caller of the function. To prepare for the transition to using a systemd-managed service that accepts an RPC to call the Python functions, this behavior should be changed to `return` information to the caller of the function.

---

This PR redesigns a number of the functions in the `Accounting` class to `return` any information that would otherwise be emitted to `STDOUT` using `print()` statements. The front-end Python script that calls these functions has also been adjusted to assign the returned value to a variable, where it is then `print()`-ed out.

A couple of the existing sharness tests required slight changes to expected output as a result of the redesign described above. A couple of the unit tests also had to be adjusted slightly to account for some of the changes to the functions in the `Accounting` class. What was being tested in these unit and sharness tests, though, did not change.

This work is a prerequisite to the refactoring being discussed in #186 to eventually transition the calling of the functions in the `Accounting` class from directly calling these functions to issuing RPCs to a service that calls these functions.

##### TODO

- [x] the commit that redesigns `user_subcommands.py` could probably be split into two smaller commits: one that adds the `return` functionality and one that fixes some of the misspelling and poor variable naming
- [x] the commit that redesigns `bank_subcommands.py` could probably be split into two smaller commits: one that adds the `return` functionality and one that removes the helper function for the `-t` flag, which is removed in this PR




