### PR TITLE
.cpp: add config.h include to source code

### DIFF
--- a/src/fairness/account/account.cpp
+++ b/src/fairness/account/account.cpp
@@ -7,6 +7,9 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <cerrno>
 #include "src/fairness/account/account.hpp"

--- a/src/fairness/reader/data_reader_base.cpp
+++ b/src/fairness/reader/data_reader_base.cpp
@@ -7,6 +7,10 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "src/fairness/reader/data_reader_base.hpp"
 
 using namespace Flux::reader;

--- a/src/fairness/reader/data_reader_db.cpp
+++ b/src/fairness/reader/data_reader_db.cpp
@@ -7,6 +7,9 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <cstdlib>
 #include <iostream>

--- a/src/fairness/reader/test/data_reader_db_test01.cpp
+++ b/src/fairness/reader/test/data_reader_db_test01.cpp
@@ -9,7 +9,7 @@
 \************************************************************/
 
 #if HAVE_CONFIG_H
-# include <config.h>
+#include "config.h"
 #endif
 
 #include <algorithm>

--- a/src/fairness/weighted_tree/test/weighted_tree_load.cpp
+++ b/src/fairness/weighted_tree/test/weighted_tree_load.cpp
@@ -9,7 +9,7 @@
 \************************************************************/
 
 #if HAVE_CONFIG_H
-# include <config.h>
+#include "config.h"
 #endif
 
 #include <cerrno>

--- a/src/fairness/weighted_tree/test/weighted_tree_test01.cpp
+++ b/src/fairness/weighted_tree/test/weighted_tree_test01.cpp
@@ -9,7 +9,7 @@
 \************************************************************/
 
 #if HAVE_CONFIG_H
-# include <config.h>
+#include "config.h"
 #endif
 
 #include <cstdlib>

--- a/src/fairness/weighted_tree/weighted_tree.cpp
+++ b/src/fairness/weighted_tree/weighted_tree.cpp
@@ -7,6 +7,9 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <cmath>
 #include <cerrno>

--- a/src/fairness/weighted_tree/weighted_walk.cpp
+++ b/src/fairness/weighted_tree/weighted_walk.cpp
@@ -7,6 +7,9 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <algorithm>
 #include "src/fairness/weighted_tree/weighted_walk.hpp"

--- a/src/fairness/writer/data_writer_base.cpp
+++ b/src/fairness/writer/data_writer_base.cpp
@@ -7,6 +7,10 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "src/fairness/writer/data_writer_base.hpp"
 
 using namespace Flux::writer;

--- a/src/fairness/writer/data_writer_db.cpp
+++ b/src/fairness/writer/data_writer_db.cpp
@@ -7,6 +7,9 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include "src/fairness/writer/data_writer_db.hpp"
 

--- a/src/fairness/writer/data_writer_stdout.cpp
+++ b/src/fairness/writer/data_writer_stdout.cpp
@@ -7,14 +7,12 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
-#include <iostream>
-#include <iomanip>
-
-extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-}
+
+#include <iostream>
+#include <iomanip>
 
 #include "src/fairness/writer/data_writer_stdout.hpp"
 

--- a/src/fairness/writer/test/data_writer_db_test01.cpp
+++ b/src/fairness/writer/test/data_writer_db_test01.cpp
@@ -23,7 +23,7 @@
 \*****************************************************************************/
 
 #if HAVE_CONFIG_H
-# include <config.h>
+#include "config.h"
 #endif
 
 #include <cmath>

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -11,12 +11,10 @@
 /* mf_priority.cpp - custom basic job priority plugin
  *
  */
-
-extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-}
+
 #include <flux/core.h>
 #include <flux/jobtap.h>
 #include <jansson.h>


### PR DESCRIPTION
#### Problem

As mentioned in #365, `config.h` is not included in many of the `.cpp` source modules. Sometimes configure defines macros that affect how other header files are interpreted.

---

This PR adds `config.h` include statements in the `.cpp` source files that do not already have them.

mf_priority.cpp already had this include, but it also had an `extern "C"` preface, which is not needed, so this PR also drops that. 