### PR TITLE
view-job-records: fix arguments passed in via `flux-account-service.py`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -65,25 +65,29 @@ def write_records_to_file(job_records, output_file):
 
 
 def fetch_job_records(job_records):
-    job_record_str = ""
-    job_record_str += "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
-        "UserID",
-        "Username",
-        "JobID",
-        "T_Submit",
-        "T_Run",
-        "T_Inactive",
-        "Nodes",
+    job_record_str = []
+    job_record_str.append(
+        "{:<10} {:<10} {:<20} {:<20} {:<20} {:<20} {:<10}".format(
+            "UserID",
+            "Username",
+            "JobID",
+            "T_Submit",
+            "T_Run",
+            "T_Inactive",
+            "Nodes",
+        )
     )
     for record in job_records:
-        job_record_str += "{:<10} {:<10} {:<10} {:<15} {:<15} {:<15} {:<10}".format(
-            record.userid,
-            record.username,
-            record.jobid,
-            record.t_submit,
-            record.t_run,
-            record.t_inactive,
-            record.nnodes,
+        job_record_str.append(
+            "{:<10} {:<10} {:<20} {:<20} {:<20} {:<20} {:<10}".format(
+                record.userid,
+                record.username,
+                record.jobid,
+                record.t_submit,
+                record.t_run,
+                record.t_inactive,
+                record.nnodes,
+            )
         )
 
     return job_record_str
@@ -242,15 +246,17 @@ def get_job_records(conn, bank, default_bank, **kwargs):
 
 
 def output_job_records(conn, output_file, **kwargs):
+    job_record_str = ""
     job_records = get_job_records(conn, None, None, **kwargs)
 
+    job_record_str = fetch_job_records(job_records)
+
     if output_file is None:
-        job_record_str = fetch_job_records(job_records)
         return job_record_str
 
     write_records_to_file(job_records, output_file)
 
-    return job_records
+    return job_record_str
 
 
 def update_t_inactive(acct_conn, last_t_inactive, user, bank):

--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -170,21 +170,21 @@ class TestAccountingCLI(unittest.TestCase):
     def test_01_with_jobid_valid(self):
         my_dict = {"jobid": 102}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 1)
+        print(job_records)
+        self.assertEqual(len(job_records), 2)
 
-    # passing a bad jobid should return a
-    # failure message
+    # passing a bad jobid should return no records
     def test_02_with_jobid_failure(self):
         my_dict = {"jobid": 000}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 0)
+        self.assertEqual(len(job_records), 1)
 
     # passing a timestamp before the first job to
     # start should return all of the jobs
     def test_03_after_start_time_all(self):
         my_dict = {"after_start_time": 0}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 18)
+        self.assertEqual(len(job_records), 19)
 
     # passing a timestamp after all of the start time
     # of all the completed jobs should return a failure message
@@ -192,7 +192,7 @@ class TestAccountingCLI(unittest.TestCase):
     def test_04_after_start_time_none(self):
         my_dict = {"after_start_time": time.time()}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 0)
+        self.assertEqual(len(job_records), 1)
 
     # passing a timestamp before the end time of the
     # last job should return all of the jobs
@@ -200,21 +200,21 @@ class TestAccountingCLI(unittest.TestCase):
     def test_05_before_end_time_all(self):
         my_dict = {"before_end_time": time.time()}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 18)
+        self.assertEqual(len(job_records), 19)
 
     # passing a timestamp before the end time of
     # the first completed jobs should return no jobs
     def test_06_before_end_time_none(self):
         my_dict = {"before_end_time": 0}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 0)
+        self.assertEqual(len(job_records), 1)
 
     # passing a user not in the jobs table
     # should return no jobs
     def test_07_by_user_failure(self):
         my_dict = {"user": "9999"}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 0)
+        self.assertEqual(len(job_records), 1)
 
     # view_jobs_run_by_username() interacts with a
     # passwd file; for the purpose of these tests,
@@ -222,7 +222,7 @@ class TestAccountingCLI(unittest.TestCase):
     def test_08_by_user_success(self):
         my_dict = {"user": "1001"}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 2)
+        self.assertEqual(len(job_records), 3)
 
     # passing a combination of params should further
     # refine the query
@@ -230,14 +230,14 @@ class TestAccountingCLI(unittest.TestCase):
     def test_09_multiple_params(self):
         my_dict = {"user": "1001", "after_start_time": time.time()}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 1)
+        self.assertEqual(len(job_records), 2)
 
     # passing no parameters will result in a generic query
     # returning all results
     def test_10_no_options_passed(self):
         my_dict = {}
         job_records = jobs.output_job_records(jobs_conn, op, **my_dict)
-        self.assertEqual(len(job_records), 18)
+        self.assertEqual(len(job_records), 19)
 
     # users that have run a lot of jobs should have a larger usage factor
     @mock.patch("time.time", mock.MagicMock(return_value=9900000))

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -276,17 +276,21 @@ class AccountingService:
 
     def view_job_records(self, handle, watcher, msg, arg):
         try:
+            # connect to job-archive DB
+            jobs_conn = establish_sqlite_connection(msg.payload["path"])
+
             val = jobs.output_job_records(
-                self.conn,
+                jobs_conn,
                 msg.payload["output_file"],
-                msg.payload["jobid"],
-                msg.payload["user"],
-                msg.payload["before_end_time"],
-                msg.payload["after_start_time"],
+                jobid=msg.payload["jobid"],
+                user=msg.payload["user"],
+                before_end_time=msg.payload["before_end_time"],
+                after_start_time=msg.payload["after_start_time"],
             )
 
             payload = {"view_job_records": val}
 
+            jobs_conn.close()
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -274,6 +274,7 @@ class AccountingService:
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
             )
 
+    # pylint: disable=no-self-use
     def view_job_records(self, handle, watcher, msg, arg):
         try:
             # connect to job-archive DB

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -552,6 +552,13 @@ def select_accounting_function(args, output_file, parser):
             "after_start_time": args.after_start_time,
         }
         return_val = flux.Flux().rpc("accounting.view_job_records", data).get()
+        # the return value of view-job-records without
+        # an output file is a list of strings, so just
+        # iterate through that list here and then return
+        job_record_list = list(return_val.values())
+        for job_record in job_record_list[0]:
+            print(job_record)
+        return
     elif args.func == "add_bank":
         data = {
             "path": args.path,

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -81,6 +81,14 @@ test_expect_success 'submit some sleep 1 jobs under one user' '
 	wait_db $jobid3 ${ARCHIVEDB}
 '
 
+test_expect_success 'view job records for a user' '
+	flux account -p ${ARCHIVEDB} view-job-records --user $username
+'
+
+test_expect_success 'view job records for a user and direct it to a file' '
+	flux account -p ${ARCHIVEDB} --output-file $(pwd)/test.txt view-job-records --user $username
+'
+
 test_expect_success 'run update-usage and update-fshare commands' '
 	flux account update-usage ${ARCHIVEDB} &&
 	flux account-update-fshare -p ${DB_PATH}


### PR DESCRIPTION
#### Background

The call to `output_job_records()` in **flux-account-service.py** currently fails due to a mismatch in arguments to the function.

```console
$ sudo flux account view-job-records
Traceback (most recent call last):
  File "/usr/libexec/flux/cmd/flux-account.py", line 679, in <module>
    main()
  File "/usr/libexec/flux/cmd/flux-account.py", line 675, in main
    select_accounting_function(args, output_file, parser)
  File "/usr/libexec/flux/cmd/flux-account.py", line 554, in select_accounting_function
    return_val = flux.Flux().rpc("accounting.view_job_records", data).get()
  File "/usr/lib64/flux/python3.6/flux/rpc.py", line 77, in get
    resp_str = self.get_str()
  File "/usr/lib64/flux/python3.6/flux/util.py", line 90, in func_wrapper
    retval = func(future, *args, **kwargs)
  File "/usr/lib64/flux/python3.6/flux/rpc.py", line 71, in get_str
    self.pimpl.flux_rpc_get(payload_str)
  File "/usr/lib64/flux/python3.6/flux/util.py", line 66, in func_wrapper
    raise EnvironmentError(error.errno, errmsg.decode("utf-8")) from None
OSError: [Errno 22] a non-OSError exception was caught: output_job_records() takes 2 positional arguments but 6 were given
```

This is because the parameters in the call to `output_job_records()` are not labeled.

The path passed to the `output_job_records()` function is incorrect. The path should be to the flux-core job-archive DB, not the flux-accounting DB.

---

This PR makes a couple of small fixes to the `view-job-records` command in **flux-account-service.py** and adjusts the helper functions for that command slightly to account for the use of the new service, most notably in its output. A couple of tests are also added to **t1011-job-archive-interface.t** that call this command, both with and without a passed output file.

