### PR TITLE
view-bank: re-add `-t` option to command

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -212,6 +212,7 @@ class AccountingService:
             val = b.view_bank(
                 self.conn,
                 msg.payload["bank"],
+                msg.payload["tree"],
                 msg.payload["users"],
             )
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -268,6 +268,14 @@ def add_view_bank_arg(subparsers):
         metavar="BANK",
     )
     subparser_view_bank.add_argument(
+        "-t",
+        "--tree",
+        action="store_const",
+        const=True,
+        help="list all sub banks in a tree format with specified bank as root of tree",
+        metavar="TREE",
+    )
+    subparser_view_bank.add_argument(
         "-u",
         "--users",
         action="store_const",
@@ -577,6 +585,7 @@ def select_accounting_function(args, output_file, parser):
         data = {
             "path": args.path,
             "bank": args.bank,
+            "tree": args.tree,
             "users": args.users,
         }
         return_val = flux.Flux().rpc("accounting.view_bank", data).get()

--- a/t/expected/flux_account/D_bank.expected
+++ b/t/expected/flux_account/D_bank.expected
@@ -1,6 +1,7 @@
-bank_id         bank            active          parent_bank     shares          
-5               D               1               root            1               
+bank_id        bank           active         parent_bank    shares         
+5              D              1              root           1              
 
 D
  E
  F
+

--- a/t/expected/flux_account/full_hierarchy.expected
+++ b/t/expected/flux_account/full_hierarchy.expected
@@ -1,5 +1,5 @@
-bank_id         bank            active          parent_bank     shares          
-1               root            1                               1               
+bank_id        bank           active         parent_bank    shares         
+1              root           1                             1              
 
 root
  A
@@ -12,3 +12,4 @@ root
  D
   E
   F
+

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -103,9 +103,19 @@ test_expect_success 'viewing the root bank with no optional args should show jus
 	test_cmp ${EXPECTED_FILES}/root_bank.expected root_bank.test
 '
 
+test_expect_success 'viewing the root bank with -t should show the entire hierarchy' '
+	flux account -p ${DB_PATH} view-bank root -t > full_hierarchy.test &&
+	test_cmp ${EXPECTED_FILES}/full_hierarchy.expected full_hierarchy.test
+'
+
 test_expect_success 'viewing a bank with users in it should print all user info under that bank as well' '
 	flux account view-bank A -u > A_bank.test &&
 	test_cmp ${EXPECTED_FILES}/A_bank.expected A_bank.test
+'
+
+test_expect_success 'viewing a bank with sub banks should return a smaller hierarchy tree' '
+	flux account -p ${DB_PATH} view-bank D -t > D_bank.test &&
+	test_cmp ${EXPECTED_FILES}/D_bank.expected D_bank.test
 '
 
 test_expect_success 'trying to view a user who does not exist in the DB should raise a ValueError' '


### PR DESCRIPTION
As reported in #321, the `-t` option no longer exists in flux-accounting. That's because it was removed in #307, but is still used in scripts, so it needs to be re-added.

---

This PR re-adds the `-t` option to the `view-bank` command, which returns a hierarchy tree containing all sub banks and users under the bank passed into the `view-bank` command. The tests that checked for expected output of the `view-bank` command are also re-added to `t1007-flux-account.t`, slightly adjusted in format because of the new way the Python bindings return information (instead of directly printing to `STDOUT`), but still contain the same information.

Fixes #321