### PR TITLE
docker: transition `bionic` container to `jammy`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ queue_rules:
       - status-success="validate commits"
       - status-success="python format"
       - status-success="python lint"
-      - status-success="bionic - py3.6"
+      - status-success="jammy - py3.6"
       - status-success="el8 - py3.6"
       - status-success="el8 - distcheck"
       - status-success="coverage"

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -6,7 +6,7 @@ Docker is used under CI to speed up deployment of an environment with correct bu
 
 ### Local Testing
 
-Developers can test the docker images themselves. If new dependencies are needed, they can update the `$image` Dockerfiles manually (where `$image` is one of `bionic` or `el8`). To run inside a local Docker image, run the command:
+Developers can test the docker images themselves. If new dependencies are needed, they can update the `$image` Dockerfiles manually (where `$image` is one of `jammy` or `el8`). To run inside a local Docker image, run the command:
 
 ```console
 docker-run-checks.sh -i $image [options] -- [arguments]
@@ -14,7 +14,7 @@ docker-run-checks.sh -i $image [options] -- [arguments]
 
 ### Interactive Testing
 
-While running in an interactive Docker container, you can build, test, and interact with flux-accounting. The `bionic` image has multiple versions of Python installed, which you can configure and build against (the default version for both images is Python version `3.6`).
+While running in an interactive Docker container, you can build, test, and interact with flux-accounting.
 
 Remember to install the required dependencies before you build and add the appropriate install location to your `PYTHONPATH`. Below is an example of configuring and building against Python version `3.7` while running inside the Docker container.
 

--- a/src/test/docker/jammy/Dockerfile
+++ b/src/test/docker/jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:bionic
+FROM fluxrm/flux-core:jammy
 
 ARG USER=flux
 ARG UID=1000

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -65,7 +65,7 @@ class BuildMatrix:
     def add_build(
         self,
         name=None,
-        image="bionic",
+        image="jammy",
         args=default_args,
         jobs=4,
         env=None,
@@ -148,10 +148,10 @@ matrix.add_build(
     docker_tag=True,
 )
 
-# Bionic
+# jammy
 matrix.add_build(
-    name="bionic - py3.6",
-    image="bionic",
+    name="jammy - py3.6",
+    image="jammy",
     docker_tag=True,
 )
 


### PR DESCRIPTION
### background

Like flux-sched, flux-accounting also uses a `bionic` container as a part of its CI checks, but the Ubuntu release is no longer under LTS standard support.

---

This PR transitions the `bionic` image to `jammy` in flux-accounting and removes references of `bionic` in the `docker/` directory's README.md.