### PR TITLE
NEWS: add release notes for `v0.22.1`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+flux-accounting version 0.22.1 - 2023-03-10
+-------------------------------------------
+
+#### Fixes
+
+* `edit-user`: make "userid" an editable field (#319)
+
+* `view-*` commands: raise `ValueError` when item cannot be found in
+flux-accounting DB (#320)
+
+* `view-bank`: re-add `-t` option to command (#322)
+
 flux-accounting version 0.22.0 - 2023-03-03
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.22.1`, which includes a number of fixes brought on by recent testing of `v0.22.0`. Once this lands, I'll create a new annotated tag with the following command:

```
git tag -a v0.22.1 -m "Tag v0.22.1" && git push upstream v0.22.1
```