### PR TITLE
`bank-*` commands: change error handling to raise error to caller

### DIFF
--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -41,20 +41,19 @@ class TestAccountingCLI(unittest.TestCase):
 
     # check for an IntegrityError when trying to add a duplicate bank
     def test_02_add_dup_bank(self):
-        b.add_bank(acct_conn, bank="root", shares=100)
-        self.assertRaises(sqlite3.IntegrityError)
+        with self.assertRaises(sqlite3.IntegrityError):
+            b.add_bank(acct_conn, bank="root", shares=100)
 
     # trying to add a sub account with an invalid parent bank
     # name should result in a ValueError
     def test_03_add_with_invalid_parent_bank(self):
-        b.add_bank(
-            acct_conn,
-            bank="bad_subaccount",
-            parent_bank="bad_parentaccount",
-            shares=1,
-        )
-
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            b.add_bank(
+                acct_conn,
+                bank="bad_subaccount",
+                parent_bank="bad_parentaccount",
+                shares=1,
+            )
 
     # add a couple sub accounts whose parent is 'root'
     def test_04_add_sub_banks(self):
@@ -129,17 +128,15 @@ class TestAccountingCLI(unittest.TestCase):
     # trying to edit a bank's parent bank to a bank that does not
     # exist should raise a ValueError
     def test_09_edit_parent_bank_failure(self):
-        b.edit_bank(acct_conn, bank="C", parent_bank="foo")
-
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            b.edit_bank(acct_conn, bank="C", parent_bank="foo")
 
     # trying to edit a bank's shares <= 0 should raise
     # a ValueError
     def test_10_edit_bank_value_fail(self):
-        b.add_bank(acct_conn, bank="bad_bank", shares=10)
-        b.edit_bank(acct_conn, bank="bad_bank", shares=-1)
-
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            b.add_bank(acct_conn, bank="bad_bank", shares=10)
+            b.edit_bank(acct_conn, bank="bad_bank", shares=-1)
 
     # trying to view a bank that does not exist should raise a ValueError
     def test_11_view_bank_nonexistent(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_bank_subcommands.py
@@ -143,6 +143,21 @@ class TestAccountingCLI(unittest.TestCase):
         with self.assertRaises(ValueError):
             b.view_bank(acct_conn, bank="foo")
 
+    # try to add a bank that is currently disabled and make sure that it
+    # gets reactivated
+    def test_12_reactivate_bank(self):
+        # check that bank is disabled
+        cur.execute("SELECT active FROM bank_table WHERE bank='G'")
+        rows = cur.fetchall()
+        self.assertEqual(rows[0][0], 0)
+
+        # re-add bank
+        b.add_bank(acct_conn, bank="G", parent_bank="C", shares=1)
+
+        cur.execute("SELECT active FROM bank_table WHERE bank='G'")
+        rows = cur.fetchall()
+        self.assertEqual(rows[0][0], 1)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -231,6 +231,8 @@ class AccountingService:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
         except ValueError as val_err:
             handle.respond_error(msg, 0, f"error in view-bank: {val_err}")
+        except sqlite3.OperationalError as sql_err:
+            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -250,6 +252,12 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in add_bank: {val_err}")
+        except sqlite3.IntegrityError as integ_err:
+            handle.respond_error(msg, 0, f"error in add_bank: {integ_err}")
+        except sqlite3.OperationalError as sql_err:
+            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -264,6 +272,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except sqlite3.OperationalError as sql_err:
+            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -283,6 +293,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in edit_bank: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -100,7 +100,7 @@ test_expect_success 'remove a queue' '
 
 test_expect_success 'trying to view a bank that does not exist in the DB should raise a ValueError' '
 	test_must_fail flux account view-bank foo > bank_nonexistent.out 2>&1 &&
-	grep "Bank foo not found in bank_table" bank_nonexistent.out
+	grep "bank foo not found in bank_table" bank_nonexistent.out
 '
 
 test_expect_success 'viewing the root bank with no optional args should show just the bank info' '
@@ -144,8 +144,8 @@ test_expect_success 'edit a field in a bank account' '
 '
 
 test_expect_success 'try to edit a field in a bank account with a bad value' '
-	flux account edit-bank C --shares=-1000 > bad_edited_value.out &&
-	grep "New shares amount must be >= 0" bad_edited_value.out
+	test_must_fail flux account edit-bank C --shares=-1000 > bad_edited_value.out 2>&1 &&
+	grep "new shares amount must be >= 0" bad_edited_value.out
 '
 
 test_expect_success 'remove a bank (and any corresponding users that belong to that bank)' '

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -119,7 +119,7 @@ for db in ${SHARNESS_TEST_SRCDIR}/expected/test_dbs/*; do
 		test_expect_success 'start flux-accounting service' \
 			"flux account-service -p $tmp_db -t"
 		test_expect_success 'add a bank: '$(basename $db) \
-			"flux account add-bank root 1"
+			"flux account add-bank --parent-bank=root G 1"
 		test_expect_success 'add a user: '$(basename $db) \
 			"flux account add-user --username=fluxuser --bank=root"
 		test_expect_success 'check validity of DB: '$(basename $db) \


### PR DESCRIPTION
This PR continues the work brought on by #327 and changes the behavior of a number of the functions in `bank_subcommands.py` to raise any error to the caller of the function with a clear message explaining what the error is.

New exception handlers are added to the flux-accounting service to handle a raised error and print out a formatted message describing the error that occurred. 

The unit/sharness tests for the `bank-*` commands are also adjusted to account for the new behavior of the commands that raise an exception on certain errors, and a couple new unit and sharness tests are also added to further check for expected raised errors.