### PR TITLE
`user-*` commands: change error handling to raise error to caller

### DIFF
--- a/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
@@ -105,8 +105,8 @@ class TestAccountingCLI(unittest.TestCase):
 
     # editing a user's project list with a bad project name should raise a ValueError
     def test_07_edit_projects_list_bad_name(self):
-        u.edit_user(acct_conn, username="user5002", bank="A", projects="foo")
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            u.edit_user(acct_conn, username="user5002", bank="A", projects="foo")
 
     # trying to view a project that does not exist should raise a ValueError
     def test_08_view_project_nonexistent(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -58,24 +58,23 @@ class TestAccountingCLI(unittest.TestCase):
     # adding a user with the same primary key (username, bank) should
     # return an IntegrityError
     def test_02_add_duplicate_primary_key(self):
-        u.add_user(
-            acct_conn,
-            username="fluxuser",
-            uid="1234",
-            bank="acct",
-            shares="10",
-            queues="",
-        )
-        u.add_user(
-            acct_conn,
-            username="fluxuser",
-            uid="1234",
-            bank="acct",
-            shares="10",
-            queues="",
-        )
-
-        self.assertRaises(sqlite3.IntegrityError)
+        with self.assertRaises(sqlite3.IntegrityError):
+            u.add_user(
+                acct_conn,
+                username="fluxuser",
+                uid="1234",
+                bank="acct",
+                shares="10",
+                queues="",
+            )
+            u.add_user(
+                acct_conn,
+                username="fluxuser",
+                uid="1234",
+                bank="acct",
+                shares="10",
+                queues="",
+            )
 
     # add a user with the same username but a different bank
     def test_03_add_duplicate_user(self):
@@ -242,9 +241,8 @@ class TestAccountingCLI(unittest.TestCase):
 
     # adding a user to a nonexistent bank should raise a ValueError
     def test_13_add_user_to_nonexistent_bank(self):
-        u.add_user(acct_conn, username="test_user4", bank="foo")
-
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            u.add_user(acct_conn, username="test_user4", bank="foo")
 
     # edit a user's userid
     def test_14_edit_user_userid(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_user_subcommands.py
@@ -256,6 +256,16 @@ class TestAccountingCLI(unittest.TestCase):
         cur.execute("SELECT userid FROM association_table WHERE username='test_user5'")
         self.assertEqual(cur.fetchone()[0], 12345)
 
+    # adding a user with a nonexistent queue should raise a ValueError
+    def test_15_add_user_with_nonexistent_queue(self):
+        with self.assertRaises(ValueError):
+            u.add_user(acct_conn, username="test_user4", bank="A", queues="foo")
+
+    # adding a user with a nonexistent project should raise a ValueError
+    def test_15_add_user_with_nonexistent_project(self):
+        with self.assertRaises(ValueError):
+            u.add_user(acct_conn, username="test_user4", bank="A", projects="foo")
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -135,6 +135,8 @@ class AccountingService:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
         except ValueError as val_err:
             handle.respond_error(msg, 0, f"error in view-user: {val_err}")
+        except sqlite3.OperationalError as sql_err:
+            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
         except Exception as exc:
             # fall through to a non-OSError exception
             handle.respond_error(
@@ -161,6 +163,10 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in add_user: {val_err}")
+        except sqlite3.IntegrityError as integ_err:
+            handle.respond_error(msg, 0, f"error in add_user: {integ_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -202,6 +208,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in edit_user: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -59,14 +59,14 @@ test_expect_success 'add a queue to an existing user account' '
 	flux account edit-user user5011 --queue="expedite"
 '
 
-test_expect_success 'trying to add a non-existent queue to a user account should return an error' '
-	flux account edit-user user5011 --queue="foo" > bad_queue.out &&
-	grep "Queue specified does not exist in queue_table" bad_queue.out
+test_expect_success 'trying to add a non-existent queue to a user account should raise a ValueError' '
+	test_must_fail flux account edit-user user5011 --queue="foo" > bad_queue.out 2>&1 &&
+	grep "Queue foo does not exist in queue_table" bad_queue.out
 '
 
 test_expect_success 'trying to add a user with a non-existent queue should also return an error' '
-	flux account add-user --username=user5015 --userid=5015 --bank=A --queue="foo" > bad_queue2.out &&
-	grep "Queue specified does not exist in queue_table" bad_queue2.out
+	test_must_fail flux account add-user --username=user5015 --bank=A --queue="foo" > bad_queue2.out 2>&1 &&
+	grep "Queue foo does not exist in queue_table" bad_queue2.out
 '
 
 test_expect_success 'add multiple queues to an existing user account' '
@@ -222,8 +222,8 @@ test_expect_success 'add a user with some specified projects to the association_
 '
 
 test_expect_success 'adding a user with a non-existing project should fail' '
-	flux account add-user --username=user5016 --bank=A --projects="project_1,foo" > bad_project.out &&
-	grep "Project \"foo\" does not exist in project_table" bad_project.out
+	test_must_fail flux account add-user --username=user5016 --bank=A --projects="project_1,foo" > bad_project.out 2>&1 &&
+	grep "Project foo does not exist in project_table" bad_project.out
 '
 
 test_expect_success 'successfully edit a projects list for a user' '
@@ -233,8 +233,8 @@ test_expect_success 'successfully edit a projects list for a user' '
 '
 
 test_expect_success 'editing a user project list with a non-existing project should fail' '
-	flux account edit-user user5015 --bank=A --projects="project_1,foo" > bad_project_2.out &&
-	grep "Project \"foo\" does not exist in project_table" bad_project_2.out
+	test_must_fail flux account edit-user user5015 --bank=A --projects="project_1,foo" > bad_project_2.out 2>&1 &&
+	grep "Project foo does not exist in project_table" bad_project_2.out
 '
 
 test_expect_success 'remove a project from the project_table that is still referenced by at least one user' '
@@ -286,8 +286,8 @@ test_expect_success 'edit the default project of a user' '
 '
 
 test_expect_success 'trying to add a user to a nonexistent bank should raise a ValueError' '
-	flux account add-user --username=user5019 --bank=foo > nonexistent_bank.out &&
-	grep "Bank \"foo\" does not exist in bank_table" nonexistent_bank.out
+	test_must_fail flux account add-user --username=user5019 --bank=foo > nonexistent_bank.out 2>&1 &&
+	grep "Bank foo does not exist in bank_table" nonexistent_bank.out
 '
 
 test_expect_success 'remove flux-accounting DB' '

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -43,6 +43,11 @@ test_expect_success 'add some queues to the DB' '
 	flux account add-queue special --priority=99999
 '
 
+test_expect_success 'trying to add an association that already exists should raise an IntegrityError' '
+	test_must_fail flux account add-user --username=user5011 --userid=5011 --bank=A > already_exists.out 2>&1 &&
+	grep "association user5011,A already active in association_table" already_exists.out
+'
+
 test_expect_success 'view some user information' '
 	flux account view-user user5011 > user_info.out &&
 	grep "user5011" | grep "5011" | grep "A" user_info.out


### PR DESCRIPTION
#### Background

The functions called by all of the `user-*` commands handle any exceptions raised during execution and just return a string containing the error message. This behavior should be changed to be more Pythonic and raise errors to the caller of the function.

As noted in #313, this behavior currently exists in all of the Python bindings, but instead of creating one large PR that changes the behavior for all of the bindings at once, it might be a little cleaner to post subsequent, smaller PRs that change the bindings one file at a time. This one starts with `user_subcommands.py`.

---

This PR changes the behavior of a number of the functions in `user_subcommands.py` to raise any error to the caller of the function with a clear message explaining what the error is. For `sqlite3.OperationalError`, a new comment is added to provide more context on what the error means and add a link to official docs containing more information about `OperationalError`.

New exception handlers are added to the flux-accounting service to handle a raised error and print out a formatted message describing the error that occurred. 

The unit/sharness tests for the `user-*` commands are also adjusted to account for the new behavior of the commands that raise an exception on certain errors, and a couple new unit and sharness tests are also added to further check for expected raised errors.