### PR TITLE
NEWS: add release notes for v0.22.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+flux-accounting version 0.22.2 - 2023-03-14
+-------------------------------------------
+
+#### Fixes
+
+* plugin: rework increment/decrement of running and active job counts for
+associations (#325)
+
 flux-accounting version 0.22.1 - 2023-03-10
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.22.2`, which includes fixes for issues reported in #262. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.22.2 -m "Tag v0.22.2" && git push upstream v0.22.2
```