### PR TITLE
plugin: add queue update validation

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1074,6 +1074,70 @@ static int run_cb (flux_plugin_t *p,
 }
 
 
+static int job_updated (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    std::map<std::string, struct bank_info>::iterator bank_it;
+    int userid;
+    char *bank = NULL;
+    char *queue = NULL;
+    struct bank_info *b;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i, s{s{s{s?s, s?s}}}}",
+                                "userid", &userid,
+                                "jobspec", "attributes", "system",
+                                "bank", &bank, "queue", &queue) < 0) {
+        return flux_jobtap_reject_job (p, args, "unable to unpack bank arg");
+    }
+
+    // grab bank_info struct for user/bank (if any)
+    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+                                                    p,
+                                                    FLUX_JOBTAP_CURRENT_JOB,
+                                                    "mf_priority:bank_info"));
+
+    if (b == NULL) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB, "mf_priority",
+                                     0, "job.update: bank info is missing");
+
+        return -1;
+    }
+
+    // look up user/bank info based on unpacked information
+    bank_info_result lookup_result = get_bank_info (userid, bank);
+
+    if (lookup_result.first == BANK_USER_NOT_FOUND) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority", 0,
+                                     "job.update: cannot find info for user: ",
+                                     userid);
+    } else if (lookup_result.first == BANK_INVALID) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority", 0,
+                                     "job.update: not a member of %s",
+                                     bank);
+    } else if (lookup_result.first == BANK_NO_DEFAULT) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority", 0,
+                                     "job.update: user/default bank "
+                                     "entry does not exist");
+    } else if (lookup_result.first == BANK_SUCCESS) {
+        bank_it = lookup_result.second;
+    }
+
+    // fetch the priority of the validated queue; assign it to the bank_info
+    // struct associated with the job
+    int queue_factor = get_queue_info (queue, bank_it);
+    b->queue_factor = queue_factor;
+
+    return 0;
+}
+
+
 static int inactive_cb (flux_plugin_t *p,
                         const char *topic,
                         flux_plugin_arg_t *args,
@@ -1143,6 +1207,7 @@ static const struct flux_plugin_handler tab[] = {
     { "job.priority.get", priority_cb, NULL },
     { "job.state.inactive", inactive_cb, NULL },
     { "job.state.depend", depend_cb, NULL },
+    { "job.update", job_updated, NULL},
     { "job.state.run", run_cb, NULL},
     { "plugin.query", query_cb, NULL},
     { 0 },

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -45,6 +45,21 @@ extern "C" {
 // the association does not have permission to run jobs under
 #define INVALID_QUEUE -6
 
+// different codes to return as a result of looking up user/bank information:
+//
+// BANK_SUCCESS: we found an entry for the passed-in user/bank
+// BANK_USER_NOT_FOUND: the user could not be found in the plugin map
+// BANK_INVALID: the user specified a bank they don't belong to
+// BANK_NO_DEFAULT: the user does not have a default bank in the plugin map
+enum bank_info_codes {
+    BANK_SUCCESS,
+    BANK_USER_NOT_FOUND,
+    BANK_INVALID,
+    BANK_NO_DEFAULT
+};
+
+typedef std::pair<bank_info_codes, std::map<std::string, struct bank_info>::iterator> bank_info_result;
+
 std::map<int, std::map<std::string, struct bank_info>> users;
 std::map<std::string, struct queue_info> queues;
 std::map<int, std::string> users_def_bank;
@@ -375,6 +390,38 @@ static int update_jobspec_bank (flux_plugin_t *p, int userid)
         return -1;
 
     return 0;
+}
+
+
+// Given a userid and an optional bank, locate the associated information in
+// the plugin's internal users map. The return value is a pair: the first value
+// is a return code to indicate success or the type of failure, and the second
+// value is an iterator that points to the appropriate user/bank's information
+// associated with the submitted job
+static bank_info_result get_bank_info (int userid, char *bank)
+{
+    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
+    std::map<std::string, struct bank_info>::iterator bank_it;
+
+    it = users.find (userid);
+    if (it == users.end ()) {
+        return {BANK_USER_NOT_FOUND, bank_it};
+    }
+
+    // make sure user belongs to bank they specified; if no bank was passed in,
+    // look up their default bank
+    if (bank != NULL) {
+        bank_it = it->second.find (std::string (bank));
+        if (bank_it == it->second.end ())
+            return {BANK_INVALID, bank_it};
+    } else {
+        bank = const_cast<char*> (users_def_bank[userid].c_str ());
+        bank_it = it->second.find (std::string (bank));
+        if (bank_it == it->second.end ())
+            return {BANK_NO_DEFAULT, bank_it};
+    }
+
+    return {BANK_SUCCESS, bank_it};
 }
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -31,6 +31,7 @@ TESTSCRIPTS = \
 	t1027-mf-priority-issue376.t \
 	t1028-mf-priority-issue385.t \
 	t1029-mf-priority-default-bank.t \
+	t1030-mf-priority-update-queue.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+test_description='test updating the queue for a pending job in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze --priority=100 &&
+	flux account add-queue silver --priority=200 &&
+	flux account add-queue gold --priority=300
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user --username=user5001 \
+		--userid=5001 \
+		--bank=A \
+		--queues="bronze,silver"
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'configure flux with some queues' '
+	cat >conf.d/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	[queues.gold]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'submit job for testing' '
+	jobid1=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
+	flux job wait-event -f json $jobid1 priority \
+		| jq '.context.priority' > job1_bronze.test &&
+ 	grep 1050000 job1_bronze.test
+'
+
+test_expect_success 'update of queue of pending job works' '
+	flux update $jobid1 queue=silver &&
+	flux job wait-event -f json $jobid1 priority &&
+	flux job eventlog $jobid1 > eventlog.out &&
+	grep "attributes.system.queue=\"silver\"" eventlog.out &&
+	grep 2050000 eventlog.out
+'
+
+test_expect_success 'updating a job using a queue the user does not belong to fails' '
+	test_must_fail flux update $jobid1 queue=gold > unavail_queue.out 2>&1 &&
+	test_debug "cat unavail_queue.out" &&
+	grep "ERROR: Queue not valid for user: gold" unavail_queue.out
+'
+
+test_expect_success 'cancel job' '
+	flux job cancel $jobid1
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Background

As noted in #377, Flux can now handle job updates to pending jobs, particularly with queues. Since flux-accounting's priority plugin is involved in queue validation (i.e making sure that the user/bank has access to the queue they want to submit their job to), it should be expanded to handle job updates.

---

This PR adds a new callback to the priority plugin for `job.update`, which will unpack user, bank, and queue information and assign the new priority associated with the updated queue to the `bank_info` struct of a job so that when the job re-enters `job.state.priority`, a new overall job priority can be calculated.

A new helper function is added to the plugin called `get_bank_info ()`, which accepts a userid and an optional bank value (if one is passed during job submission) that performs a lookup in the plugin's internal map to retrieve the necessary information to associate with the submitted job. It returns a pair: a return code as well as the iterator to the user/bank map that is associated with the job. The `job.update` callback makes use of this to retrieve the user/bank information, and then retrieves the new priority associated with the updated queue and assigns it to the `bank_info` struct associated with a job, which could affect its priority.

This new helper function can most likely be adapted in other places in the plugin code, but I think its best to probably leave it for a future PR to refactor some of the callbacks to make use of it.

Finally, a new set of tests are added to the testsuite which test updating the queue for a job in which the user/bank **does** have access to and updating the queue for a job in which the user/bank **does not** have access to. In the former, the job is updated and the priority is increased, and in the latter, an error is raised when the job re-enters `job.validate` and the priority remains the same as it was before the attempted update. Note that these tests are commented out until flux-framework/flux-core#5424 has landed; otherwise, I think these tests will fail in the meantime.