### PR TITLE
`view-bank`: improve `-t` option

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -123,7 +123,8 @@ def create_db(
                 bank        text                NOT NULL,
                 active      int(11) DEFAULT 1   NOT NULL,
                 parent_bank text    DEFAULT '',
-                shares      int                 NOT NULL
+                shares      int                 NOT NULL,
+                job_usage   real    DEFAULT 0.0 NOT NULL
         );"""
     )
     logging.info("Created bank_table successfully")

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -75,6 +75,8 @@ EXTRA_DIST= \
 	expected/flux_account/root_bank.expected \
 	expected/flux_account/deleted_user.expected \
 	expected/flux_account/deleted_bank.expected \
+	expected/flux_account/F_bank_tree.expected \
+	expected/flux_account/F_bank_users.expected \
 	expected/pop_db/db_hierarchy_base.expected \
 	expected/pop_db/db_hierarchy_new_users.expected \
 	expected/job_usage/pre_update.expected \

--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -1,5 +1,5 @@
-bank_id        bank           active         parent_bank    shares         
-2              A              1              root           1              
+bank_id        bank           active         parent_bank    shares         job_usage      
+2              A              1              root           1              0.0            
 
 Users Under Bank A:
 

--- a/t/expected/flux_account/D_bank.expected
+++ b/t/expected/flux_account/D_bank.expected
@@ -1,7 +1,8 @@
 bank_id        bank           active         parent_bank    shares         job_usage      
 5              D              1              root           1              0.0            
 
-D
- E
- F
+Bank                            Username           RawShares            RawUsage           Fairshare
+D                                                          1                 0.0
+ E                                                         1                 0.0
+ F                                                         1                 0.0
 

--- a/t/expected/flux_account/D_bank.expected
+++ b/t/expected/flux_account/D_bank.expected
@@ -1,5 +1,5 @@
-bank_id        bank           active         parent_bank    shares         
-5              D              1              root           1              
+bank_id        bank           active         parent_bank    shares         job_usage      
+5              D              1              root           1              0.0            
 
 D
  E

--- a/t/expected/flux_account/F_bank_tree.expected
+++ b/t/expected/flux_account/F_bank_tree.expected
@@ -1,0 +1,6 @@
+bank_id        bank           active         parent_bank    shares         job_usage      
+7              F              1              D              1              0.0            
+
+Bank                            Username           RawShares            RawUsage           Fairshare
+F                                                          1                 0.0
+

--- a/t/expected/flux_account/F_bank_users.expected
+++ b/t/expected/flux_account/F_bank_users.expected
@@ -1,0 +1,4 @@
+bank_id        bank           active         parent_bank    shares         job_usage      
+7              F              1              D              1              0.0            
+
+no users under F

--- a/t/expected/flux_account/full_hierarchy.expected
+++ b/t/expected/flux_account/full_hierarchy.expected
@@ -1,5 +1,5 @@
-bank_id        bank           active         parent_bank    shares         
-1              root           1                             1              
+bank_id        bank           active         parent_bank    shares         job_usage      
+1              root           1                             1              0.0            
 
 root
  A

--- a/t/expected/flux_account/full_hierarchy.expected
+++ b/t/expected/flux_account/full_hierarchy.expected
@@ -1,15 +1,16 @@
 bank_id        bank           active         parent_bank    shares         job_usage      
 1              root           1                             1              0.0            
 
-root
- A
-  user5011
-  user5012
- B
-  user5013
- C
-  user5014
- D
-  E
-  F
+Bank                            Username           RawShares            RawUsage           Fairshare
+root                                                       1                 0.0
+ A                                                         1                 0.0
+  A                             user5011                   1                 0.0                 0.5
+  A                             user5012                   1                 0.0                 0.5
+ B                                                         1                 0.0
+  B                             user5013                   1                 0.0                 0.5
+ C                                                         1                 0.0
+  C                             user5014                   1                 0.0                 0.5
+ D                                                         1                 0.0
+  E                                                        1                 0.0
+  F                                                        1                 0.0
 

--- a/t/expected/flux_account/root_bank.expected
+++ b/t/expected/flux_account/root_bank.expected
@@ -1,3 +1,3 @@
-bank_id        bank           active         parent_bank    shares         
-1              root           1                             1              
+bank_id        bank           active         parent_bank    shares         job_usage      
+1              root           1                             1              0.0            
 

--- a/t/t1007-flux-account.t
+++ b/t/t1007-flux-account.t
@@ -128,6 +128,16 @@ test_expect_success 'viewing a bank with users in it should print all user info 
 	test_cmp ${EXPECTED_FILES}/A_bank.expected A_bank.test
 '
 
+test_expect_success 'viewing a leaf bank in hierarchy mode with no users in it works' '
+	flux account view-bank F -t > F_bank_tree.test &&
+	test_cmp ${EXPECTED_FILES}/F_bank_tree.expected F_bank_tree.test
+'
+
+test_expect_success 'viewing a leaf bank in users mode with no users in it works' '
+	flux account view-bank F -u > F_bank_users.test &&
+	test_cmp ${EXPECTED_FILES}/F_bank_users.expected F_bank_users.test
+'
+
 test_expect_success 'viewing a bank with sub banks should return a smaller hierarchy tree' '
 	flux account -p ${DB_PATH} view-bank D -t > D_bank.test &&
 	test_cmp ${EXPECTED_FILES}/D_bank.expected D_bank.test


### PR DESCRIPTION
#### Problem

There is no way to see an overarching view of a flux-accounting hierarchy without running `flux account-shares`, which includes job usage values for banks and users all in one place. It would be nice if you could see this view with a Python command.

---

This PR edits the `-t` option of the `view-bank` command to more closely match the output of the `flux account-shares` command in Python, which includes job usage values for banks and fair share values for users all in one place. The new format of the `-t` option is the following:

```console
$ flux account view-bank -t root
bank_id        bank           active         parent_bank    shares         job_usage      
1              root           1                             1              0.0            

Bank                            Username           RawShares            RawUsage           Fairshare
root                                                       1                 0.0
 A                                                         1                 0.0
  A                             user5011                   1                 0.0                 0.5
  A                             user5012                   1                 0.0                 0.5
 B                                                         1                 0.0
  B                             user5013                   1                 0.0                 0.5
 C                                                         1                 0.0
  C                             user5014                   1                 0.0                 0.5
 D                                                         1                 0.0
  E                                                        1                 0.0
  F                                                        1                 0.0


```

This option is slightly more extensible than `flux account-shares` because it can generate a hierarchy from any bank in the flux-accounting database, not just the root bank. So, if you only want to see a sub-tree in the overall hierarchy, you can just pass that bank in the `view-bank -t` command.

It also adds a new column to the `bank_table` which stores job usage; this gets updated when all of the job usage values for all users also get updated.