### PR TITLE
NEWS: add release notes for `v0.23.1`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+flux-accounting version 0.23.1 - 2023-04-07
+-------------------------------------------
+
+#### Fixes
+
+* flux-accounting service: change Requires to BindTo (#338)
+
 flux-accounting version 0.23.0 - 2023-04-04
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.23.1`. It includes the bug fix to the flux-accounting systemd unit file to prevent Flux from being auto-restarted. Once this is merged, I'll create an annotated tag with the following command:

```
git tag -a v0.23.1 -m "Tag v0.23.1" && git push upstream v0.23.1
```