### PR TITLE
`edit-user`: fix default values for optional args

### DIFF
--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -173,13 +173,13 @@ def add_edit_user_arg(subparsers):
     subparser_edit_user.add_argument(
         "--max-active-jobs",
         help="max number of both pending and running jobs",
-        default=7,
+        default=None,
         metavar="max_active_jobs",
     )
     subparser_edit_user.add_argument(
         "--max-nodes",
         help="max number of nodes a user can have across all of their running jobs",
-        default=5,
+        default=None,
         metavar="MAX_NODES",
     )
     subparser_edit_user.add_argument(


### PR DESCRIPTION
Problem: as mentioned in #381, the `max_nodes` and `max_active_jobs` optional args in the `edit-user` command do not have properly set default values, which causes them to reset a user's `max_nodes` and `max_active_jobs` fields to their default values unintentionally.

---

This PR just changes the default values for both the `max_nodes` and `max_active_jobs` fields to None, which should align with the rest of the optional arguments for this command.

Fixes #381