### PR TITLE
`.cpp`: wrap `"config.h"`, C headers in `extern "C"`

### DIFF
--- a/src/fairness/account/account.cpp
+++ b/src/fairness/account/account.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <cerrno>
 #include "src/fairness/account/account.hpp"

--- a/src/fairness/reader/data_reader_base.cpp
+++ b/src/fairness/reader/data_reader_base.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include "src/fairness/reader/data_reader_base.hpp"
 

--- a/src/fairness/reader/data_reader_db.cpp
+++ b/src/fairness/reader/data_reader_db.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <cstdlib>
 #include <iostream>

--- a/src/fairness/weighted_tree/test/weighted_tree_load.cpp
+++ b/src/fairness/weighted_tree/test/weighted_tree_load.cpp
@@ -8,9 +8,11 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <cerrno>
 #include <deque>

--- a/src/fairness/weighted_tree/test/weighted_tree_test01.cpp
+++ b/src/fairness/weighted_tree/test/weighted_tree_test01.cpp
@@ -8,9 +8,11 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <cstdlib>
 #include <algorithm>

--- a/src/fairness/weighted_tree/weighted_tree.cpp
+++ b/src/fairness/weighted_tree/weighted_tree.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <cmath>
 #include <cerrno>

--- a/src/fairness/weighted_tree/weighted_walk.cpp
+++ b/src/fairness/weighted_tree/weighted_walk.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <algorithm>
 #include "src/fairness/weighted_tree/weighted_walk.hpp"

--- a/src/fairness/writer/data_writer_base.cpp
+++ b/src/fairness/writer/data_writer_base.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include "src/fairness/writer/data_writer_base.hpp"
 

--- a/src/fairness/writer/data_writer_db.cpp
+++ b/src/fairness/writer/data_writer_db.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include "src/fairness/writer/data_writer_db.hpp"
 

--- a/src/fairness/writer/data_writer_stdout.cpp
+++ b/src/fairness/writer/data_writer_stdout.cpp
@@ -7,9 +7,11 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <iostream>
 #include <iomanip>

--- a/src/fairness/writer/test/data_writer_db_test01.cpp
+++ b/src/fairness/writer/test/data_writer_db_test01.cpp
@@ -21,10 +21,11 @@
  *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
-
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+}
 
 #include <cmath>
 #include <vector>

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -11,13 +11,15 @@
 /* mf_priority.cpp - custom basic job priority plugin
  *
  */
+extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-
 #include <flux/core.h>
 #include <flux/jobtap.h>
 #include <jansson.h>
+}
+
 #include <map>
 #include <iterator>
 #include <cmath>


### PR DESCRIPTION
#### Problem

There are C++ files in this repo that include headers from C files, but they are not wrapped in "extern C", which could cause some unwanted mucky behavior and make it tricky to diagnose link issues.

---

Wrap the `.cpp` files in this repository that include `config.h` in `extern "C"`. In `src/plugins/mf_priority.cpp`, also wrap `flux/core.h`, `flux/joptap.h`, and `jansson.h` in `extern "C"`.