### PR TITLE
NEWS: add release notes for v0.26.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+flux-accounting version 0.26.0 - 2023-07-07
+-------------------------------------------
+
+#### Fixes
+
+* database: update DB schema version (#361)
+
+#### Features
+
+* bank_table: add new job_usage column (#359)
+
+* `view-bank`: improve `-t` option (#359)
+
+#### Testsuite
+
+* t: add new Python test directory in `t/` (#358)
+
 flux-accounting version 0.25.0 - 2023-05-04
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.26.0`. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.26.0 -m "Tag v0.26.0" && git push upstream v0.26.0
```

Leaving this as [WIP] until #361 lands and/or there are other last minute fixes needed before a release. 🙂