### PR TITLE
test: replace "flux mini" usage

### DIFF
--- a/t/scripts/submit_as.py
+++ b/t/scripts/submit_as.py
@@ -39,15 +39,14 @@ def main():
         if "urgency" in arg:
             submitcmd.append(arg)
 
-    minicmd = [
+    runcmd = [
         "flux",
-        "mini",
         "run",
         "--dry-run",
         "--setattr=system.exec.test.duration=0.1",
         *sys.argv[2:],
     ]
-    jobspec = run_process(minicmd)
+    jobspec = run_process(runcmd)
 
     signedJ = SecurityContext().sign_wrap_as(userid, jobspec, mech_type="none")
 

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -85,7 +85,7 @@ test_expect_success 'update plugin with sample test data' '
 '
 
 test_expect_success 'submit a job with default urgency' '
-	jobid=$(flux mini submit --setattr=system.bank=account3 -n1 hostname) &&
+	jobid=$(flux submit --setattr=system.bank=account3 -n1 hostname) &&
 	flux job wait-event -f json $jobid priority | jq '.context.priority' > job1.test &&
 	cat <<-EOF >job1.expected &&
 	45321
@@ -95,7 +95,7 @@ test_expect_success 'submit a job with default urgency' '
 '
 
 test_expect_success 'submit a job with custom urgency' '
-	jobid=$(flux mini submit --setattr=system.bank=account3 --urgency=15 -n1 hostname) &&
+	jobid=$(flux submit --setattr=system.bank=account3 --urgency=15 -n1 hostname) &&
 	flux job wait-event -f json $jobid priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	45320
@@ -105,7 +105,7 @@ test_expect_success 'submit a job with custom urgency' '
 '
 
 test_expect_success 'submit a job with urgency of 0' '
-	jobid=$(flux mini submit --setattr=system.bank=account3 --urgency=0 -n1 hostname) &&
+	jobid=$(flux submit --setattr=system.bank=account3 --urgency=0 -n1 hostname) &&
 	flux job wait-event -f json $jobid priority | jq '.context.priority' > job3.test &&
 	cat <<-EOF >job3.expected &&
 	0
@@ -115,7 +115,7 @@ test_expect_success 'submit a job with urgency of 0' '
 '
 
 test_expect_success 'submit a job with urgency of 31' '
-	jobid=$(flux mini submit --setattr=system.bank=account3 --urgency=31 -n1 hostname) &&
+	jobid=$(flux submit --setattr=system.bank=account3 --urgency=31 -n1 hostname) &&
 	flux job wait-event -f json $jobid priority | jq '.context.priority' > job4.test &&
 	cat <<-EOF >job4.expected &&
 	4294967295
@@ -125,7 +125,7 @@ test_expect_success 'submit a job with urgency of 31' '
 '
 
 test_expect_success 'submit a job with other bank' '
-	jobid=$(flux mini submit --setattr=system.bank=account2 -n1 hostname) &&
+	jobid=$(flux submit --setattr=system.bank=account2 -n1 hostname) &&
 	flux job wait-event -f json $jobid priority | jq '.context.priority' > job5.test &&
 	cat <<-EOF >job5.expected &&
 	11345
@@ -135,7 +135,7 @@ test_expect_success 'submit a job with other bank' '
 '
 
 test_expect_success 'submit a job using default bank' '
-	jobid=$(flux mini submit -n1 hostname) &&
+	jobid=$(flux submit -n1 hostname) &&
 	flux job wait-event -f json $jobid priority | jq '.context.priority' > job6.test &&
 	cat <<-EOF >job6.expected &&
 	45321
@@ -145,13 +145,13 @@ test_expect_success 'submit a job using default bank' '
 '
 
 test_expect_success 'submit a job using a bank the user does not belong to' '
-	test_must_fail flux mini submit --setattr=system.bank=account1 -n1 hostname > bad_bank.out 2>&1 &&
+	test_must_fail flux submit --setattr=system.bank=account1 -n1 hostname > bad_bank.out 2>&1 &&
 	test_debug "cat bad_bank.out" &&
 	grep "user does not belong to specified bank" bad_bank.out
 '
 
 test_expect_success 'reject job when invalid bank format is passed in' '
-	test_must_fail flux mini submit --setattr=system.bank=1 -n1 hostname > invalid_fmt.out 2>&1 &&
+	test_must_fail flux submit --setattr=system.bank=1 -n1 hostname > invalid_fmt.out 2>&1 &&
 	test_debug "cat invalid_fmt.out" &&
 	grep "unable to unpack bank arg" invalid_fmt.out
 '

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -73,9 +73,9 @@ test_expect_success 'load job-archive module' '
 '
 
 test_expect_success 'submit some sleep 1 jobs under one user' '
-	jobid1=$(flux mini submit -N 1 sleep 1) &&
-	jobid2=$(flux mini submit -N 1 sleep 1) &&
-	jobid3=$(flux mini submit -n 2 -N 2 sleep 1) &&
+	jobid1=$(flux submit -N 1 sleep 1) &&
+	jobid2=$(flux submit -N 1 sleep 1) &&
+	jobid3=$(flux submit -n 2 -N 2 sleep 1) &&
 	wait_db $jobid1 ${ARCHIVEDB} &&
 	wait_db $jobid2 ${ARCHIVEDB} &&
 	wait_db $jobid3 ${ARCHIVEDB}
@@ -100,9 +100,9 @@ test_expect_success 'check that job usage and fairshare values get updated' '
 '
 
 test_expect_success 'submit some sleep 1 jobs under the secondary bank of the same user ' '
-	jobid1=$(flux mini submit --setattr=system.bank=account2 -N 1 sleep 1) &&
-	jobid2=$(flux mini submit --setattr=system.bank=account2 -N 1 sleep 1) &&
-	jobid3=$(flux mini submit --setattr=system.bank=account2 -n 2 -N 2 sleep 1) &&
+	jobid1=$(flux submit --setattr=system.bank=account2 -N 1 sleep 1) &&
+	jobid2=$(flux submit --setattr=system.bank=account2 -N 1 sleep 1) &&
+	jobid3=$(flux submit --setattr=system.bank=account2 -n 2 -N 2 sleep 1) &&
 	wait_db $jobid1 ${ARCHIVEDB} &&
 	wait_db $jobid2 ${ARCHIVEDB} &&
 	wait_db $jobid3 ${ARCHIVEDB}

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -54,7 +54,7 @@ test_expect_success 'create fake_payload.py' '
 '
 
 test_expect_success 'submitting a job specifying an incorrect bank with no user data results in a job exception' '
-	jobid0=$(flux mini submit --setattr=system.bank=account4 -n1 sleep 60) &&
+	jobid0=$(flux submit --setattr=system.bank=account4 -n1 sleep 60) &&
 	flux python fake_payload.py &&
 	flux job wait-event -v ${jobid0} exception > exception.test &&
 	grep "not a member of account4" exception.test
@@ -67,7 +67,7 @@ test_expect_success 'unload and reload mf_priority.so' '
 '
 
 test_expect_success 'submit sleep 60 jobs with no data update' '
-	jobid1=$(flux mini submit -n1 sleep 60)
+	jobid1=$(flux submit -n1 sleep 60)
 '
 
 test_expect_success 'check that submitted job is in state PRIORITY' '
@@ -83,8 +83,8 @@ test_expect_success 'check that previously held job transitions to RUN' '
 '
 
 test_expect_success 'submit 2 more sleep jobs' '
-	jobid2=$(flux mini submit -n1 sleep 60) &&
-	jobid3=$(flux mini submit -n1 sleep 60)
+	jobid2=$(flux submit -n1 sleep 60) &&
+	jobid3=$(flux submit -n1 sleep 60)
 '
 
 test_expect_success 'check flux jobs - should have 1 running job, 2 pending jobs' '
@@ -106,7 +106,7 @@ test_expect_success 'unload mf_priority.so' '
 '
 
 test_expect_success 'submit a job with no plugin loaded' '
-	jobid4=$(flux mini submit -n 1 sleep 60) &&
+	jobid4=$(flux submit -n 1 sleep 60) &&
 	test $(flux jobs -no {state} ${jobid4}) = PRIORITY
 '
 

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -19,9 +19,9 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 '
 
 test_expect_success 'submit a number of jobs with no user/bank info loaded to plugin' '
-	jobid1=$(flux mini submit --wait-event=depend hostname) &&
-	jobid2=$(flux mini submit --wait-event=depend hostname) &&
-	jobid3=$(flux mini submit --wait-event=depend hostname)
+	jobid1=$(flux submit --wait-event=depend hostname) &&
+	jobid2=$(flux submit --wait-event=depend hostname) &&
+	jobid3=$(flux submit --wait-event=depend hostname)
 '
 
 test_expect_success 'make sure jobs get held in state PRIORITY' '
@@ -37,7 +37,7 @@ test_expect_success 'cancel held jobs' '
 '
 
 test_expect_success 'submit job #1 with no user/bank info loaded to plugin' '
-	jobid1=$(flux mini submit --wait-event=depend hostname)
+	jobid1=$(flux submit --wait-event=depend hostname)
 '
 
 test_expect_success 'check that job #1 is in state PRIORITY' '
@@ -85,7 +85,7 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 '
 
 test_expect_success 'submit job #2 which should run before job #1' '
-	jobid2=$(flux mini submit hostname) &&
+	jobid2=$(flux submit hostname) &&
 	flux job wait-event -t 15 $jobid2 clean
 '
 

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -45,7 +45,7 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 '
 
 test_expect_success 'submit a job successfully under default bank' '
-	jobid1=$(flux mini submit -n1 hostname) &&
+	jobid1=$(flux submit -n1 hostname) &&
 	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
 	cat <<-EOF >job1.expected &&
 	50000
@@ -54,7 +54,7 @@ test_expect_success 'submit a job successfully under default bank' '
 '
 
 test_expect_success 'submit a job successfully under second bank' '
-	jobid2=$(flux mini submit --setattr=system.bank=account2 -n1 hostname) &&
+	jobid2=$(flux submit --setattr=system.bank=account2 -n1 hostname) &&
 	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	50000
@@ -68,7 +68,7 @@ test_expect_success 'disable second user/bank entry and update plugin' '
 '
 
 test_expect_success 'try to submit job under second user/bank entry' '
-	test_must_fail flux mini submit --setattr=system.bank=account2 -n1 hostname > deleted_entry1.out 2>&1 &&
+	test_must_fail flux submit --setattr=system.bank=account2 -n1 hostname > deleted_entry1.out 2>&1 &&
 	test_debug "cat deleted_entry1.out" &&
 	grep "user/bank entry has been disabled from flux-accounting DB" deleted_entry1.out
 '
@@ -79,7 +79,7 @@ test_expect_success 're-add second user/bank entry and update-plugin' '
 '
 
 test_expect_success 'submit a job successfully under second bank' '
-	jobid3=$(flux mini submit --setattr=system.bank=account2 -n1 hostname) &&
+	jobid3=$(flux submit --setattr=system.bank=account2 -n1 hostname) &&
 	flux job wait-event -f json $jobid3 priority | jq '.context.priority' > job3.test &&
 	cat <<-EOF >job3.expected &&
 	50000
@@ -93,7 +93,7 @@ test_expect_success 'disable first (and default) bank entry for user (will updat
 '
 
 test_expect_success 'try to submit job under new default user/bank entry' '
-	jobid4=$(flux mini submit -n1 hostname) &&
+	jobid4=$(flux submit -n1 hostname) &&
 	flux job wait-event -f json $jobid4 priority | jq '.context.priority' > job4.test &&
 	cat <<-EOF >job4.expected &&
 	50000
@@ -102,7 +102,7 @@ test_expect_success 'try to submit job under new default user/bank entry' '
 '
 
 test_expect_success 'disabling a user while they have an active job should not kill the job' '
-	jobid5=$(flux mini submit -n1 sleep 60) &&
+	jobid5=$(flux submit -n1 sleep 60) &&
 	flux account delete-user $username account2 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
 	test $(flux jobs -no {state} ${jobid5}) = RUN &&
@@ -110,7 +110,7 @@ test_expect_success 'disabling a user while they have an active job should not k
 '
 
 test_expect_success 'trying to submit a job now should result in a job rejection' '
-	test_must_fail flux mini submit --setattr=system.bank=account2 -n1 hostname > deleted_entry2.out 2>&1 &&
+	test_must_fail flux submit --setattr=system.bank=account2 -n1 hostname > deleted_entry2.out 2>&1 &&
 	test_debug "cat deleted_entry2.out" &&
 	grep "user/bank entry has been disabled from flux-accounting DB" deleted_entry2.out
 '


### PR DESCRIPTION
#### Problem

`flux mini CMD` is deprecated in favor of `flux CMD`.

---

This PR replaces the old usage in the test suite.