### PR TITLE
`view-*` commands: raise `ValueError` when item cannot be found in flux-accounting DB

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -114,7 +114,7 @@ def view_bank(conn, bank, users=False):
         if rows:
             bank_str = get_bank_rows(cur, rows, bank)
         else:
-            return "Bank not found in bank_table"
+            raise ValueError(f"Bank {bank} not found in bank_table")
 
         # if users is passed in, print out all potential users under
         # the passed in bank

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -21,7 +21,7 @@ def view_project(conn, project):
         headers = [description[0] for description in cur.description]
         project_str = ""
         if not rows:
-            return "Project not found in project_table"
+            raise ValueError(f"Project {project} not found in project_table")
 
         for header in headers:
             project_str += header.ljust(18)

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -21,7 +21,7 @@ def view_queue(conn, queue):
         headers = [description[0] for description in cur.description]
         queue_str = ""
         if not rows:
-            return "Queue not found in queue_table"
+            raise ValueError(f"Queue {queue} not found in queue_table")
 
         # print column names of queue_table
         for header in headers:

--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -141,6 +141,11 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertRaises(ValueError)
 
+    # trying to view a bank that does not exist should raise a ValueError
+    def test_11_view_bank_nonexistent(self):
+        with self.assertRaises(ValueError):
+            b.view_bank(acct_conn, bank="foo")
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
@@ -108,6 +108,11 @@ class TestAccountingCLI(unittest.TestCase):
         u.edit_user(acct_conn, username="user5002", bank="A", projects="foo")
         self.assertRaises(ValueError)
 
+    # trying to view a project that does not exist should raise a ValueError
+    def test_08_view_project_nonexistent(self):
+        with self.assertRaises(ValueError):
+            p.view_project(acct_conn, "foo")
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
@@ -83,6 +83,11 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(len(rows), 0)
 
+    # trying to view a queue that does not exist should raise a ValueError
+    def test_08_view_queue_nonexistent(self):
+        with self.assertRaises(ValueError):
+            q.view_queue(acct_conn, "foo")
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -196,11 +196,9 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(cursor.fetchone()[0], "other_test_bank")
 
-    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_10_view_nonexistent_user(self, mock_stdout):
-        test_output = u.view_user(acct_conn, "foo")
-        expected_output = "User not found in association_table"
-        self.assertEqual(test_output, expected_output)
+    def test_10_view_nonexistent_user(self):
+        with self.assertRaises(ValueError):
+            u.view_user(acct_conn, "foo")
 
     # disable a user who belongs to multiple banks; make sure that the default_bank
     # is updated to the next earliest associated bank

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -191,7 +191,7 @@ def view_user(conn, user):
         rows = cur.fetchall()
         headers = [description[0] for description in cur.description]  # column names
         if not rows:
-            return "User not found in association_table"
+            raise ValueError(f"User {user} not found in association_table")
 
         user_str = get_user_rows(headers, rows)
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -133,6 +133,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in view-user: {val_err}")
         except Exception as exc:
             # fall through to a non-OSError exception
             handle.respond_error(

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -420,6 +420,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in view-project: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -220,6 +220,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in view-bank: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -355,6 +355,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in view-queue: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -93,9 +93,9 @@ test_expect_success 'remove a queue' '
 	grep "Queue not found in queue_table" deleted_queue.out
 '
 
-test_expect_success 'trying to view a bank that does not exist in the DB should return an error message' '
-	flux account view-bank foo > bad_bank.out &&
-	grep "Bank not found in bank_table" bad_bank.out
+test_expect_success 'trying to view a bank that does not exist in the DB should raise a ValueError' '
+	test_must_fail flux account view-bank foo > bank_nonexistent.out 2>&1 &&
+	grep "Bank foo not found in bank_table" bank_nonexistent.out
 '
 
 test_expect_success 'viewing the root bank with no optional args should show just the bank info' '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -89,8 +89,8 @@ test_expect_success 'edit a queue priority' '
 
 test_expect_success 'remove a queue' '
 	flux account delete-queue special &&
-	flux account view-queue special > deleted_queue.out &&
-	grep "Queue not found in queue_table" deleted_queue.out
+	test_must_fail flux account view-queue special > deleted_queue.out 2>&1 &&
+	grep "Queue special not found in queue_table" deleted_queue.out
 '
 
 test_expect_success 'trying to view a bank that does not exist in the DB should raise a ValueError' '
@@ -173,10 +173,9 @@ test_expect_success 'reset a queue limit' '
 	grep "queue_1" | grep "1" | grep "1" | grep "120" | grep "0" reset_limit.out
 '
 
-test_expect_success 'remove a queue from the queue_table' '
-	flux account delete-queue queue_2 &&
-	flux account view-queue queue_2 > deleted_queue.out &&
-	grep "Queue not found in queue_table" deleted_queue.out
+test_expect_success 'Trying to view a queue that does not exist should raise a ValueError' '
+	test_must_fail flux account view-queue foo > queue_nonexistent.out 2>&1 &&
+	grep "Queue foo not found in queue_table" queue_nonexistent.out
 '
 
 test_expect_success 'Add a user to two different banks' '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -108,9 +108,9 @@ test_expect_success 'viewing a bank with users in it should print all user info 
 	test_cmp ${EXPECTED_FILES}/A_bank.expected A_bank.test
 '
 
-test_expect_success 'trying to view a user who does not exist in the DB should return an error message' '
-	flux account view-user user9999 > bad_user.out &&
-	grep "User not found in association_table" bad_user.out
+test_expect_success 'trying to view a user who does not exist in the DB should raise a ValueError' '
+	test_must_fail flux account view-user user9999 > user_nonexistent.out 2>&1 &&
+	grep "User user9999 not found in association_table" user_nonexistent.out
 '
 
 test_expect_success 'trying to view a user that does exist in the DB should return some information' '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -229,15 +229,15 @@ test_expect_success 'editing a user project list with a non-existing project sho
 
 test_expect_success 'remove a project from the project_table that is still referenced by at least one user' '
 	flux account delete-project project_1 > warning_message.out &&
-	flux account view-project project_1 > deleted_project.out &&
+	test_must_fail flux account view-project project_1 > deleted_project.out 2>&1 &&
 	grep "WARNING: user(s) in the assocation_table still reference this project." warning_message.out &&
-	grep "Project not found in project_table" deleted_project.out
+	grep "Project project_1 not found in project_table" deleted_project.out
 '
 
 test_expect_success 'remove a project that is not referenced by any users' '
 	flux account delete-project project_4 &&
-	flux account view-project project_4 > deleted_project_2.out &&
-	grep "Project not found in project_table" deleted_project_2.out
+	test_must_fail flux account view-project project_4 > deleted_project_2.out 2>&1 &&
+	grep "Project project_4 not found in project_table" deleted_project_2.out
 '
 
 test_expect_success 'add a user to the accounting DB without specifying any projects' '


### PR DESCRIPTION
#### Background

As mentioned in #309 and #310, the `view-*` commands for flux-accounting still "succeed" even when the item being searched cannot be found in the flux-accounting DB. It's current behavior is just to return a string saying "Item not found in *_table." This behavior should be changed to instead raise an exception.

---

This PR changes the functions called by the various `view-*` commands to instead raise a `ValueError` when an item cannot be found in the flux-accounting database. The error is caught by the flux-accounting service and a message is sent saying, for example:

```console
$ flux account view-user foo
error in view-user: User not found in association_table
```

The respective unit and sharness tests are also slightly changed to account for this new raised exception when a user cannot be found, i.e instead of just checking for string output, checking for a raised `ValueError` in the unit tests and checking that the failed `view-*` commands _do_ fail when an item cannot be found.

Fixes #309
Fixes #310