### PR TITLE
testsuite: allow sharness tests to be run by hand

### DIFF
--- a/t/sharness.d/flux-accounting.sh
+++ b/t/sharness.d/flux-accounting.sh
@@ -1,5 +1,19 @@
-FLUX_EXEC_PATH_PREPEND=${SHARNESS_TEST_SRCDIR}/../src/cmd
 
-export FLUX_EXEC_PATH_PREPEND
+prepend_colon_separated() {
+    local var=$1
+    local val=$2
+    eval "prev=\${$var}"
+    case "$prev:" in
+        ${val}:*) ;;  # Do nothing val already in var
+        *) eval "$var=${val}${prev+:${prev}}" ;;
+    esac
+}
+
+SRC_DIR=${SHARNESS_TEST_SRCDIR}/..
+
+prepend_colon_separated FLUX_EXEC_PATH_PREPEND ${SRC_DIR}/src/cmd
+prepend_colon_separated PYTHONPATH ${SRC_DIR}/src/bindings/python
+
+export FLUX_EXEC_PATH_PREPEND PYTHONPATH
 
 # vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: sharness tests in the testsuite can't be run by hand because `PYTHONPATH` is not set to the in-tree accounting python path.

In `t/sharness.d/flux-accounting.sh` add a function to prepend to a colon-separated path variable if the argument is not already the first entry. Use this to prepend the in-tree python path to `PYTHONPATH`h if necessary. Also use it for `FLUX_EXEC_PATH_PREPEND` so we don't prepend the same path multiple times.
 
```
$ ./t1000-print-hierarchy.t  -d -v
```

or 
```
$ FLUX_TEST_VALGRIND=t ./t1000-print-hierarchy.t  -d -v
```