### PR TITLE
flux-accounting service: make certain commands accessible to all users

### DIFF
--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -299,6 +299,114 @@ test_expect_success 'trying to add a user to a nonexistent bank should raise a V
 	grep "Bank foo does not exist in bank_table" nonexistent_bank.out
 '
 
+test_expect_success 'add-user should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account add-user --username=ohtani --bank=A > no_access_add-user.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_add-user.out
+	)
+'
+
+test_expect_success 'delete-user should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account delete-user ohtani A > no_access_delete-user.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_delete-user.out
+	)
+'
+
+test_expect_success 'edit-user should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account edit-user --max-active-jobs=100000 ohtani > no_access_edit-user.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_edit-user.out
+	)
+'
+
+test_expect_success 'add-bank should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account add-bank --parent-bank=root H 1 > no_access_add-bank.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_add-bank.out
+	)
+'
+
+test_expect_success 'delete-bank should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account delete-bank H > no_access_delete-bank.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_delete-bank.out
+	)
+'
+
+test_expect_success 'edit-bank should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account edit-bank H --shares=12345 > no_access_edit-bank.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_edit-bank.out
+	)
+'
+
+test_expect_success 'update-usage should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account update-usage path_to_db.db > no_access_update-usage.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_update-usage.out
+	)
+'
+
+test_expect_success 'add-queue should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account add-queue queue_6 > no_access_add-queue.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_add-queue.out
+	)
+'
+
+test_expect_success 'delete-queue should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account delete-queue queue_6 > no_access_delete-queue.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_delete-queue.out
+	)
+'
+
+test_expect_success 'edit-queue should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account edit-queue queue_6 --priority=12345 > no_access_edit-queue.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_edit-queue.out
+	)
+'
+
+test_expect_success 'add-project should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account add-project project_6 > no_access_add-project.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_add-project.out
+	)
+'
+
+test_expect_success 'delete-project should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account delete-project project_3 > no_access_delete-project.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_delete-project.out
+	)
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

All of the message handlers in the flux-accounting service are only available to the instance owner, but some of them should be open to all users. Commands that simply read from the flux-accounting DB, like `view-user`, `view-bank`, etc. should be able to be run by any user in on the machine, while others that write to the DB, like `add-user`, `add-bank`, should only be able to be run by a privileged group of administrators.

---

This PR breaks up the `endpoints` list into two smaller lists, one that is "general" and can be run by any user, and one that is "privileged" and is only available to the instance owner. Specifically, from the "general" list, the watchers set a rolemask to `FLUX_ROLE_USER` when creating the watcher.

A couple of tests are also added to `t1007-flux-account.t` that make sure that certain commands fail for a normal user but others succeed.