### PR TITLE
ci: update github actions `main.yml` file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: validate commits
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -19,12 +19,12 @@ jobs:
     name: python format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -41,10 +41,10 @@ jobs:
     name: python lint
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.6
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -60,16 +60,16 @@ jobs:
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(src/test/generate-matrix.py)"
+      run: echo "matrix=$(src/test/generate-matrix.py)" >> $GITHUB_OUTPUT
     - run: src/test/generate-matrix.py | jq -S .
-    - run: echo "::set-output name=GITHUB_BRANCH::${GITHUB_REF#refs/heads}"
-    - run: echo "::set-output name=GITHUB_TAG::${GITHUB_REF#refs/tags}"
-    - run: echo "::set-output name=EVENT_NAME::${{github.event_name}}"
+    - run: echo "GITHUB_BRANCH=${GITHUB_REF#refs/heads}" >> $GITHUB_OUTPUT
+    - run: echo "GITHUB_TAG=${GITHUB_REF#refs/tags}" >> $GITHUB_OUTPUT
+    - run: echo "EVENT_NAME=${{ github.event_name }}" >> $GITHUB_OUTPUT
 
   ci-checks:
     needs: [ generate-matrix ]
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
     name: ${{matrix.name}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0
@@ -94,11 +94,6 @@ jobs:
         (matrix.create_release || matrix.docker_tag) &&
         github.ref != 'refs/heads/master'
       run: |
-        # Ensure git-describe works on a tag.
-        #  (checkout@v2 action may have left current tag as
-        #   lightweight instead of annotated. See
-        #   https://github.com/actions/checkout/issues/290)
-        #
         echo github.ref == ${{ github.ref }} ;
         git fetch -f origin ${{ github.ref }}:${{ github.ref }} ;
         echo git describe now reports $(git describe --always)
@@ -126,22 +121,19 @@ jobs:
       env: ${{matrix.env}}
       run: src/test/checks-annotate.sh
 
-    #   prepare, create and deploy release on tag:
-    - name: prep release
-      id: prep_release
-      if: success() && matrix.create_release
-      env: ${{matrix.env}}
-      run: echo "::set-output name=tarball::$(echo flux-accounting*.tar.gz)"
-
     - name: create release
       id: create_release
-      if: success() && matrix.create_release
+      if: |
+        success()
+        && matrix.create_release
+        && github.repository == 'flux-framework/flux-accounting'
       env: ${{matrix.env}}
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ matrix.tag }}
-        release_name: flux-accounting ${{ matrix.tag }}
+        name: flux-accounting ${{ matrix.tag }}
         prerelease: true
+        files: flux-accounting*.tar.gz
         body: |
           View [Release Notes](https://github.com/${{ github.repository }}/blob/${{ matrix.tag }}/NEWS.md) for flux-accounting ${{ matrix.tag }}
 


### PR DESCRIPTION
#### Problem

flux-accounting's GitHub actions uses a number of near-deprecated/deprecated actions that show warnings when running CI.

---

This PR just updates the workflow file for CI for flux-accounting to use newer versions of a number of actions. I've mostly tried to just copy what flux-core has in their workflow file.

One point of clarification I think I might need is on this proposed change:

```diff
- run: echo "::set-output name=tarball::$(echo flux-accounting*.tar.gz)"
+ run: echo "$(echo flux-accounting*.tar.gz)"
```

Is the new change correct? I couldn't find the flux-core equivalent via quick GitHub search. 