### PR TITLE
edit-user: make "userid" an editable field

### DIFF
--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -248,6 +248,18 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertRaises(ValueError)
 
+    # edit a user's userid
+    def test_14_edit_user_userid(self):
+        cur = acct_conn.cursor()
+        u.add_user(acct_conn, username="test_user5", bank="A")
+
+        cur.execute("SELECT userid FROM association_table WHERE username='test_user5'")
+        self.assertEqual(cur.fetchone()[0], 65534)
+
+        u.edit_user(acct_conn, username="test_user5", userid="12345")
+        cur.execute("SELECT userid FROM association_table WHERE username='test_user5'")
+        self.assertEqual(cur.fetchone()[0], 12345)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -329,6 +329,7 @@ def edit_user(
     conn,
     username,
     bank=None,
+    userid=None,
     default_bank=None,
     shares=None,
     max_running_jobs=None,
@@ -342,6 +343,7 @@ def edit_user(
     editable_fields = [
         "username",
         "bank",
+        "userid",
         "default_bank",
         "shares",
         "max_running_jobs",

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -184,6 +184,7 @@ class AccountingService:
                 self.conn,
                 msg.payload["username"],
                 msg.payload["bank"],
+                msg.payload["userid"],
                 msg.payload["default_bank"],
                 msg.payload["shares"],
                 msg.payload["max_running_jobs"],

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -134,6 +134,11 @@ def add_edit_user_arg(subparsers):
         metavar="BANK",
     )
     subparser_edit_user.add_argument(
+        "--userid",
+        default=None,
+        metavar="USERID",
+    )
+    subparser_edit_user.add_argument(
         "--default-bank",
         help="default bank",
         default=None,
@@ -532,6 +537,7 @@ def select_accounting_function(args, output_file, parser):
             "path": args.path,
             "username": args.username,
             "bank": args.bank,
+            "userid": args.userid,
             "default_bank": args.default_bank,
             "shares": args.shares,
             "max_running_jobs": args.max_running_jobs,

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -48,6 +48,13 @@ test_expect_success 'view some user information' '
 	grep "user5011" | grep "5011" | grep "A" user_info.out
 '
 
+test_expect_success 'edit a userid for a user' '
+	flux account edit-user user5011 --userid=12345 &&
+	flux account view-user user5011 > edit_userid.out &&
+	grep "user5011" | grep "12345" | grep "A" edit_userid.out &&
+	flux account edit-user user5011 --userid=5011
+'
+
 test_expect_success 'add a queue to an existing user account' '
 	flux account edit-user user5011 --queue="expedite"
 '


### PR DESCRIPTION
#### Problem

As reported in #318, the "userid" field for a user is not editable in the `association_table`, so when a user is created in the DB before they are in the passwd file, they get a default UID of 65534 with no way to edit it unless they go into a SQLite shell and manually edit the column themselves.

---

This PR adds "userid" as an editable field in the `edit-user` command. It also adds a unit test and a sharness test that confirms that the userid can be edited.

Fixes #318