### PR TITLE
flux-accounting service: change `BindTo` to `BindsTo`

### DIFF
--- a/etc/flux-accounting.service.in
+++ b/etc/flux-accounting.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Flux accounting service
-BindTo=flux.service
+BindsTo=flux.service
 After=flux.service
 
 [Service]


### PR DESCRIPTION
#### Problem

The flux-accounting systemd unit file uses `BindTo` instead of `BindsTo`. @jameshcorbett  pointed out that `BindsTo` is the correct variable to use according to: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#BindsTo=

---

This PR changes `BindTo` to `BindsTo` in the flux-accounting systemd unit file. Note that the flux-accounting service was still able to be started on fluke according to @grondo, so a new release doesn't seem to be necessary at the moment.