### PR TITLE
flux-accounting service: change `Requires` to `BindTo`

### DIFF
--- a/etc/flux-accounting.service.in
+++ b/etc/flux-accounting.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Flux accounting service
-Requires=flux.service
+BindTo=flux.service
 After=flux.service
 
 [Service]


### PR DESCRIPTION
#### Problem

Flux can be restarted by systemd because it is mentioned as a `Requires` by flux-accounting, which has `Restart=Always`. We don't want Flux to be auto-restarted when the admins don't expect it.

---

This PR changes `Requires=flux.service` to `BindTo=flux.service`. This should allow things to behave more as expected, i.e if Flux is shut down, then flux-accounting is also, and similarly when Flux is started, the flux-accounting service is started.

Fixes #337