### PR TITLE
plugin: check for `FLUX_JOB_STATE_NEW` in `validate_cb()`

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -28,6 +28,7 @@ TESTSCRIPTS = \
 	t1024-flux-account-queues.t \
 	t1025-flux-account-projects.t \
 	t1026-flux-account-perms.t \
+	t1027-mf-priority-issue376.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/t1027-mf-priority-issue376.t
+++ b/t/t1027-mf-priority-issue376.t
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+test_description='Test submitting jobs to queues after queue access is changed'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user --username=user1001 \
+		--userid=1001 \
+		--bank=A \
+		--max-active-jobs=2
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit job for testing' '
+	jobid1=$(flux python ${SUBMIT_AS} 1001 --urgency=0 sleep 30) &&
+	jobid2=$(flux python ${SUBMIT_AS} 1001 --urgency=0 sleep 30)
+'
+
+test_expect_success 'update of duration of pending job works while at active jobs limit' '
+	flux update $jobid1 duration=1m &&
+	flux job eventlog $jobid1 \
+		| grep jobspec-update \
+		| grep duration=60
+'
+
+test_expect_success 'active jobs limit of user/bank remains the same after job-update' '
+	flux jobtap query mf_priority.so > job_limits.json &&
+	test_debug "jq -S . <job_limits.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 2" <job_limits.json &&
+	jq -e ".mf_priority_map[0].banks[0].max_active_jobs == 2" <job_limits.json
+'
+
+test_expect_success 'third submitted job will be rejected because of active jobs limit' '
+	test_must_fail flux python ${SUBMIT_AS} 1001 sleep 60 > max_active_jobs.out 2>&1 &&
+	test_debug "cat max_active_jobs.out" &&
+	grep "user has max active jobs" max_active_jobs.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The multi-factor priority plugin checks a user/bank's active jobs limit when a job enters `job.validate` and will reject a job if the user/bank is currently at their max active jobs limit. Now that Flux supports job updates, previously validated jobs can re-enter `job.validate`, which breaks the plugin's assumptions that `job.validate` is only for newly submitted jobs, particularly with this check for a user/bank's active jobs count.

---

This PR adds an unpack for the **state** of a job in `job.validate` and check this state for `FLUX_JOB_STATE_NEW` *before* checking for a user/bank's active jobs count to protect it from jobs that were already validated by the priority plugin.

It also adds a small number of tests that validates the priority plugin can support job updates for job duration while maintaining the integrity of a user/bank's active job count.