### PR TITLE
plugin: clear queues on flux-accounting DB update

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -476,6 +476,9 @@ static void rec_q_cb (flux_t *h,
     }
     num_data = json_array_size (data);
 
+    // clear queues map
+    queues.clear ();
+
     for (int i = 0; i < num_data; i++) {
         json_t *el = json_array_get(data, i);
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -436,6 +436,7 @@ static void rec_update_cb (flux_t *h,
         b->active = active;
 
         // split queues comma-delimited string and add it to b->queues vector
+        b->queues.clear ();
         split_string (queues, b);
 
         users_def_bank[uid] = def_bank;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -21,7 +21,8 @@ TESTSCRIPTS = \
 	t1017-update-db.t \
 	t1018-mf-priority-disable-entry.t \
 	t1019-mf-priority-info-fetch.t \
-	t1020-mf-priority-issue262.t
+	t1020-mf-priority-issue262.t \
+	t1021-mf-priority-issue332.t
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/t1021-mf-priority-issue332.t
+++ b/t/t1021-mf-priority-issue332.t
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+test_description='Test submitting jobs to queues after queue access is changed'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/plugin_state
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze --priority=200 &&
+	flux account add-queue silver --priority=300 &&
+	flux account add-queue gold   --priority=400
+'
+
+test_expect_success 'configure flux with those queues' '
+	cat >conf.d/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	[queues.gold]
+	EOT
+	flux config reload &&
+	flux queue stop --all
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user --username=user1001 --userid=1001 --bank=A --queues="bronze,silver,gold" &&
+	flux account view-user user1001
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job while specifying a queue' '
+	flux python ${SUBMIT_AS} 1001 -n1 --queue=bronze hostname
+'
+
+test_expect_success 'edit a user to no longer have access to any of the added queues' '
+	flux account edit-user user1001 --bank=A --queues=
+'
+
+test_expect_success 're-send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submitting a job while specifying a queue they no longer have access to should be rejected' '
+	test_must_fail flux python ${SUBMIT_AS} 1001 -n1 --queue=bronze hostname > no_queue_access.out 2>&1 &&
+	grep "Queue not valid for user: bronze" no_queue_access.out
+'
+
+test_expect_success 're-add the available queues to the user' '
+	flux account edit-user user1001 --bank=A --queues="bronze,silver,gold"
+'
+
+test_expect_success 're-send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a job while specifying a queue' '
+	flux python ${SUBMIT_AS} 1001 -n1 --queue=bronze hostname
+'
+
+test_expect_success 'delete the queues from the flux-accounting database and from the user' '
+	flux account delete-queue bronze &&
+	flux account delete-queue silver &&
+	flux account delete-queue gold &&
+	flux account edit-user user1001 --bank=A --queues=
+'
+
+test_expect_success 're-send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submitting a job should now skip the check for queue validation' '
+	flux python ${SUBMIT_AS} 1001 -n1 --queue=bronze hostname
+'
+
+test_expect_success 're-add those queues to the DB' '
+	flux account add-queue bronze --priority=200 &&
+	flux account add-queue silver --priority=300 &&
+	flux account add-queue gold   --priority=400
+'
+
+test_expect_success 're-send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submitting a job specifying a queue should now trigger queue validation' '
+	test_must_fail flux python ${SUBMIT_AS} 1001 -n1 --queue=bronze hostname > no_queue_access2.out 2>&1 &&
+	grep "Queue not valid for user: bronze" no_queue_access2.out
+'
+
+test_expect_success 'submitting a job to a nonexistent queue should be rejected' '
+	test_must_fail flux python ${SUBMIT_AS} 1001 -n1 --queue=foo hostname > no_such_queue.out 2>&1 &&
+	grep "flux-job: Invalid queue '\''foo'\'' specified" no_such_queue.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As reported in #332 and #333, there are a couple of issues with how the plugin handles unpacking queues on a flux-accounting update.

1) If a user who has been added to a queue via `flux account edit-user --queue=_queue_name user_name_` is removed from that queue with `flux account edit-user --queue= _user_name_`, their access to the queue persists after running an `account-priority-update`.
2) If a queue is deleted with `flux account delete-queue ...`, and then `flux account-priority-update` is run, users who were not given access to it continue to be unable to submit to it.

This is because both the `queues` field for a user entry in the plugin and the `queues` map itself are not cleared before an update, so if queues are removed for a user or if queues are removed in the `queues_table` in the flux-accounting DB, they still remain in the plugin's internal data.

---

This PR adds a small helper function to the `edit-user` command that allows a `queues` list to be cleared for user by just passing `--queues=` to the command.

It also adds `.clear ()` calls to both of the helper functions that unpack `queues` attributes for each user/bank entry in the plugin and the `queues` map before receiving the newest update via `flux account-priority-update`. This should ensure consistency with the database even when queues are removed.

A new sharness test is also added that reproduces the steps outlined in issues #332 and #333. It creates a number of queues and a user who has access to all of these queues. It clears the queues for the user, sends an update to the plugin, and ensures that a user can no longer submit jobs to those queues after an update. It then removes the queues from the flux-accounting database, sends an update to the plugin, and ensures that users can submit jobs without being prevented by the plugin. 