### PR TITLE
`*-queue`/`*-project` commands: change error handling to raise error to caller

### DIFF
--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -21,7 +21,7 @@ def view_queue(conn, queue):
         headers = [description[0] for description in cur.description]
         queue_str = ""
         if not rows:
-            raise ValueError(f"Queue {queue} not found in queue_table")
+            raise ValueError(f"queue {queue} not found in queue_table")
 
         # print column names of queue_table
         for header in headers:
@@ -33,8 +33,8 @@ def view_queue(conn, queue):
             queue_str += "\n"
 
         return queue_str
-    except sqlite3.OperationalError as e_database_error:
-        return e_database_error
+    except sqlite3.OperationalError as exc:
+        raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
 
 
 def add_queue(conn, queue, min_nodes=1, max_nodes=1, max_time=60, priority=0):
@@ -63,8 +63,8 @@ def add_queue(conn, queue, min_nodes=1, max_nodes=1, max_time=60, priority=0):
 
         return 0
     # make sure entry is unique
-    except sqlite3.IntegrityError as integrity_error:
-        return integrity_error
+    except sqlite3.IntegrityError:
+        raise sqlite3.IntegrityError(f"queue {queue} already exists in queue_table")
 
 
 def delete_queue(conn, queue):
@@ -97,10 +97,7 @@ def edit_queue(
         if params[field] is not None:
             # check that the passed in value is truly an integer
             if not isinstance(params[field], int):
-                try:
-                    raise ValueError("passed in value must be an integer")
-                except ValueError as val_err:
-                    return f"error editing field for queue: {val_err}"
+                raise ValueError("passed in value must be an integer")
 
             update_stmt = "UPDATE queue_table SET " + field
 

--- a/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_project_subcommands.py
@@ -41,8 +41,8 @@ class TestAccountingCLI(unittest.TestCase):
     # let's make sure if we try to add it a second time,
     # it fails gracefully
     def test_02_add_dup_project(self):
-        p.add_project(acct_conn, project="project_1")
-        self.assertRaises(sqlite3.IntegrityError)
+        with self.assertRaises(sqlite3.IntegrityError):
+            p.add_project(acct_conn, project="project_1")
 
     # remove a project currently in the project_table
     def test_03_delete_project(self):

--- a/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_queue_subcommands.py
@@ -39,8 +39,8 @@ class TestAccountingCLI(unittest.TestCase):
     # let's make sure if we try to add it a second time,
     # it fails gracefully
     def test_02_add_dup_queue(self):
-        q.add_queue(acct_conn, queue="queue_1")
-        self.assertRaises(sqlite3.IntegrityError)
+        with self.assertRaises(sqlite3.IntegrityError):
+            q.add_queue(acct_conn, queue="queue_1")
 
     # edit a value for a queue in the queue_table
     def test_03_edit_queue_successfully(self):
@@ -64,9 +64,8 @@ class TestAccountingCLI(unittest.TestCase):
 
     # edit a value with a bad type for a queue in the queue_table
     def test_05_edit_queue_bad_type(self):
-        q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job="foo")
-
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            q.edit_queue(acct_conn, queue="queue_1", max_nodes_per_job="foo")
 
     # reset a value for a queue in the queue_table
     def test_06_reset_queue_limit(self):

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -272,7 +272,7 @@ def add_user(
         try:
             projects = validate_project(conn, projects)
         except ValueError as bad_project:
-            raise ValueError(f"Project {bad_project} does not exist in project_table")
+            raise ValueError(f"project {bad_project} does not exist in project_table")
 
     # determine default_project for user; if no other projects
     # were specified, use '*' as the default. If a project was
@@ -394,7 +394,7 @@ def edit_user(
                     params[field] = validate_project(conn, params[field])
                 except ValueError as bad_project:
                     raise ValueError(
-                        f"Project {bad_project} does not exist in project_table"
+                        f"project {bad_project} does not exist in project_table"
                     )
 
             update_stmt = "UPDATE association_table SET " + field

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -263,7 +263,7 @@ def add_user(
         try:
             validate_queue(conn, queues)
         except ValueError as bad_queue:
-            raise ValueError(f"Queue {bad_queue} does not exist in queue_table")
+            raise ValueError(f"queue {bad_queue} does not exist in queue_table")
 
     # validate the project(s) specified if any were passed in;
     # add default project name ('*') to project(s) specified if
@@ -388,7 +388,7 @@ def edit_user(
                 try:
                     validate_queue(conn, params[field])
                 except ValueError as bad_queue:
-                    raise ValueError(f"Queue {bad_queue} does not exist in queue_table")
+                    raise ValueError(f"queue {bad_queue} does not exist in queue_table")
             if field == "projects":
                 try:
                     params[field] = validate_project(conn, params[field])

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -419,6 +419,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except sqlite3.IntegrityError as integ_err:
+            handle.respond_error(msg, 0, f"error in add_project: {integ_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -449,6 +451,8 @@ class AccountingService:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
         except ValueError as val_err:
             handle.respond_error(msg, 0, f"error in view-project: {val_err}")
+        except sqlite3.OperationalError as sql_err:
+            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -341,6 +341,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except sqlite3.IntegrityError as integ_err:
+            handle.respond_error(msg, 0, f"error in add_queue: {integ_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -378,6 +380,8 @@ class AccountingService:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
         except ValueError as val_err:
             handle.respond_error(msg, 0, f"error in view-queue: {val_err}")
+        except sqlite3.OperationalError as sql_err:
+            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -392,6 +396,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as val_err:
+            handle.respond_error(msg, 0, f"error in edit-queue: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -66,12 +66,12 @@ test_expect_success 'add a queue to an existing user account' '
 
 test_expect_success 'trying to add a non-existent queue to a user account should raise a ValueError' '
 	test_must_fail flux account edit-user user5011 --queue="foo" > bad_queue.out 2>&1 &&
-	grep "Queue foo does not exist in queue_table" bad_queue.out
+	grep "queue foo does not exist in queue_table" bad_queue.out
 '
 
 test_expect_success 'trying to add a user with a non-existent queue should also return an error' '
 	test_must_fail flux account add-user --username=user5015 --bank=A --queue="foo" > bad_queue2.out 2>&1 &&
-	grep "Queue foo does not exist in queue_table" bad_queue2.out
+	grep "queue foo does not exist in queue_table" bad_queue2.out
 '
 
 test_expect_success 'add multiple queues to an existing user account' '
@@ -95,7 +95,7 @@ test_expect_success 'edit a queue priority' '
 test_expect_success 'remove a queue' '
 	flux account delete-queue special &&
 	test_must_fail flux account view-queue special > deleted_queue.out 2>&1 &&
-	grep "Queue special not found in queue_table" deleted_queue.out
+	grep "queue special not found in queue_table" deleted_queue.out
 '
 
 test_expect_success 'trying to view a bank that does not exist in the DB should raise a ValueError' '
@@ -169,7 +169,9 @@ test_expect_success 'add a queue with no optional args to the queue_table' '
 '
 
 test_expect_success 'add another queue with some optional args' '
-	flux account add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120
+	flux account add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120 &&
+	flux account view-queue queue_2 > new_queue2.out &&
+	grep "queue_1" | grep "1" | grep "10" | grep "120" new_queue2.out
 '
 
 test_expect_success 'edit some queue information' '
@@ -179,7 +181,9 @@ test_expect_success 'edit some queue information' '
 '
 
 test_expect_success 'edit multiple columns for one queue' '
-	flux account edit-queue queue_1 --min-nodes-per-job 1 --max-nodes-per-job 128 --max-time-per-job 120
+	flux account edit-queue queue_1 --min-nodes-per-job 1 --max-nodes-per-job 128 --max-time-per-job 120 &&
+	flux account view-queue queue_1 > edited_queue_multiple.out &&
+	grep "queue_1" | grep "1" | grep "128" | grep "120" edited_queue_multiple.out
 '
 
 test_expect_success 'reset a queue limit' '
@@ -188,9 +192,9 @@ test_expect_success 'reset a queue limit' '
 	grep "queue_1" | grep "1" | grep "1" | grep "120" | grep "0" reset_limit.out
 '
 
-test_expect_success 'Trying to view a queue that does not exist should raise a ValueError' '
+test_expect_success 'trying to view a queue that does not exist should raise a ValueError' '
 	test_must_fail flux account view-queue foo > queue_nonexistent.out 2>&1 &&
-	grep "Queue foo not found in queue_table" queue_nonexistent.out
+	grep "queue foo not found in queue_table" queue_nonexistent.out
 '
 
 test_expect_success 'Add a user to two different banks' '
@@ -228,7 +232,7 @@ test_expect_success 'add a user with some specified projects to the association_
 
 test_expect_success 'adding a user with a non-existing project should fail' '
 	test_must_fail flux account add-user --username=user5016 --bank=A --projects="project_1,foo" > bad_project.out 2>&1 &&
-	grep "Project foo does not exist in project_table" bad_project.out
+	grep "project foo does not exist in project_table" bad_project.out
 '
 
 test_expect_success 'successfully edit a projects list for a user' '
@@ -239,20 +243,20 @@ test_expect_success 'successfully edit a projects list for a user' '
 
 test_expect_success 'editing a user project list with a non-existing project should fail' '
 	test_must_fail flux account edit-user user5015 --bank=A --projects="project_1,foo" > bad_project_2.out 2>&1 &&
-	grep "Project foo does not exist in project_table" bad_project_2.out
+	grep "project foo does not exist in project_table" bad_project_2.out
 '
 
 test_expect_success 'remove a project from the project_table that is still referenced by at least one user' '
 	flux account delete-project project_1 > warning_message.out &&
 	test_must_fail flux account view-project project_1 > deleted_project.out 2>&1 &&
 	grep "WARNING: user(s) in the assocation_table still reference this project." warning_message.out &&
-	grep "Project project_1 not found in project_table" deleted_project.out
+	grep "project project_1 not found in project_table" deleted_project.out
 '
 
 test_expect_success 'remove a project that is not referenced by any users' '
 	flux account delete-project project_4 &&
 	test_must_fail flux account view-project project_4 > deleted_project_2.out 2>&1 &&
-	grep "Project project_4 not found in project_table" deleted_project_2.out
+	grep "project project_4 not found in project_table" deleted_project_2.out
 '
 
 test_expect_success 'add a user to the accounting DB without specifying any projects' '


### PR DESCRIPTION
This PR completes the work brought on by https://github.com/flux-framework/flux-accounting/pull/327 and changes the behavior of a number of the functions in `queue_subcommands.py` and `project_subcommands.py` to raise any error to the caller of the function with a clear message explaining what the error is.

New exception handlers are added to the flux-accounting service to handle a raised error and print out a formatted message describing the error that occurred.

The unit/sharness tests for the `queue-*` and `*-project` commands are also adjusted to account for the new behavior of the commands that raise an exception on certain errors, and a couple new unit and sharness tests are also added to further check for expected raised errors.