### PR TITLE
`view-user`: improve formatting of output of command

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -84,8 +84,21 @@ def set_default_project(projects):
     return "*"
 
 
-def get_user_rows(headers, rows):
+def get_user_rows(headers, rows, parseable):
     user_str = ""
+
+    if parseable is True:
+        # find length of longest column name
+        col_width = len(sorted(headers, key=len)[-1])
+
+        for header in headers:
+            user_str += header.ljust(col_width)
+        user_str += "\n"
+        for row in rows:
+            for col in list(row):
+                user_str += str(col).ljust(col_width)
+
+        return user_str
 
     for row in rows:
         # iterate through column names of association_table and
@@ -217,7 +230,7 @@ def clear_queues(conn, username, bank=None):
 #                   Subcommand Functions                      #
 #                                                             #
 ###############################################################
-def view_user(conn, user):
+def view_user(conn, user, parseable=False):
     cur = conn.cursor()
     try:
         # get the information pertaining to a user in the DB
@@ -227,7 +240,7 @@ def view_user(conn, user):
         if not rows:
             raise ValueError(f"User {user} not found in association_table")
 
-        user_str = get_user_rows(headers, rows)
+        user_str = get_user_rows(headers, rows, parseable)
 
         return user_str
     # this kind of exception is raised for errors related to the DB's operation,

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -12,6 +12,7 @@
 import sqlite3
 import time
 import pwd
+import json
 
 ###############################################################
 #                                                             #
@@ -84,7 +85,51 @@ def set_default_project(projects):
     return "*"
 
 
-def get_user_rows(headers, rows, parseable):
+def create_json_object(conn, user):
+    cur = conn.cursor()
+    main_headers = ["username", "userid", "default_bank"]
+    secondary_headers = [
+        "bank",
+        "active",
+        "shares",
+        "job_usage",
+        "fairshare",
+        "max_running_jobs",
+        "max_active_jobs",
+        "max_nodes",
+        "queues",
+        "projects",
+        "default_project",
+    ]
+
+    cur.execute(
+        """SELECT username, userid, default_bank
+        FROM association_table WHERE username=?""",
+        (user,),
+    )
+    rows = cur.fetchall()
+    user_info_dict = dict(zip(main_headers, list(rows)[0]))
+
+    cur.execute(
+        """SELECT bank, active, shares, job_usage, fairshare,
+        max_running_jobs, max_active_jobs, max_nodes,
+        queues, projects, default_project FROM association_table
+        WHERE username=?""",
+        (user,),
+    )
+    rows = cur.fetchall()
+
+    # store all information pertaining to each bank as a separate
+    # entry in a list
+    user_info_dict["banks"] = []
+    for row in rows:
+        user_info_dict["banks"].append(dict(zip(secondary_headers, list(row))))
+
+    user_info_json = json.dumps(user_info_dict, indent=4)
+    return user_info_json
+
+
+def get_user_rows(conn, user, headers, rows, parseable, json_fmt):
     user_str = ""
 
     if parseable is True:
@@ -97,6 +142,11 @@ def get_user_rows(headers, rows, parseable):
         for row in rows:
             for col in list(row):
                 user_str += str(col).ljust(col_width)
+
+        return user_str
+
+    if json_fmt is True:
+        user_str += create_json_object(conn, user)
 
         return user_str
 
@@ -230,7 +280,7 @@ def clear_queues(conn, username, bank=None):
 #                   Subcommand Functions                      #
 #                                                             #
 ###############################################################
-def view_user(conn, user, parseable=False):
+def view_user(conn, user, parseable=False, json_fmt=False):
     cur = conn.cursor()
     try:
         # get the information pertaining to a user in the DB
@@ -240,7 +290,7 @@ def view_user(conn, user, parseable=False):
         if not rows:
             raise ValueError(f"User {user} not found in association_table")
 
-        user_str = get_user_rows(headers, rows, parseable)
+        user_str = get_user_rows(conn, user, headers, rows, parseable, json_fmt)
 
         return user_str
     # this kind of exception is raised for errors related to the DB's operation,

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -85,16 +85,13 @@ def set_default_project(projects):
 
 
 def get_user_rows(headers, rows):
-    # find length of longest column name
-    col_width = len(sorted(headers, key=len)[-1])
     user_str = ""
 
-    for header in headers:
-        user_str += header.ljust(col_width)
-    user_str += "\n"
     for row in rows:
-        for col in list(row):
-            user_str += str(col).ljust(col_width)
+        # iterate through column names of association_table and
+        # print out its associated value
+        for key, value in zip(headers, list(row)):
+            user_str += key + ": " + str(value) + "\n"
         user_str += "\n"
 
     return user_str

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -138,7 +138,11 @@ class AccountingService:
     def view_user(self, handle, watcher, msg, arg):
         try:
             # call view-user function
-            val = u.view_user(self.conn, msg.payload["username"])
+            val = u.view_user(
+                self.conn,
+                msg.payload["username"],
+                msg.payload["parseable"],
+            )
 
             payload = {"view_user": val}
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -142,6 +142,7 @@ class AccountingService:
                 self.conn,
                 msg.payload["username"],
                 msg.payload["parseable"],
+                msg.payload["json"],
             )
 
             payload = {"view_user": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -46,6 +46,13 @@ def add_view_user_arg(subparsers):
         help="print all information of an association on one line",
         metavar="PARSEABLE",
     )
+    subparser_view_user.add_argument(
+        "--json",
+        action="store_const",
+        const=True,
+        help="print all information of an association in JSON format",
+        metavar="JSON",
+    )
 
 
 def add_add_user_arg(subparsers):
@@ -525,6 +532,7 @@ def select_accounting_function(args, output_file, parser):
             "path": args.path,
             "username": args.username,
             "parseable": args.parseable,
+            "json": args.json,
         }
         return_val = flux.Flux().rpc("accounting.view_user", data).get()
     elif args.func == "add_user":

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -39,6 +39,13 @@ def add_view_user_arg(subparsers):
     )
     subparser_view_user.set_defaults(func="view_user")
     subparser_view_user.add_argument("username", help="username", metavar=("USERNAME"))
+    subparser_view_user.add_argument(
+        "--parseable",
+        action="store_const",
+        const=True,
+        help="print all information of an association on one line",
+        metavar="PARSEABLE",
+    )
 
 
 def add_add_user_arg(subparsers):
@@ -517,6 +524,7 @@ def select_accounting_function(args, output_file, parser):
         data = {
             "path": args.path,
             "username": args.username,
+            "parseable": args.parseable,
         }
         return_val = flux.Flux().rpc("accounting.view_user", data).get()
     elif args.func == "add_user":

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -53,6 +53,11 @@ test_expect_success 'view some user information' '
 	grep "user5011" | grep "5011" | grep "A" user_info.out
 '
 
+test_expect_success 'view some user information with --parseable' '
+	flux account view-user --parseable user5011 > user_info_parseable.out &&
+	grep -w "user5011\|5011\|A" user_info_parseable.out
+'
+
 test_expect_success 'edit a userid for a user' '
 	flux account edit-user user5011 --userid=12345 &&
 	flux account view-user user5011 > edit_userid.out &&

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -58,6 +58,11 @@ test_expect_success 'view some user information with --parseable' '
 	grep -w "user5011\|5011\|A" user_info_parseable.out
 '
 
+test_expect_success 'view some user information with --json' '
+	flux account view-user --json user5014 > user_info_json.out &&
+	grep -w "\"username\": \"user5014\"\|\"userid\": 5014\|\"bank\": \"C\"" user_info_json.out
+'
+
 test_expect_success 'edit a userid for a user' '
 	flux account edit-user user5011 --userid=12345 &&
 	flux account view-user user5011 > edit_userid.out &&

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -50,7 +50,7 @@ test_expect_success 'trying to add an association that already exists should rai
 
 test_expect_success 'view some user information' '
 	flux account view-user user5011 > user_info.out &&
-	grep "user5011" | grep "5011" | grep "A" user_info.out
+	grep -w "username: user5011\|userid: 5011\|bank: A" user_info.out
 '
 
 test_expect_success 'view some user information with --parseable' '
@@ -66,7 +66,7 @@ test_expect_success 'view some user information with --json' '
 test_expect_success 'edit a userid for a user' '
 	flux account edit-user user5011 --userid=12345 &&
 	flux account view-user user5011 > edit_userid.out &&
-	grep "user5011" | grep "12345" | grep "A" edit_userid.out &&
+	grep -w "user5011\|12345\|A" edit_userid.out &&
 	flux account edit-user user5011 --userid=5011
 '
 
@@ -93,7 +93,7 @@ test_expect_success 'add multiple queues to an existing user account' '
 test_expect_success 'edit the max_active_jobs of an existing user' '
 	flux account edit-user user5011 --max-active-jobs 999 &&
 	flux account view-user user5011 > edited_shares.out &&
-	grep "user5011" | grep "5011" | grep "999" edited_shares.out
+	grep -w "user5011\|5011\|999" edited_shares.out
 '
 
 test_expect_success 'edit a queue priority' '
@@ -140,7 +140,7 @@ test_expect_success 'trying to view a user who does not exist in the DB should r
 
 test_expect_success 'trying to view a user that does exist in the DB should return some information' '
 	flux account view-user user5011 > good_user.out &&
-	grep "user5011" | grep "5011" | grep "A" good_user.out
+	grep -w "user5011\|5011\|A" good_user.out
 '
 
 test_expect_success 'edit a field in a user account' '
@@ -150,7 +150,7 @@ test_expect_success 'edit a field in a user account' '
 test_expect_success 'edit a field in a bank account' '
 	flux account edit-bank C --shares=50 &&
 	flux account view-bank C > edited_bank.out &&
-	grep "C" | grep "50" edited_bank.out
+	grep -w "C\|50" edited_bank.out
 '
 
 test_expect_success 'try to edit a field in a bank account with a bad value' '
@@ -175,31 +175,31 @@ test_expect_success 'remove a user account' '
 test_expect_success 'add a queue with no optional args to the queue_table' '
 	flux account add-queue queue_1
 	flux account view-queue queue_1 > new_queue.out &&
-	grep "queue_1" | grep "1" | grep "1" | grep "60" | grep "0" new_queue.out
+	grep -w "queue_1\|1\|1\|60\|0" new_queue.out
 '
 
 test_expect_success 'add another queue with some optional args' '
 	flux account add-queue queue_2 --min-nodes-per-job=1 --max-nodes-per-job=10 --max-time-per-job=120 &&
 	flux account view-queue queue_2 > new_queue2.out &&
-	grep "queue_1" | grep "1" | grep "10" | grep "120" new_queue2.out
+	grep -w "queue_1\|1\|10\|120" new_queue2.out
 '
 
 test_expect_success 'edit some queue information' '
 	flux account edit-queue queue_1 --max-nodes-per-job 100 &&
 	flux account view-queue queue_1 > edited_max_nodes.out &&
-	grep "queue_1" | grep "100" edited_max_nodes.out
+	grep -w "queue_1\|100" edited_max_nodes.out
 '
 
 test_expect_success 'edit multiple columns for one queue' '
 	flux account edit-queue queue_1 --min-nodes-per-job 1 --max-nodes-per-job 128 --max-time-per-job 120 &&
 	flux account view-queue queue_1 > edited_queue_multiple.out &&
-	grep "queue_1" | grep "1" | grep "128" | grep "120" edited_queue_multiple.out
+	grep -w "queue_1\|1\|128\|120" edited_queue_multiple.out
 '
 
 test_expect_success 'reset a queue limit' '
 	flux account edit-queue queue_1 --max-nodes-per-job -1 &&
 	flux account view-queue queue_1 > reset_limit.out &&
-	grep "queue_1" | grep "1" | grep "1" | grep "120" | grep "0" reset_limit.out
+	grep -w "queue_1\|1\|1\|120\|0" reset_limit.out
 '
 
 test_expect_success 'trying to view a queue that does not exist should raise a ValueError' '
@@ -219,7 +219,7 @@ test_expect_success 'Delete user default bank row' '
 test_expect_success 'Check that user default bank gets updated to other bank' '
 	flux account view-user user5015 > new_default_bank.out &&
 	cat new_default_bank.out &&
-	grep "user5015" | grep "F" | grep "F" new_default_bank.out
+	grep -w "username: user5015\|bank: F\|default_bank: F" new_default_bank.out
 '
 
 test_expect_success 'add some projects to the project_table' '
@@ -231,13 +231,13 @@ test_expect_success 'add some projects to the project_table' '
 
 test_expect_success 'view project information from the project_table' '
 	flux account view-project project_1 > project_1.out &&
-	grep "1" | grep "project_1" project_1.out
+	grep -w "1\|project_1" project_1.out
 '
 
 test_expect_success 'add a user with some specified projects to the association_table' '
 	flux account add-user --username=user5015 --bank=A --projects="project_1,project_3" &&
 	flux account view-user user5015 > user5015_info.out &&
-	grep "user5015" | grep "project_1,project_3,*" user5015_info.out
+	grep -w "username: user5015\|projects: project_1,project_3,*" user5015_info.out
 '
 
 test_expect_success 'adding a user with a non-existing project should fail' '
@@ -248,7 +248,7 @@ test_expect_success 'adding a user with a non-existing project should fail' '
 test_expect_success 'successfully edit a projects list for a user' '
 	flux account edit-user user5015 --bank=A --projects="project_1,project_2,project_3" &&
 	flux account view-user user5015 > user5015_edited_info.out &&
-	grep "user5015" | grep "project_1,project_2,project_3,*" user5015_edited_info.out
+	grep -w "username: user5015\|projects: project_1,project_2,project_3,*" user5015_edited_info.out
 '
 
 test_expect_success 'editing a user project list with a non-existing project should fail' '


### PR DESCRIPTION
#### Problem

Mentioned in #340, the output of the `view-user` command is quite ugly because of how many columns there are in the `association_table`. Often times the output wraps around the terminal which makes it hard to look at.

---

This PR changes the format of the output of `view-user` to print user information vertically instead of horizontally. This way the output of the command looks cleaner and easier to look at.

It also slightly changes the tests that look for output of this command to use `grep -w` instead of calling `grep` multiple times. Passing the `-w` flag allows `grep` to look for multiple strings in the output, which was the original intention of the tests.

@ryanday36 let me know if this new output of the `view-user` command looks okay to you, or if you had another format in mind, I'd be happy to adjust it.