### PR TITLE
python: introduce new service for `flux account` commands

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,4 +130,5 @@ dist_fluxcmd_SCRIPTS = \
 	cmd/flux-account-shares \
 	cmd/flux-account-pop-db.py \
 	cmd/flux-account-export-db.py \
-	cmd/flux-account-update-db.py
+	cmd/flux-account-update-db.py \
+	cmd/flux-account-service.py

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -78,8 +78,8 @@ def add_bank(conn, bank, shares, parent_bank=""):
     try:
         if parent_bank != "":
             validate_parent_bank(cur, parent_bank)
-    except ValueError:
-        return "Parent bank not found in bank table"
+    except ValueError as val_err:
+        return f"error adding bank: {val_err}"
     except sqlite3.OperationalError as e_database_error:
         return e_database_error
 
@@ -197,10 +197,16 @@ def edit_bank(
     for field in editable_fields:
         if params[field] is not None:
             if field == "parent_bank":
-                validate_parent_bank(cur, params[field])
+                try:
+                    validate_parent_bank(cur, params[field])
+                except ValueError as val_err:
+                    return f"error editing parent bank: {val_err}"
             if field == "shares":
                 if int(shares) <= 0:
-                    raise ValueError("New shares amount must be >= 0")
+                    try:
+                        raise ValueError("New shares amount must be >= 0")
+                    except ValueError as val_err:
+                        return f"error editing shares value for bank: {val_err}"
 
             update_stmt = "UPDATE bank_table SET " + field
 

--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -502,3 +502,5 @@ def update_job_usage(acct_conn, jobs_conn, pdhl=1):
         calc_usage_factor(jobs_conn, acct_conn, pdhl, row[0], row[1], row[2])
 
     check_end_hl(acct_conn, pdhl)
+
+    return 0

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -97,7 +97,10 @@ def edit_queue(
         if params[field] is not None:
             # check that the passed in value is truly an integer
             if not isinstance(params[field], int):
-                raise ValueError("passed in value must be an integer")
+                try:
+                    raise ValueError("passed in value must be an integer")
+                except ValueError as val_err:
+                    return f"error editing field for queue: {val_err}"
 
             update_stmt = "UPDATE queue_table SET " + field
 

--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -129,19 +129,17 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to edit a bank's parent bank to a bank that does not
     # exist should raise a ValueError
     def test_09_edit_parent_bank_failure(self):
-        with self.assertRaises(ValueError) as context:
-            b.edit_bank(acct_conn, bank="C", parent_bank="foo")
+        b.edit_bank(acct_conn, bank="C", parent_bank="foo")
 
-        self.assertTrue("Parent bank not found in bank table" in str(context.exception))
+        self.assertRaises(ValueError)
 
     # trying to edit a bank's shares <= 0 should raise
     # a ValueError
     def test_10_edit_bank_value_fail(self):
-        with self.assertRaises(ValueError) as context:
-            b.add_bank(acct_conn, bank="bad_bank", shares=10)
-            b.edit_bank(acct_conn, bank="bad_bank", shares=-1)
+        b.add_bank(acct_conn, bank="bad_bank", shares=10)
+        b.edit_bank(acct_conn, bank="bad_bank", shares=-1)
 
-        self.assertTrue("New shares amount must be >= 0" in str(context.exception))
+        self.assertRaises(ValueError)
 
     # remove database and log file
     @classmethod

--- a/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
@@ -64,8 +64,9 @@ class TestAccountingCLI(unittest.TestCase):
 
     # edit a value with a bad type for a queue in the queue_table
     def test_05_edit_queue_bad_type(self):
-        with self.assertRaises(ValueError):
-            q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job="foo")
+        q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job="foo")
+
+        self.assertRaises(ValueError)
 
     # reset a value for a queue in the queue_table
     def test_06_reset_queue_limit(self):

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -1,0 +1,474 @@
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import signal
+import sys
+import sqlite3
+import os
+import argparse
+import logging
+
+import flux
+import fluxacct.accounting
+
+from flux.constants import FLUX_MSGTYPE_REQUEST
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import job_archive_interface as jobs
+from fluxacct.accounting import queue_subcommands as qu
+from fluxacct.accounting import project_subcommands as p
+
+
+def establish_sqlite_connection(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError as exc:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
+        sys.exit(1)
+
+    return conn
+
+
+def background():
+    pid = os.fork()
+    if pid > 0:
+        # exit first parent
+        sys.exit(0)
+
+
+def check_db_version(conn):
+    # check version of database; if not up to date, output message
+    # and exit
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version")
+    db_version = cur.fetchone()[0]
+    if db_version < 20:
+        print(
+            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+        )
+        sys.exit(1)
+
+
+class AccountingService:
+    def __init__(self, flux_handle, conn):
+
+        self.handle = flux_handle
+        self.conn = conn
+
+        try:
+            # register service with broker
+            self.handle.service_register("accounting").get()
+            print("registered accounting service", file=sys.stderr)
+        except FileExistsError:
+            LOGGER.error("flux-accounting service is already registered")
+
+        # register signal watcher for SIGTERM to initiate shutdown
+        self.handle.signal_watcher_create(signal.SIGTERM, self.shutdown).start()
+        self.handle.signal_watcher_create(signal.SIGINT, self.shutdown).start()
+
+        endpoints = [
+            "view_user",
+            "add_user",
+            "delete_user",
+            "edit_user",
+            "view_bank",
+            "add_bank",
+            "delete_bank",
+            "edit_bank",
+            "view_job_records",
+            "update_usage",
+            "add_queue",
+            "view_queue",
+            "delete_queue",
+            "edit_queue",
+            "add_project",
+            "view_project",
+            "delete_project",
+            "shutdown_service",
+        ]
+
+        for name in endpoints:
+            self.handle.msg_watcher_create(
+                getattr(self, name), FLUX_MSGTYPE_REQUEST, f"accounting.{name}", self
+            ).start()
+
+    def shutdown(self, handle, watcher, signum, arg):
+        print("Shutting down...", file=sys.stderr)
+        self.conn.close()
+        self.handle.service_unregister("accounting").get()
+        self.handle.reactor_stop()
+
+    # watches for a shutdown message
+    def shutdown_service(self, handle, watcher, msg, arg):
+        print("Shutting down...", file=sys.stderr)
+        self.conn.close()
+        self.handle.service_unregister("accounting").get()
+        self.handle.reactor_stop()
+        handle.respond(msg)
+
+    def view_user(self, handle, watcher, msg, arg):
+        try:
+            # call view-user function
+            val = u.view_user(self.conn, msg.payload["username"])
+
+            payload = {"view_user": val}
+
+            # handle a flux-accounting.view_user request
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            # fall through to a non-OSError exception
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def add_user(self, handle, watcher, msg, arg):
+        try:
+            val = u.add_user(
+                self.conn,
+                msg.payload["username"],
+                msg.payload["bank"],
+                msg.payload["userid"],
+                msg.payload["shares"],
+                msg.payload["max_running_jobs"],
+                msg.payload["max_active_jobs"],
+                msg.payload["max_nodes"],
+                msg.payload["queues"],
+                msg.payload["projects"],
+            )
+
+            payload = {"add_user": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def delete_user(self, handle, watcher, msg, arg):
+        try:
+            val = u.delete_user(self.conn, msg.payload["username"], msg.payload["bank"])
+
+            payload = {"delete_user": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def edit_user(self, handle, watcher, msg, arg):
+        try:
+            val = u.edit_user(
+                self.conn,
+                msg.payload["username"],
+                msg.payload["bank"],
+                msg.payload["default_bank"],
+                msg.payload["shares"],
+                msg.payload["max_running_jobs"],
+                msg.payload["max_active_jobs"],
+                msg.payload["max_nodes"],
+                msg.payload["queues"],
+                msg.payload["projects"],
+                msg.payload["default_project"],
+            )
+
+            payload = {"edit_user": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def view_bank(self, handle, watcher, msg, arg):
+        try:
+            val = b.view_bank(
+                self.conn,
+                msg.payload["bank"],
+                msg.payload["users"],
+            )
+
+            payload = {"view_bank": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def add_bank(self, handle, watcher, msg, arg):
+        try:
+            val = b.add_bank(
+                self.conn,
+                msg.payload["bank"],
+                msg.payload["shares"],
+                msg.payload["parent_bank"],
+            )
+
+            payload = {"add_bank": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def delete_bank(self, handle, watcher, msg, arg):
+        try:
+            val = b.delete_bank(self.conn, msg.payload["bank"])
+
+            payload = {"delete_bank": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def edit_bank(self, handle, watcher, msg, arg):
+        try:
+            val = b.edit_bank(
+                self.conn,
+                msg.payload["bank"],
+                msg.payload["shares"],
+                msg.payload["parent_bank"],
+            )
+
+            payload = {"edit_bank": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def view_job_records(self, handle, watcher, msg, arg):
+        try:
+            val = jobs.output_job_records(
+                self.conn,
+                msg.payload["output_file"],
+                msg.payload["jobid"],
+                msg.payload["user"],
+                msg.payload["before_end_time"],
+                msg.payload["after_start_time"],
+            )
+
+            payload = {"view_job_records": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def update_usage(self, handle, watcher, msg, arg):
+        try:
+            jobs_conn = establish_sqlite_connection(msg.payload["job_archive_db_path"])
+
+            val = jobs.update_job_usage(
+                self.conn,
+                jobs_conn,
+                msg.payload["priority_decay_half_life"],
+            )
+
+            payload = {"update_job_usage": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def add_queue(self, handle, watcher, msg, arg):
+        try:
+            val = qu.add_queue(
+                self.conn,
+                msg.payload["queue"],
+                msg.payload["min_nodes_per_job"],
+                msg.payload["max_nodes_per_job"],
+                msg.payload["max_time_per_job"],
+                msg.payload["priority"],
+            )
+
+            payload = {"add_queue": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def view_queue(self, handle, watcher, msg, arg):
+        try:
+            val = qu.view_queue(self.conn, msg.payload["queue"])
+
+            payload = {"view_queue": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def delete_queue(self, handle, watcher, msg, arg):
+        try:
+            val = qu.delete_queue(self.conn, msg.payload["queue"])
+
+            payload = {"delete_queue": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def edit_queue(self, handle, watcher, msg, arg):
+        try:
+            val = qu.edit_queue(
+                self.conn,
+                msg.payload["queue"],
+                msg.payload["min_nodes_per_job"],
+                msg.payload["max_nodes_per_job"],
+                msg.payload["max_time_per_job"],
+                msg.payload["priority"],
+            )
+
+            payload = {"edit_queue": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def add_project(self, handle, watcher, msg, arg):
+        try:
+            val = p.add_project(self.conn, msg.payload["project"])
+
+            payload = {"add_project": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def view_project(self, handle, watcher, msg, arg):
+        try:
+            val = p.view_project(self.conn, msg.payload["project"])
+
+            payload = {"view_project": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def delete_project(self, handle, watcher, msg, arg):
+        try:
+            val = p.delete_project(self.conn, msg.payload["project"])
+
+            payload = {"delete_project": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+
+LOGGER = logging.getLogger("flux-uri")
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    parser = argparse.ArgumentParser(prog="flux-uri")
+    parser.add_argument(
+        "-p", "--path", dest="path", help="specify location of database file"
+    )
+    parser.add_argument(
+        "-t",
+        "--test-background",
+        action="store_true",
+        dest="background",
+        help="used for testing",
+    )
+    args = parser.parse_args()
+
+    # try to connect to flux-accounting database; if connection fails, exit
+    # flux-accounting service
+    db_path = args.path if args.path else fluxacct.accounting.db_path
+    conn = establish_sqlite_connection(db_path)
+
+    # check version of database; if not up to date, output message
+    # and exit
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version")
+    db_version = cur.fetchone()[0]
+    if db_version < 20:
+        LOGGER.error(
+            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+        )
+        sys.exit(1)
+
+    handle = flux.Flux()
+    server = AccountingService(handle, conn)
+
+    if args.background:
+        background()
+
+    handle.reactor_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -64,6 +64,7 @@ def check_db_version(conn):
         sys.exit(1)
 
 
+# pylint: disable=broad-except
 class AccountingService:
     def __init__(self, flux_handle, conn):
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -9,15 +9,11 @@
 ###############################################################
 import argparse
 import sys
-import json
 
+import flux
 import fluxacct.accounting
-from fluxacct.accounting import user_subcommands as u
-from fluxacct.accounting import bank_subcommands as b
-from fluxacct.accounting import job_archive_interface as jobs
+
 from fluxacct.accounting import create_db as c
-from fluxacct.accounting import queue_subcommands as qu
-from fluxacct.accounting import project_subcommands as p
 
 
 def add_path_arg(parser):
@@ -502,93 +498,151 @@ def set_output_file(args):
     return output_file
 
 
-def select_accounting_function(args, conn, output_file, parser):
-    return_val = 0
+def select_accounting_function(args, output_file, parser):
     if args.func == "view_user":
-        return_val = u.view_user(conn, args.username)
+        data = {
+            "path": args.path,
+            "username": args.username,
+        }
+        return_val = flux.Flux().rpc("accounting.view_user", data).get()
     elif args.func == "add_user":
-        return_val = u.add_user(
-            conn,
-            args.username,
-            args.bank,
-            args.userid,
-            args.shares,
-            args.max_running_jobs,
-            args.max_active_jobs,
-            args.max_nodes,
-            args.queues,
-            args.projects,
-        )
+        data = {
+            "path": args.path,
+            "username": args.username,
+            "bank": args.bank,
+            "userid": args.userid,
+            "shares": args.shares,
+            "max_running_jobs": args.max_running_jobs,
+            "max_active_jobs": args.max_active_jobs,
+            "max_nodes": args.max_nodes,
+            "queues": args.queues,
+            "projects": args.projects,
+        }
+        return_val = flux.Flux().rpc("accounting.add_user", data).get()
     elif args.func == "delete_user":
-        return_val = u.delete_user(conn, args.username, args.bank)
+        data = {
+            "path": args.path,
+            "username": args.username,
+            "bank": args.bank,
+        }
+        return_val = flux.Flux().rpc("accounting.delete_user", data).get()
     elif args.func == "edit_user":
-        return_val = u.edit_user(
-            conn,
-            args.username,
-            args.bank,
-            args.default_bank,
-            args.shares,
-            args.max_running_jobs,
-            args.max_active_jobs,
-            args.max_nodes,
-            args.queues,
-            args.projects,
-            args.default_project,
-        )
+        data = {
+            "path": args.path,
+            "username": args.username,
+            "bank": args.bank,
+            "default_bank": args.default_bank,
+            "shares": args.shares,
+            "max_running_jobs": args.max_running_jobs,
+            "max_active_jobs": args.max_active_jobs,
+            "max_nodes": args.max_nodes,
+            "queues": args.queues,
+            "projects": args.projects,
+            "default_project": args.default_project,
+        }
+        return_val = flux.Flux().rpc("accounting.edit_user", data).get()
     elif args.func == "view_job_records":
-        return_val = jobs.output_job_records(
-            conn,
-            output_file,
-            jobid=args.jobid,
-            user=args.user,
-            before_end_time=args.before_end_time,
-            after_start_time=args.after_start_time,
-        )
+        data = {
+            "path": args.path,
+            "output_file": output_file,
+            "jobid": args.jobid,
+            "user": args.user,
+            "before_end_time": args.before_end_time,
+            "after_start_time": args.after_start_time,
+        }
+        return_val = flux.Flux().rpc("accounting.view_job_records", data).get()
     elif args.func == "add_bank":
-        return_val = b.add_bank(conn, args.bank, args.shares, args.parent_bank)
+        data = {
+            "path": args.path,
+            "bank": args.bank,
+            "shares": args.shares,
+            "parent_bank": args.parent_bank,
+        }
+        return_val = flux.Flux().rpc("accounting.add_bank", data).get()
     elif args.func == "view_bank":
-        return_val = b.view_bank(conn, args.bank, args.users)
+        data = {
+            "path": args.path,
+            "bank": args.bank,
+            "users": args.users,
+        }
+        return_val = flux.Flux().rpc("accounting.view_bank", data).get()
     elif args.func == "delete_bank":
-        return_val = b.delete_bank(conn, args.bank)
+        data = {
+            "path": args.path,
+            "bank": args.bank,
+        }
+        return_val = flux.Flux().rpc("accounting.delete_bank", data).get()
     elif args.func == "edit_bank":
-        return_val = b.edit_bank(conn, args.bank, args.shares, args.parent_bank)
+        data = {
+            "path": args.path,
+            "bank": args.bank,
+            "shares": args.shares,
+            "parent_bank": args.parent_bank,
+        }
+        return_val = flux.Flux().rpc("accounting.edit_bank", data).get()
     elif args.func == "update_usage":
-        jobs_conn = establish_sqlite_connection(args.job_archive_db_path)
-        jobs.update_job_usage(conn, jobs_conn, args.priority_decay_half_life)
+        data = {
+            "path": args.path,
+            "job_archive_db_path": args.job_archive_db_path,
+            "priority_decay_half_life": args.priority_decay_half_life,
+        }
+        return_val = flux.Flux().rpc("accounting.update_usage", data).get()
     elif args.func == "add_queue":
-        return_val = qu.add_queue(
-            conn,
-            args.queue,
-            args.min_nodes_per_job,
-            args.max_nodes_per_job,
-            args.max_time_per_job,
-            args.priority,
-        )
+        data = {
+            "path": args.path,
+            "queue": args.queue,
+            "min_nodes_per_job": args.min_nodes_per_job,
+            "max_nodes_per_job": args.max_nodes_per_job,
+            "max_time_per_job": args.max_time_per_job,
+            "priority": args.priority,
+        }
+        return_val = flux.Flux().rpc("accounting.add_queue", data).get()
     elif args.func == "view_queue":
-        return_val = qu.view_queue(conn, args.queue)
+        data = {
+            "path": args.path,
+            "queue": args.queue,
+        }
+        return_val = flux.Flux().rpc("accounting.view_queue", data).get()
     elif args.func == "delete_queue":
-        return_val = qu.delete_queue(conn, args.queue)
+        data = {
+            "path": args.path,
+            "queue": args.queue,
+        }
+        return_val = flux.Flux().rpc("accounting.delete_queue", data).get()
     elif args.func == "edit_queue":
-        return_val = qu.edit_queue(
-            conn,
-            args.queue,
-            args.min_nodes_per_job,
-            args.max_nodes_per_job,
-            args.max_time_per_job,
-            args.priority,
-        )
+        data = {
+            "path": args.path,
+            "queue": args.queue,
+            "min_nodes_per_job": args.min_nodes_per_job,
+            "max_nodes_per_job": args.max_nodes_per_job,
+            "max_time_per_job": args.max_time_per_job,
+            "priority": args.priority,
+        }
+        return_val = flux.Flux().rpc("accounting.edit_queue", data).get()
     elif args.func == "add_project":
-        return_val = p.add_project(conn, args.project)
+        data = {
+            "path": args.path,
+            "project": args.project,
+        }
+        return_val = flux.Flux().rpc("accounting.add_project", data).get()
     elif args.func == "view_project":
-        return_val = p.view_project(conn, args.project)
+        data = {
+            "path": args.path,
+            "project": args.project,
+        }
+        return_val = flux.Flux().rpc("accounting.view_project", data).get()
     elif args.func == "delete_project":
-        return_val = p.delete_project(conn, args.project)
+        data = {
+            "path": args.path,
+            "project": args.project,
+        }
+        return_val = flux.Flux().rpc("accounting.delete_project", data).get()
     else:
         print(parser.print_usage())
         return
 
-    if return_val != 0:
-        print(return_val)
+    if list(return_val.values())[0] != 0:
+        print(list(return_val.values())[0])
 
 
 def main():

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -498,6 +498,7 @@ def set_output_file(args):
     return output_file
 
 
+# pylint: disable=too-many-statements
 def select_accounting_function(args, output_file, parser):
     if args.func == "view_user":
         data = {

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -38,7 +38,9 @@ def add_output_file_arg(parser):
 
 def add_view_user_arg(subparsers):
     subparser_view_user = subparsers.add_parser(
-        "view-user", help="view a user's information in the accounting database"
+        "view-user",
+        help="view a user's information in the accounting database",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_view_user.set_defaults(func="view_user")
     subparser_view_user.add_argument("username", help="username", metavar=("USERNAME"))
@@ -46,7 +48,9 @@ def add_view_user_arg(subparsers):
 
 def add_add_user_arg(subparsers):
     subparser_add_user = subparsers.add_parser(
-        "add-user", help="add a user to the accounting database"
+        "add-user",
+        help="add a user to the accounting database",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_add_user.set_defaults(func="add_user")
     subparser_add_user.add_argument(
@@ -105,7 +109,9 @@ def add_add_user_arg(subparsers):
 
 def add_delete_user_arg(subparsers):
     subparser_delete_user = subparsers.add_parser(
-        "delete-user", help="remove a user from the accounting database"
+        "delete-user",
+        help="remove a user from the accounting database",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_delete_user.set_defaults(func="delete_user")
     subparser_delete_user.add_argument(
@@ -115,7 +121,11 @@ def add_delete_user_arg(subparsers):
 
 
 def add_edit_user_arg(subparsers):
-    subparser_edit_user = subparsers.add_parser("edit-user", help="edit a user's value")
+    subparser_edit_user = subparsers.add_parser(
+        "edit-user",
+        help="edit a user's value",
+        formatter_class=flux.util.help_formatter(),
+    )
     subparser_edit_user.set_defaults(func="edit_user")
     subparser_edit_user.add_argument(
         "username",
@@ -180,7 +190,9 @@ def add_edit_user_arg(subparsers):
 
 def add_view_job_records_arg(subparsers):
     subparser_view_job_records = subparsers.add_parser(
-        "view-job-records", help="view job records"
+        "view-job-records",
+        help="view job records",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_view_job_records.set_defaults(func="view_job_records")
     subparser_view_job_records.add_argument(
@@ -208,7 +220,9 @@ def add_view_job_records_arg(subparsers):
 
 def add_create_db_arg(subparsers):
     subparser_create_db = subparsers.add_parser(
-        "create-db", help="create the flux-accounting database"
+        "create-db",
+        help="create the flux-accounting database",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_create_db.set_defaults(func="create_db")
     subparser_create_db.add_argument(
@@ -224,7 +238,9 @@ def add_create_db_arg(subparsers):
 
 
 def add_add_bank_arg(subparsers):
-    subparser_add_bank = subparsers.add_parser("add-bank", help="add a new bank")
+    subparser_add_bank = subparsers.add_parser(
+        "add-bank", help="add a new bank", formatter_class=flux.util.help_formatter()
+    )
     subparser_add_bank.set_defaults(func="add_bank")
     subparser_add_bank.add_argument(
         "bank",
@@ -241,7 +257,9 @@ def add_add_bank_arg(subparsers):
 
 def add_view_bank_arg(subparsers):
     subparser_view_bank = subparsers.add_parser(
-        "view-bank", help="view bank information"
+        "view-bank",
+        help="view bank information",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_view_bank.set_defaults(func="view_bank")
     subparser_view_bank.add_argument(
@@ -260,7 +278,9 @@ def add_view_bank_arg(subparsers):
 
 
 def add_delete_bank_arg(subparsers):
-    subparser_delete_bank = subparsers.add_parser("delete-bank", help="remove a bank")
+    subparser_delete_bank = subparsers.add_parser(
+        "delete-bank", help="remove a bank", formatter_class=flux.util.help_formatter()
+    )
     subparser_delete_bank.set_defaults(func="delete_bank")
     subparser_delete_bank.add_argument(
         "bank",
@@ -271,7 +291,9 @@ def add_delete_bank_arg(subparsers):
 
 def add_edit_bank_arg(subparsers):
     subparser_edit_bank = subparsers.add_parser(
-        "edit-bank", help="edit a bank's allocation"
+        "edit-bank",
+        help="edit a bank's allocation",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_edit_bank.set_defaults(func="edit_bank")
     subparser_edit_bank.add_argument(
@@ -293,7 +315,9 @@ def add_edit_bank_arg(subparsers):
 
 def add_update_usage_arg(subparsers):
     subparser_update_usage = subparsers.add_parser(
-        "update-usage", help="update usage factors for associations"
+        "update-usage",
+        help="update usage factors for associations",
+        formatter_class=flux.util.help_formatter(),
     )
     subparser_update_usage.set_defaults(func="update_usage")
     subparser_update_usage.add_argument(
@@ -311,7 +335,9 @@ def add_update_usage_arg(subparsers):
 
 
 def add_add_queue_arg(subparsers):
-    subparser_add_queue = subparsers.add_parser("add-queue", help="add a new queue")
+    subparser_add_queue = subparsers.add_parser(
+        "add-queue", help="add a new queue", formatter_class=flux.util.help_formatter()
+    )
 
     subparser_add_queue.set_defaults(func="add_queue")
     subparser_add_queue.add_argument("queue", help="queue name", metavar="QUEUE")
@@ -343,7 +369,9 @@ def add_add_queue_arg(subparsers):
 
 def add_view_queue_arg(subparsers):
     subparser_view_queue = subparsers.add_parser(
-        "view-queue", help="view queue information"
+        "view-queue",
+        help="view queue information",
+        formatter_class=flux.util.help_formatter(),
     )
 
     subparser_view_queue.set_defaults(func="view_queue")
@@ -352,7 +380,9 @@ def add_view_queue_arg(subparsers):
 
 def add_edit_queue_arg(subparsers):
     subparser_edit_queue = subparsers.add_parser(
-        "edit-queue", help="edit a queue's priority"
+        "edit-queue",
+        help="edit a queue's priority",
+        formatter_class=flux.util.help_formatter(),
     )
 
     subparser_edit_queue.set_defaults(func="edit_queue")
@@ -389,7 +419,9 @@ def add_edit_queue_arg(subparsers):
 
 def add_delete_queue_arg(subparsers):
     subparser_delete_queue = subparsers.add_parser(
-        "delete-queue", help="remove a queue"
+        "delete-queue",
+        help="remove a queue",
+        formatter_class=flux.util.help_formatter(),
     )
 
     subparser_delete_queue.set_defaults(func="delete_queue")
@@ -398,7 +430,9 @@ def add_delete_queue_arg(subparsers):
 
 def add_add_project_arg(subparsers):
     subparser_add_project = subparsers.add_parser(
-        "add-project", help="add a new project"
+        "add-project",
+        help="add a new project",
+        formatter_class=flux.util.help_formatter(),
     )
 
     subparser_add_project.set_defaults(func="add_project")
@@ -409,7 +443,9 @@ def add_add_project_arg(subparsers):
 
 def add_view_project_arg(subparsers):
     subparser_view_project = subparsers.add_parser(
-        "view-project", help="view project information"
+        "view-project",
+        help="view project information",
+        formatter_class=flux.util.help_formatter(),
     )
 
     subparser_view_project.set_defaults(func="view_project")
@@ -420,7 +456,9 @@ def add_view_project_arg(subparsers):
 
 def add_delete_project_arg(subparsers):
     subparser_delete_project = subparsers.add_parser(
-        "delete-project", help="remove a project"
+        "delete-project",
+        help="remove a project",
+        formatter_class=flux.util.help_formatter(),
     )
 
     subparser_delete_project.set_defaults(func="delete_project")

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -111,6 +111,11 @@ test_expect_success 'edit a field in a bank account' '
 	grep "C" | grep "50" edited_bank.out
 '
 
+test_expect_success 'try to edit a field in a bank account with a bad value' '
+	flux account edit-bank C --shares=-1000 > bad_edited_value.out &&
+	grep "New shares amount must be >= 0" bad_edited_value.out
+'
+
 test_expect_success 'remove a bank (and any corresponding users that belong to that bank)' '
 	flux account -p ${DB_PATH} delete-bank C &&
 	flux account -p ${DB_PATH} view-bank C > deleted_bank.test &&

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -6,108 +6,118 @@ test_description='Test flux-account commands'
 DB_PATH=$(pwd)/FluxAccountingTest.db
 EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/flux_account
 
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '
 
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
 test_expect_success 'add some banks to the DB' '
-	flux account -p ${DB_PATH} add-bank root 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root A 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root B 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root C 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root D 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=D E 1
-	flux account -p ${DB_PATH} add-bank --parent-bank=D F 1
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1 &&
+	flux account add-bank --parent-bank=root D 1 &&
+	flux account add-bank --parent-bank=D E 1
+	flux account add-bank --parent-bank=D F 1
 '
 
 test_expect_success 'add some users to the DB' '
-	flux account -p ${DB_PATH} add-user --username=user5011 --userid=5011 --bank=A &&
-	flux account -p ${DB_PATH} add-user --username=user5012 --userid=5012 --bank=A &&
-	flux account -p ${DB_PATH} add-user --username=user5013 --userid=5013 --bank=B &&
-	flux account -p ${DB_PATH} add-user --username=user5014 --userid=5014 --bank=C
+	flux account add-user --username=user5011 --userid=5011 --bank=A &&
+	flux account add-user --username=user5012 --userid=5012 --bank=A &&
+	flux account add-user --username=user5013 --userid=5013 --bank=B &&
+	flux account add-user --username=user5014 --userid=5014 --bank=C
 '
 
 test_expect_success 'add some queues to the DB' '
-	flux account -p ${DB_PATH} add-queue standby --priority=0 &&
-	flux account -p ${DB_PATH} add-queue expedite --priority=10000 &&
-	flux account -p ${DB_PATH} add-queue special --priority=99999
+	flux account add-queue standby --priority=0 &&
+	flux account add-queue expedite --priority=10000 &&
+	flux account add-queue special --priority=99999
 '
 
 test_expect_success 'view some user information' '
-	flux account -p ${DB_PATH} view-user user5011 > user_info.out &&
+	flux account view-user user5011 > user_info.out &&
 	grep "user5011" | grep "5011" | grep "A" user_info.out
 '
 
 test_expect_success 'add a queue to an existing user account' '
-	flux account -p ${DB_PATH} edit-user user5011 --queue="expedite"
+	flux account edit-user user5011 --queue="expedite"
 '
 
 test_expect_success 'trying to add a non-existent queue to a user account should return an error' '
-	flux account -p ${DB_PATH} edit-user user5011 --queue="foo" > bad_queue.out &&
+	flux account edit-user user5011 --queue="foo" > bad_queue.out &&
 	grep "Queue specified does not exist in queue_table" bad_queue.out
 '
 
 test_expect_success 'trying to add a user with a non-existent queue should also return an error' '
-	flux account -p ${DB_PATH} add-user --username=user5015 --userid=5015 --bank=A --queue="foo" > bad_queue2.out &&
+	flux account add-user --username=user5015 --userid=5015 --bank=A --queue="foo" > bad_queue2.out &&
 	grep "Queue specified does not exist in queue_table" bad_queue2.out
 '
 
 test_expect_success 'add multiple queues to an existing user account' '
-	flux account -p ${DB_PATH} edit-user user5012 --queue="expedite,standby" &&
-	flux account -p ${DB_PATH} view-user user5012 > user5012.out &&
+	flux account edit-user user5012 --queue="expedite,standby" &&
+	flux account view-user user5012 > user5012.out &&
 	grep "expedite,standby" user5012.out
 '
 
 test_expect_success 'edit the max_active_jobs of an existing user' '
-	flux account -p ${DB_PATH} edit-user user5011 --max-active-jobs 999 &&
-	flux account -p ${DB_PATH} view-user user5011 > edited_shares.out &&
+	flux account edit-user user5011 --max-active-jobs 999 &&
+	flux account view-user user5011 > edited_shares.out &&
 	grep "user5011" | grep "5011" | grep "999" edited_shares.out
 '
 
 test_expect_success 'edit a queue priority' '
-	flux account -p ${DB_PATH} edit-queue expedite --priority=20000 &&
-	flux account -p ${DB_PATH} view-queue expedite > edited_queue.out &&
+	flux account edit-queue expedite --priority=20000 &&
+	flux account view-queue expedite > edited_queue.out &&
 	grep "20000" edited_queue.out
 '
 
 test_expect_success 'remove a queue' '
-	flux account -p ${DB_PATH} delete-queue special &&
-	flux account -p ${DB_PATH} view-queue special > deleted_queue.out &&
+	flux account delete-queue special &&
+	flux account view-queue special > deleted_queue.out &&
 	grep "Queue not found in queue_table" deleted_queue.out
 '
 
 test_expect_success 'trying to view a bank that does not exist in the DB should return an error message' '
-	flux account -p ${DB_PATH} view-bank foo > bad_bank.out &&
+	flux account view-bank foo > bad_bank.out &&
 	grep "Bank not found in bank_table" bad_bank.out
 '
 
 test_expect_success 'viewing the root bank with no optional args should show just the bank info' '
-	flux account -p ${DB_PATH} view-bank root > root_bank.test &&
+	flux account view-bank root > root_bank.test &&
 	test_cmp ${EXPECTED_FILES}/root_bank.expected root_bank.test
 '
 
 test_expect_success 'viewing a bank with users in it should print all user info under that bank as well' '
-	flux account -p ${DB_PATH} view-bank A -u > A_bank.test &&
+	flux account view-bank A -u > A_bank.test &&
 	test_cmp ${EXPECTED_FILES}/A_bank.expected A_bank.test
 '
 
 test_expect_success 'trying to view a user who does not exist in the DB should return an error message' '
-	flux account -p ${DB_PATH} view-user user9999 > bad_user.out &&
+	flux account view-user user9999 > bad_user.out &&
 	grep "User not found in association_table" bad_user.out
 '
 
 test_expect_success 'trying to view a user that does exist in the DB should return some information' '
-	flux account -p ${DB_PATH} view-user user5011 > good_user.out &&
+	flux account view-user user5011 > good_user.out &&
 	grep "user5011" | grep "5011" | grep "A" good_user.out
 '
 
 test_expect_success 'edit a field in a user account' '
-	flux account -p ${DB_PATH} edit-user user5011 --shares 50
+	flux account edit-user user5011 --shares 50
 '
 
 test_expect_success 'edit a field in a bank account' '
-	flux account -p ${DB_PATH} edit-bank C --shares=50 &&
-	flux account -p ${DB_PATH} view-bank C > edited_bank.out &&
+	flux account edit-bank C --shares=50 &&
+	flux account view-bank C > edited_bank.out &&
 	grep "C" | grep "50" edited_bank.out
 '
 
@@ -117,116 +127,116 @@ test_expect_success 'try to edit a field in a bank account with a bad value' '
 '
 
 test_expect_success 'remove a bank (and any corresponding users that belong to that bank)' '
-	flux account -p ${DB_PATH} delete-bank C &&
-	flux account -p ${DB_PATH} view-bank C > deleted_bank.test &&
+	flux account delete-bank C &&
+	flux account view-bank C > deleted_bank.test &&
 	grep -f ${EXPECTED_FILES}/deleted_bank.expected deleted_bank.test &&
-	flux account -p ${DB_PATH} view-user user5014 > deleted_user.out &&
+	flux account view-user user5014 > deleted_user.out &&
 	grep -f ${EXPECTED_FILES}/deleted_user.expected deleted_user.out
 '
 
 test_expect_success 'remove a user account' '
-	flux account -p ${DB_PATH} delete-user user5012 A &&
-	flux account -p ${DB_PATH} view-user user5012 > deleted_user.out &&
+	flux account delete-user user5012 A &&
+	flux account view-user user5012 > deleted_user.out &&
 	grep -f ${EXPECTED_FILES}/deleted_user.expected deleted_user.out
 '
 
 test_expect_success 'add a queue with no optional args to the queue_table' '
-	flux account -p ${DB_PATH} add-queue queue_1
-	flux account -p ${DB_PATH} view-queue queue_1 > new_queue.out &&
+	flux account add-queue queue_1
+	flux account view-queue queue_1 > new_queue.out &&
 	grep "queue_1" | grep "1" | grep "1" | grep "60" | grep "0" new_queue.out
 '
 
 test_expect_success 'add another queue with some optional args' '
-	flux account -p ${DB_PATH} add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120
+	flux account add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120
 '
 
 test_expect_success 'edit some queue information' '
-	flux account -p ${DB_PATH} edit-queue queue_1 --max-nodes-per-job 100 &&
-	flux account -p ${DB_PATH} view-queue queue_1 > edited_max_nodes.out &&
+	flux account edit-queue queue_1 --max-nodes-per-job 100 &&
+	flux account view-queue queue_1 > edited_max_nodes.out &&
 	grep "queue_1" | grep "100" edited_max_nodes.out
 '
 
 test_expect_success 'edit multiple columns for one queue' '
-	flux account -p ${DB_PATH} edit-queue queue_1 --min-nodes-per-job 1 --max-nodes-per-job 128 --max-time-per-job 120
+	flux account edit-queue queue_1 --min-nodes-per-job 1 --max-nodes-per-job 128 --max-time-per-job 120
 '
 
 test_expect_success 'reset a queue limit' '
-	flux account -p ${DB_PATH} edit-queue queue_1 --max-nodes-per-job -1 &&
-	flux account -p ${DB_PATH} view-queue queue_1 > reset_limit.out &&
+	flux account edit-queue queue_1 --max-nodes-per-job -1 &&
+	flux account view-queue queue_1 > reset_limit.out &&
 	grep "queue_1" | grep "1" | grep "1" | grep "120" | grep "0" reset_limit.out
 '
 
 test_expect_success 'remove a queue from the queue_table' '
-	flux account -p ${DB_PATH} delete-queue queue_2 &&
-	flux account -p ${DB_PATH} view-queue queue_2 > deleted_queue.out &&
+	flux account delete-queue queue_2 &&
+	flux account view-queue queue_2 > deleted_queue.out &&
 	grep "Queue not found in queue_table" deleted_queue.out
 '
 
 test_expect_success 'Add a user to two different banks' '
-	flux account -p ${DB_PATH} add-user --username=user5015 --userid=5015 --bank=E &&
-	flux account -p ${DB_PATH} add-user --username=user5015 --userid=5015 --bank=F
+	flux account add-user --username=user5015 --userid=5015 --bank=E &&
+	flux account add-user --username=user5015 --userid=5015 --bank=F
 '
 
 test_expect_success 'Delete user default bank row' '
-	flux account -p ${DB_PATH} delete-user user5013 E
+	flux account delete-user user5013 E
 '
 
 test_expect_success 'Check that user default bank gets updated to other bank' '
-	flux account -p ${DB_PATH} view-user user5015 > new_default_bank.out &&
+	flux account view-user user5015 > new_default_bank.out &&
 	cat new_default_bank.out &&
 	grep "user5015" | grep "F" | grep "F" new_default_bank.out
 '
 
 test_expect_success 'add some projects to the project_table' '
-	flux account -p ${DB_PATH} add-project project_1 &&
-	flux account -p ${DB_PATH} add-project project_2 &&
-	flux account -p ${DB_PATH} add-project project_3 &&
-	flux account -p ${DB_PATH} add-project project_4
+	flux account add-project project_1 &&
+	flux account add-project project_2 &&
+	flux account add-project project_3 &&
+	flux account add-project project_4
 '
 
 test_expect_success 'view project information from the project_table' '
-	flux account -p ${DB_PATH} view-project project_1 > project_1.out &&
+	flux account view-project project_1 > project_1.out &&
 	grep "1" | grep "project_1" project_1.out
 '
 
 test_expect_success 'add a user with some specified projects to the association_table' '
-	flux account -p ${DB_PATH} add-user --username=user5015 --bank=A --projects="project_1,project_3" &&
-	flux account -p ${DB_PATH} view-user user5015 > user5015_info.out &&
+	flux account add-user --username=user5015 --bank=A --projects="project_1,project_3" &&
+	flux account view-user user5015 > user5015_info.out &&
 	grep "user5015" | grep "project_1,project_3,*" user5015_info.out
 '
 
 test_expect_success 'adding a user with a non-existing project should fail' '
-	flux account -p ${DB_PATH} add-user --username=user5016 --bank=A --projects="project_1,foo" > bad_project.out &&
+	flux account add-user --username=user5016 --bank=A --projects="project_1,foo" > bad_project.out &&
 	grep "Project \"foo\" does not exist in project_table" bad_project.out
 '
 
 test_expect_success 'successfully edit a projects list for a user' '
-	flux account -p ${DB_PATH} edit-user user5015 --bank=A --projects="project_1,project_2,project_3" &&
-	flux account -p ${DB_PATH} view-user user5015 > user5015_edited_info.out &&
+	flux account edit-user user5015 --bank=A --projects="project_1,project_2,project_3" &&
+	flux account view-user user5015 > user5015_edited_info.out &&
 	grep "user5015" | grep "project_1,project_2,project_3,*" user5015_edited_info.out
 '
 
 test_expect_success 'editing a user project list with a non-existing project should fail' '
-	flux account -p ${DB_PATH} edit-user user5015 --bank=A --projects="project_1,foo" > bad_project_2.out &&
+	flux account edit-user user5015 --bank=A --projects="project_1,foo" > bad_project_2.out &&
 	grep "Project \"foo\" does not exist in project_table" bad_project_2.out
 '
 
 test_expect_success 'remove a project from the project_table that is still referenced by at least one user' '
-	flux account -p ${DB_PATH} delete-project project_1 > warning_message.out &&
-	flux account -p ${DB_PATH} view-project project_1 > deleted_project.out &&
+	flux account delete-project project_1 > warning_message.out &&
+	flux account view-project project_1 > deleted_project.out &&
 	grep "WARNING: user(s) in the assocation_table still reference this project." warning_message.out &&
 	grep "Project not found in project_table" deleted_project.out
 '
 
 test_expect_success 'remove a project that is not referenced by any users' '
-	flux account -p ${DB_PATH} delete-project project_4 &&
-	flux account -p ${DB_PATH} view-project project_4 > deleted_project_2.out &&
+	flux account delete-project project_4 &&
+	flux account view-project project_4 > deleted_project_2.out &&
 	grep "Project not found in project_table" deleted_project_2.out
 '
 
 test_expect_success 'add a user to the accounting DB without specifying any projects' '
-	flux account -p ${DB_PATH} add-user --username=user5017 --bank=A &&
-	flux account -p ${DB_PATH} view-user user5017 > default_project_unspecified.test &&
+	flux account add-user --username=user5017 --bank=A &&
+	flux account view-user user5017 > default_project_unspecified.test &&
 	cat <<-EOF >default_project_unspecfied.expected
 	default_project
 	*
@@ -235,8 +245,8 @@ test_expect_success 'add a user to the accounting DB without specifying any proj
 '
 
 test_expect_success 'add a user to the accounting DB and specify a project' '
-	flux account -p ${DB_PATH} add-user --username=user5018 --bank=A --projects=project_2 &&
-	flux account -p ${DB_PATH} view-user user5018 > default_project_specified.test &&
+	flux account add-user --username=user5018 --bank=A --projects=project_2 &&
+	flux account view-user user5018 > default_project_specified.test &&
 	cat <<-EOF >default_project_specified.expected
 	default_project
 	project_2
@@ -245,8 +255,8 @@ test_expect_success 'add a user to the accounting DB and specify a project' '
 '
 
 test_expect_success 'edit the default project of a user' '
-	flux account -p ${DB_PATH} edit-user user5018 --default-project=* &&
-	flux account -p ${DB_PATH} view-user user5018 > edited_default_project.test &&
+	flux account edit-user user5018 --default-project=* &&
+	flux account view-user user5018 > edited_default_project.test &&
 	cat <<-EOF >edited_default_project.expected
 	default_project
 	*
@@ -260,12 +270,16 @@ test_expect_success 'edit the default project of a user' '
 '
 
 test_expect_success 'trying to add a user to a nonexistent bank should raise a ValueError' '
-	flux account -p ${DB_PATH} add-user --username=user5019 --bank=foo > nonexistent_bank.out &&
+	flux account add-user --username=user5019 --bank=foo > nonexistent_bank.out &&
 	grep "Bank \"foo\" does not exist in bank_table" nonexistent_bank.out
 '
 
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
 '
 
 test_done

--- a/t/t1010-update-usage.t
+++ b/t/t1010-update-usage.t
@@ -8,25 +8,35 @@ CREATE_TEST_DB=${SHARNESS_TEST_SRCDIR}/scripts/create_test_db.py
 UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 CREATE_JOB_ARCHIVE=${SHARNESS_TEST_SRCDIR}/scripts/create_job_archive_db.py
 
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '
 
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
 test_expect_success 'add some banks to the DB' '
-	flux account -p ${DB_PATH} add-bank root 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root account3 1
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root account1 1 &&
+	flux account add-bank --parent-bank=root account2 1 &&
+	flux account add-bank --parent-bank=root account3 1
 '
 
 test_expect_success 'add some users to the DB' '
-	flux account -p ${DB_PATH} add-user --username=5011 --userid=5011 --bank=account1 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=5012 --userid=5012 --bank=account1 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=5013 --userid=5013 --bank=account1 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=5021 --userid=5021 --bank=account2 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=5022 --userid=5022 --bank=account2 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=5031 --userid=5031 --bank=account3 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=5032 --userid=5032 --bank=account3 --shares=1
+	flux account add-user --username=5011 --userid=5011 --bank=account1 --shares=1 &&
+	flux account add-user --username=5012 --userid=5012 --bank=account1 --shares=1 &&
+	flux account add-user --username=5013 --userid=5013 --bank=account1 --shares=1 &&
+	flux account add-user --username=5021 --userid=5021 --bank=account2 --shares=1 &&
+	flux account add-user --username=5022 --userid=5022 --bank=account2 --shares=1 &&
+	flux account add-user --username=5031 --userid=5031 --bank=account3 --shares=1 &&
+	flux account add-user --username=5032 --userid=5032 --bank=account3 --shares=1
 '
 
 test_expect_success 'create sample job-archive DB' '
@@ -34,7 +44,7 @@ test_expect_success 'create sample job-archive DB' '
 '
 
 test_expect_success 'update-usage raises a usage error when passing a bad type for priority-decay-half-life' '
-	test_must_fail flux account -p ${DB_PATH} update-usage job-archive.sqlite \
+	test_must_fail flux account update-usage job-archive.sqlite \
 		--priority-decay-half-life foo > bad_arg.out 2>&1 &&
 	test_debug "cat bad_arg.out" &&
 	grep "flux-account.py update-usage: error: argument --priority-decay-half-life: invalid int value:" bad_arg.out
@@ -46,7 +56,7 @@ test_expect_success 'create & compare hierarchy output from FluxAccountingTest.d
 '
 
 test_expect_success 'run update-usage and update-fshare commands' '
-	flux account -p ${DB_PATH} update-usage job-archive.sqlite &&
+	flux account update-usage job-archive.sqlite &&
 	flux account-update-fshare -p ${DB_PATH}
 '
 
@@ -56,13 +66,17 @@ test_expect_success 'create & compare hierarchy output from FluxAccountingTest.d
 '
 
 test_expect_success 'run update-usage and update-fshare commands with an optional arg' '
-	flux account -p ${DB_PATH} update-usage job-archive.sqlite --priority-decay-half-life 1 &&
+	flux account update-usage job-archive.sqlite --priority-decay-half-life 1 &&
 	flux account-update-fshare -p ${DB_PATH}
 '
 
 test_expect_success 'create & compare hierarchy output from FluxAccountingTest.db: post-usage update 2' '
 	flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update2.test &&
 	test_cmp ${SHARNESS_TEST_SRCDIR}/expected/job_usage/post_update2.expected post_update2.test
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
 '
 
 test_done

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -11,6 +11,14 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '
@@ -19,21 +27,17 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create flux-accounting DB' '
-	flux account -p $(pwd)/FluxAccountingTest.db create-db
-'
-
 test_expect_success 'add some banks to the DB' '
-	flux account -p ${DB_PATH} add-bank root 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root account1 1 &&
-	flux account -p ${DB_PATH} add-bank --parent-bank=root account2 1
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root account1 1 &&
+	flux account add-bank --parent-bank=root account2 1
 '
 
 test_expect_success 'add a user with two different banks to the DB' '
 	username=$(whoami) &&
 	uid=$(id -u) &&
-	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account1 --shares=1 &&
-	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account2 --shares=1
+	flux account add-user --username=$username --userid=$uid --bank=account1 --shares=1 &&
+	flux account add-user --username=$username --userid=$uid --bank=account2 --shares=1
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
@@ -59,7 +63,7 @@ test_expect_success 'submit a job successfully under second bank' '
 '
 
 test_expect_success 'disable second user/bank entry and update plugin' '
-	flux account -p ${DB_PATH} delete-user $username account2 &&
+	flux account delete-user $username account2 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 
@@ -70,7 +74,7 @@ test_expect_success 'try to submit job under second user/bank entry' '
 '
 
 test_expect_success 're-add second user/bank entry and update-plugin' '
-	flux account -p ${DB_PATH} add-user --username=$username --userid=$uid --bank=account2 --shares=1 &&
+	flux account add-user --username=$username --userid=$uid --bank=account2 --shares=1 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 
@@ -84,7 +88,7 @@ test_expect_success 'submit a job successfully under second bank' '
 '
 
 test_expect_success 'disable first (and default) bank entry for user (will update the plugin with a new default bank)' '
-	flux account -p ${DB_PATH} delete-user $username account1 &&
+	flux account delete-user $username account1 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 
@@ -99,7 +103,7 @@ test_expect_success 'try to submit job under new default user/bank entry' '
 
 test_expect_success 'disabling a user while they have an active job should not kill the job' '
 	jobid5=$(flux mini submit -n1 sleep 60) &&
-	flux account -p ${DB_PATH} delete-user $username account2 &&
+	flux account delete-user $username account2 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
 	test $(flux jobs -no {state} ${jobid5}) = RUN &&
 	flux job cancel $jobid5
@@ -109,6 +113,10 @@ test_expect_success 'trying to submit a job now should result in a job rejection
 	test_must_fail flux mini submit --setattr=system.bank=account2 -n1 hostname > deleted_entry2.out 2>&1 &&
 	test_debug "cat deleted_entry2.out" &&
 	grep "user/bank entry has been disabled from flux-accounting DB" deleted_entry2.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
 '
 
 test_done


### PR DESCRIPTION
#### Background

`flux account` commands can currently only be executed on the management node of a cluster (where the flux-accounting DB is installed). So, users/admins who want to run simple `flux account` commands to see user or bank info cannot run these commands from other nodes on a cluster. There is a need to improve this and enable commands to interface with the DB "remotely."

---

This is an early [WIP] PR that introduces a new service to flux-accounting that can be managed by `systemd` and is designed to run on the rank 0 broker of a Flux system instance. This service, `flux-account-service.py`, is installed to `${prefix}/libexec/flux/cmd` and can be started _after_ the creation of a flux-accounting database:

```console
$ flux account-service -p path/to/db &
[1] 1234
```

If no path is specified on the command line when the service is started, it will try to connect to the database in its default location, `/var/lib/flux/FluxAccounting.db`. The service is now the component responsible for maintaining a connection to the SQLite database instead of the front-end script that accepts `flux account` commands, `flux-account.py`.

`flux-account.py` now issues RPCs to this service instead of calling the Python bindings directly. The service will accept the RPCs from the front-end script, call the appropriate Python binding, and send a payload back to the front-end script with any returned information, where it is unpacked, and if necessary, printed to `STDOUT` or `STDERR`.

These changes did not require any major rework to the existing suite of tests for flux-accounting, other than now starting this new service in the tests where `flux account` commands are called. You'll also notice that the optional path that had to previously be specified when issuing a `flux account` command is no longer needed, since the service is now responsible for connecting to the flux-accounting database. This is true for almost every `flux account` command _except_ for the command that creates the database for the first time, `flux account create-db`, which I have left to directly call the `create_db()` Python function.

I'm leaving this as [WIP] for now until I can do a little cleanup here and there with the commits, and to also get some early feedback on the service, as this is my first time writing something like this, and I'm sure there are improvements that I missed 😄 . I'll list them below:

- [x] check commit messages and contents for misspellings and type of commit
- [x] consult on various `sleep 1` inserts in tests where service is loaded and `flux account` commands are called immediately after
- [x] consult behavior of service when connection to DB fails (because of bad path, some other error occurs, etc.)

