### PR TITLE
NEWS: add release notes for `v0.24.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+flux-accounting version 0.24.0 - 2023-05-02
+-------------------------------------------
+
+#### Fixes
+
+* flux-accounting service: make certain commands accessible to all users (#330)
+
+* flux-accounting service: change BindTo to BindsTo (#341)
+
+* `view-user`: improve formatting of output of command (#342)
+
+* `update-db`: fix SQLite statement when updating a table with no primary key
+(#343)
+
+#### Testsuite
+
+* replace `flux mini` usage (#344)
+
 flux-accounting version 0.23.1 - 2023-04-07
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.24.0`. Leaving as [WIP] for now in case any last minute changes are added before we want to release (release date can also be changed in the `NEWS` document). Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.24.0 -m "Tag v0.24.0" && git push upstream v0.24.0
```