### PR TITLE
`update-db`: fix statement when updating a table with no primary key

### DIFF
--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -129,7 +129,7 @@ def rename_tmp_table(old_cur, table):
 # in the old flux-accounting DB. It will look at the table schema for the table
 # that doesn't yet exist and create a "CREATE TABLE ..." statement to add to the
 # old flux-accounting DB
-def update_tables(old_conn, old_cur, new_cur):
+def update_tables(old_cur, new_cur):
     print("checking for new tables...")
 
     # get all tables from old database
@@ -181,7 +181,7 @@ def update_tables(old_conn, old_cur, new_cur):
 # If it does, it will create a new version of the table with any added or removed
 # columns from a newer version of flux-accounting, copy any and all existing rows
 # from the old table, and DROP the old table to be replaced with the new table
-def update_columns(old_conn, old_cur, new_cur):
+def update_columns(old_cur, new_cur):
     print("checking for new columns to add in tables...")
 
     # get all table names from the temporary new database
@@ -232,9 +232,9 @@ def update_db(path, new_db):
 
             new_cur = new_conn.cursor()
 
-            update_tables(old_conn, old_cur, new_cur)
+            update_tables(old_cur, new_cur)
 
-            update_columns(old_conn, old_cur, new_cur)
+            update_columns(old_cur, new_cur)
 
             # update user_version for DB
             old_cur.execute(

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -161,12 +161,16 @@ def update_tables(old_conn, old_cur, new_cur):
                 if default_value is not None:
                     add_stmt += "DEFAULT " + default_value + " "
                 if not_null == 1:
-                    add_stmt += "NOT NULL, "
+                    add_stmt += "NOT NULL"
+                if column != new_columns[-1]:
+                    add_stmt += ", "
 
             # look for primary key in new table to add
             for column in new_columns:
                 if column[5] == 1:
-                    add_stmt += "PRIMARY KEY (" + column[1] + "));"
+                    add_stmt += ", PRIMARY KEY (" + column[1] + ")"
+
+            add_stmt += ");"
 
             # add table to old DB
             old_cur.execute(add_stmt)


### PR DESCRIPTION
#### Problem

The `add_stmt` used to add tables to an old version of a flux-accounting DB breaks when a table does not have a primary key. The generated statement used to update the table ends in a comma with nothing else after it, which results in a `sqlite3.OperationalError`.

---

This PR changes the construction of the `add_stmt` to only add a comma if the column is not the last one in the table. It moves the outer parentheses and semi-colon to the very end of the `add_stmt` construction instead of inside the for-loop where a PRIMARY KEY is generated. It also includes some minor cleanup that removes some unused variables from a couple function definitions.