### PR TITLE
python: remove empty `quotechar` argument from `csv.writer` object initialization

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -35,7 +35,7 @@ def get_uid(username):
 def write_records_to_file(job_records, output_file):
     with open(output_file, "w", newline="") as csvfile:
         spamwriter = csv.writer(
-            csvfile, delimiter="|", quotechar="", escapechar="'", quoting=csv.QUOTE_NONE
+            csvfile, delimiter="|", escapechar="'", quoting=csv.QUOTE_NONE
         )
         spamwriter.writerow(
             (


### PR DESCRIPTION
#### Problem 

The `csv.writer` object created in `job_archive_interface.py` uses an optional argument `quotechar` that is initialized to an empty string `("")`, but the [docs](https://docs.python.org/2/library/csv.html#dialects-and-formatting-parameters) state that this must be at least a one-character string, causing some tests to fail. I think I had copied the initialization of the `csv.writer` object from somewhere when I first wrote this file, evidently not using it correctly. 🤷‍♂️ 

---

This PR just removes this optional argument from the object initialization.