### PR TITLE
NEWS: add release notes for v0.25.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+flux-accounting version 0.25.0 - 2023-05-04
+-------------------------------------------
+
+#### Fixes
+
+* plugin: improve handling of submitted jobs based on data presence in
+plugin (#347)
+
 flux-accounting version 0.24.0 - 2023-05-02
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.25.0`. This version includes the improvements to the multi-factor priority plugin brought on by #347. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.25.0 -m "Tag v0.25.0" && git push upstream v0.25.0
```