### PR TITLE
NEWS: add release notes for `v0.23.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+flux-accounting version 0.23.0 - 2023-04-04
+-------------------------------------------
+
+#### Fixes
+
+* bindings: raise error to caller (#327, #328, #329)
+
+* plugin: clear queues on flux-accounting DB update (#334)
+
 flux-accounting version 0.22.2 - 2023-03-14
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.23.0`. It includes the changes to error handling in the Python bindings and the bug fix for updated queue lists in the multi-factor priority plugin. Once this is merged, I'll create an annotated tag with the following command:

```
git tag -a v0.23.0 -m "Tag v0.23.0" && git push upstream v0.23.0
```