### PR TITLE
python: rename `rows` variable to something more descriptive

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -223,22 +223,22 @@ def get_job_records(conn, bank, default_bank, **kwargs):
 
     cur = conn.cursor()
     cur.execute(select_stmt, (*tuple(params_list),))
-    rows = cur.fetchall()
+    result = cur.fetchall()
     # if the length of dataframe is 0, that means no job records were found
     # in the jobs table, so just return an empty list
-    if len(rows) == 0:
+    if len(result) == 0:
         return job_records
 
     if bank is None and default_bank is None:
         # special case for unit tests in test_job_archive_interface.py
-        job_records = add_job_records(rows)
+        job_records = add_job_records(result)
 
         return job_records
 
     if bank != default_bank:
-        jobs = sec_bank_jobs(rows, bank)
+        jobs = sec_bank_jobs(result, bank)
     else:
-        jobs = def_bank_jobs(rows, default_bank)
+        jobs = def_bank_jobs(result, default_bank)
 
     job_records = add_job_records(jobs)
 
@@ -561,17 +561,17 @@ def update_job_usage(acct_conn, jobs_conn, pdhl=1):
     s_assoc = "SELECT username, bank, default_bank FROM association_table"
     cur = acct_conn.cursor()
     cur.execute(s_assoc)
-    rows = cur.fetchall()
+    result = cur.fetchall()
 
     # update the job usage for every user in the association_table
-    for row in rows:
+    for row in result:
         calc_usage_factor(jobs_conn, acct_conn, pdhl, row[0], row[1], row[2])
 
     # find the root bank in the flux-accounting database
     s_root_bank = "SELECT bank FROM bank_table WHERE parent_bank=''"
     cur.execute(s_root_bank)
-    rows = cur.fetchall()
-    parent_bank = rows[0][0]  # store the name of the root bank
+    result = cur.fetchall()
+    parent_bank = result[0][0]  # store the name of the root bank
 
     # update the job usage for every bank in the bank_table
     calc_parent_bank_usage(acct_conn, cur, parent_bank, 0.0)

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -45,16 +45,16 @@ def view_project(conn, project):
     try:
         # get the information pertaining to a project in the DB
         cur.execute("SELECT * FROM project_table where project=?", (project,))
-        rows = cur.fetchall()
+        result = cur.fetchall()
         headers = [description[0] for description in cur.description]
         project_str = ""
-        if not rows:
+        if not result:
             raise ValueError(f"project {project} not found in project_table")
 
         for header in headers:
             project_str += header.ljust(18)
         project_str += "\n"
-        for row in rows:
+        for row in result:
             for col in list(row):
                 project_str += str(col).ljust(18)
             project_str += "\n"
@@ -95,7 +95,7 @@ def delete_project(conn, project):
     # look for any rows in the association_table that reference this project
     select_stmt = "SELECT * FROM association_table WHERE projects LIKE ?"
     cursor.execute(select_stmt, ("%" + project + "%",))
-    rows = cursor.fetchall()
+    result = cursor.fetchall()
     warning_stmt = (
         "WARNING: user(s) in the assocation_table still "
         "reference this project. Make sure to edit user rows to "
@@ -110,7 +110,7 @@ def delete_project(conn, project):
     # if len(rows) > 0, this means that at least one association in the
     # association_table references this project. If this is the case,
     # return the warning message after deleting the project.
-    if len(rows) > 0:
+    if len(result) > 0:
         return warning_stmt
 
     return 0

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -17,17 +17,17 @@ def view_queue(conn, queue):
     try:
         # get the information pertaining to a queue in the DB
         cur.execute("SELECT * FROM queue_table where queue=?", (queue,))
-        rows = cur.fetchall()
+        result = cur.fetchall()
         headers = [description[0] for description in cur.description]
         queue_str = ""
-        if not rows:
+        if not result:
             raise ValueError(f"queue {queue} not found in queue_table")
 
         # print column names of queue_table
         for header in headers:
             queue_str += header.ljust(18)
         queue_str += "\n"
-        for row in rows:
+        for row in result:
             for col in list(row):
                 queue_str += str(col).ljust(18)
             queue_str += "\n"


### PR DESCRIPTION
#### Problem

The `rows` variable used to store the results of a number of queries to the flux-accounting database is poorly named and can be confusing to someone looking at the code for the first time (or me, who looks at this code a lot).

---

This PR just renames the `rows` variable in a number of locations in the Python bindings to something more descriptive.