### PR TITLE
testsuite: load content module in rc scripts

### DIFF
--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -28,6 +28,7 @@ modload() {
 }
 
 
+modload all content || :
 modload 0 content-sqlite
 modload all kvs
 modload all kvs-watch

--- a/t/rc/rc1-kvs
+++ b/t/rc/rc1-kvs
@@ -10,6 +10,7 @@ modload() {
     fi
 }
 
+modload all content || :
 modload 0 content-sqlite
 modload all kvs
 modload all kvs-watch

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -29,3 +29,4 @@ modrm all kvs
 flux content flush
 
 modrm 0 content-sqlite
+modrm all content

--- a/t/rc/rc3-kvs
+++ b/t/rc/rc3-kvs
@@ -15,3 +15,4 @@ modrm all kvs
 
 flux content flush
 modrm 0 content-sqlite
+modrm all content


### PR DESCRIPTION
Problem: flux-core is migrating the content service from the broker to a broker module.

Load the content module in test rc scripts.

Ignore any errors from 'flux module load' so that flux-accounting continues to work with older flux-core versions.

I would hold off merging until it looks like flux-framework/flux-core#5435 is going to be accepted.