### PR TITLE
testsuite: change check for specific job states

### DIFF
--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -29,7 +29,7 @@ wait_db() {
 				sleep 0.1
 				i=$((i + 1))
 		done
-		if [ "$i" -eq "50" ]
+		if [ "$i" -eq "100" ]
 		then
 			return 1
 		fi

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -175,8 +175,9 @@ test_expect_success 'run update-usage and update-fshare commands' '
 '
 
 test_expect_success 'check that job usage and fairshare values get updated' '
-	flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update2.test &&
-	grep "account2" post_update2.test | grep "4" | grep "0.5"
+	flux account -p ${DB_PATH} view-user $username --json > query1.json &&
+	test_debug "jq -S . <query1.json" &&
+	jq -e ".banks[1].job_usage >= 4" <query1.json
 '
 
 # if update-usage is called in the same half-life period when no jobs are found
@@ -185,8 +186,9 @@ test_expect_success 'check that job usage and fairshare values get updated' '
 test_expect_success 'call update-usage in the same half-life period where no jobs are run' '
 	flux account -p ${DB_PATH} update-usage &&
 	flux account-update-fshare -p ${DB_PATH} &&
-	flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update3.test &&
-	grep "account2" post_update3.test | grep "4" | grep "0.5"
+	flux account -p ${DB_PATH} view-user $username --json > query2.json &&
+	test_debug "jq -S . <query2.json" &&
+	jq -e ".banks[1].job_usage >= 4" <query2.json
 '
 
 test_expect_success 'remove flux-accounting DB' '

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -156,12 +156,12 @@ test_expect_success 'unload mf_priority.so' '
 
 test_expect_success 'submit a job to a nonexistent queue with no plugin information loaded' '
 	jobid6=$(flux python ${SUBMIT_AS} 5011 --queue=foo -n1 hostname) &&
-	test $(flux jobs -no {state} ${jobid6}) = PRIORITY
+	flux job wait-event -vt 60 $jobid6 depend
 '
 
 test_expect_success 'reload mf_priority.so and update it with the sample test data again' '
 	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
-	test $(flux jobs -no {state} ${jobid6}) = PRIORITY &&
+	flux job wait-event -vt 60 $jobid6 depend &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -25,9 +25,9 @@ test_expect_success 'submit a number of jobs with no user/bank info loaded to pl
 '
 
 test_expect_success 'make sure jobs get held in state PRIORITY' '
-	test $(flux jobs -no {state} ${jobid1}) = PRIORITY &&
-	test $(flux jobs -no {state} ${jobid2}) = PRIORITY &&
-	test $(flux jobs -no {state} ${jobid3}) = PRIORITY
+	flux job wait-event -vt 60 $jobid1 depend &&
+	flux job wait-event -vt 60 $jobid2 depend &&
+	flux job wait-event -vt 60 $jobid3 depend
 '
 
 test_expect_success 'cancel held jobs' '
@@ -41,7 +41,7 @@ test_expect_success 'submit job #1 with no user/bank info loaded to plugin' '
 '
 
 test_expect_success 'check that job #1 is in state PRIORITY' '
-	test $(flux jobs -no {state} ${jobid1}) = PRIORITY
+	flux job wait-event -vt 60 $jobid1 depend
 '
 
 test_expect_success 'send the user/bank information to the plugin without reprioritizing all active jobs' '

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -105,7 +105,7 @@ test_expect_success 'disabling a user while they have an active job should not k
 	jobid5=$(flux submit -n1 sleep 60) &&
 	flux account delete-user $username account2 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
-	test $(flux jobs -no {state} ${jobid5}) = RUN &&
+	flux job wait-event -vt 60 $jobid5 alloc &&
 	flux job cancel $jobid5
 '
 

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -90,10 +90,10 @@ test_expect_success HAVE_JQ 'fetch plugin state and make sure that jobs are refl
 	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_2.json
 '
 
-test_expect_success 'cancel jobs' '
-	flux job cancel $jobid1 &&
+test_expect_success 'cancel jobs in reverse order so last job does not get alloc event' '
+	flux job cancel $jobid3 &&
 	flux job cancel $jobid2 &&
-	flux job cancel $jobid3
+	flux job cancel $jobid1
 '
 
 test_expect_success 'add another user to flux-accounting DB and send it to plugin' '

--- a/t/t1020-mf-priority-issue262.t
+++ b/t/t1020-mf-priority-issue262.t
@@ -21,35 +21,35 @@ test_expect_success 'allow guest access to testexec' '
 	EOF
 '
 test_expect_success 'create flux-accounting DB' '
-    flux account -p $(pwd)/FluxAccountingTest.db create-db
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '
 
 test_expect_success 'start flux-accounting service' '
-    flux account-service -p ${DB_PATH} -t
+	flux account-service -p ${DB_PATH} -t
 '
 
 test_expect_success 'load multi-factor priority plugin' '
-    flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '
 
 test_expect_success 'check that mf_priority plugin is loaded' '
-    flux jobtap list | grep mf_priority
+	flux jobtap list | grep mf_priority
 '
 
 test_expect_success 'add some banks to the DB' '
-    flux account add-bank root 1 &&
-    flux account add-bank --parent-bank=root account1 1 &&
-    flux account add-bank --parent-bank=root account2 1 &&
-    flux account add-bank --parent-bank=root account3 1
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root account1 1 &&
+	flux account add-bank --parent-bank=root account2 1 &&
+	flux account add-bank --parent-bank=root account3 1
 '
 
 test_expect_success 'add a user with two different banks to the DB' '
-    flux account add-user --username=user1001 --userid=1001 --bank=account1 --max-running-jobs=5 --max-active-jobs=10 &&
-    flux account add-user --username=user1001 --userid=1001 --bank=account2
+	flux account add-user --username=user1001 --userid=1001 --bank=account1 --max-running-jobs=5 --max-active-jobs=10 &&
+	flux account add-user --username=user1001 --userid=1001 --bank=account2
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
-    flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 
 test_expect_success 'submit a sleep 180 job and ensure it is running' '
@@ -58,7 +58,7 @@ test_expect_success 'submit a sleep 180 job and ensure it is running' '
 '
 
 test_expect_success 'stop scheduler from allocating resources to jobs' '
-    flux queue stop
+	flux queue stop
 '
 
 test_expect_success 'submit 2 more sleep 180 jobs; ensure both are in SCHED state' '
@@ -69,48 +69,48 @@ test_expect_success 'submit 2 more sleep 180 jobs; ensure both are in SCHED stat
 '
 
 test_expect_success 'ensure current running and active jobs are correct: 1 running, 3 active' '
-    flux jobtap query mf_priority.so > query_1.json &&
-    test_debug "jq -S . <query_1.json" &&
-    jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_1.json &&
-    jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_1.json
+	flux jobtap query mf_priority.so > query_1.json &&
+	test_debug "jq -S . <query_1.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_1.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_1.json
 '
 
 test_expect_success 'update the plugin and ensure current running and active jobs are correct' '
-    flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
-    flux jobtap query mf_priority.so > query_2.json &&
-    test_debug "jq -S . <query_2.json" &&
-    jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_2.json &&
-    jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_2.json
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
+	flux jobtap query mf_priority.so > query_2.json &&
+	test_debug "jq -S . <query_2.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_2.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_2.json
 '
 
 test_expect_success 'change the priority of one of the jobs' '
-    flux job urgency $jobid2 31 &&
-    flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
-    flux job eventlog $jobid2 | grep ^priority | tail -n 1 | priority=4294967295
+	flux job urgency $jobid2 31 &&
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
+	flux job eventlog $jobid2 | grep ^priority | tail -n 1 | priority=4294967295
 '
 
 test_expect_success 'ensure job counts are still the same: 1 running, 3 active' '
-    flux jobtap query mf_priority.so > query_3.json &&
-    test_debug "jq -S . <query_3.json" &&
-    jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_3.json &&
-    jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_3.json
+	flux jobtap query mf_priority.so > query_3.json &&
+	test_debug "jq -S . <query_3.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_3.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 3" <query_3.json
 '
 
 test_expect_success 'cancel one of the scheduled jobs, check job counts are correct: 1 running, 2 active' '
-    flux job cancel $jobid2 &&
-    flux jobtap query mf_priority.so > query_4.json &&
-    test_debug "jq -S . <query_4.json" &&
-    jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_4.json &&
-    jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 2" <query_4.json
+	flux job cancel $jobid2 &&
+	flux jobtap query mf_priority.so > query_4.json &&
+	test_debug "jq -S . <query_4.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_4.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 2" <query_4.json
 '
 
 test_expect_success 'cancel sleep 180 job(s), check job counts: 0 running, 0 active' '
-    flux job cancel $jobid1 &&
-    flux job cancel $jobid3 &&
-    flux jobtap query mf_priority.so > query_5.json &&
-    test_debug "jq -S . <query_5.json" &&
-    jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 0" <query_5.json &&
-    jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 0" <query_5.json
+	flux job cancel $jobid1 &&
+	flux job cancel $jobid3 &&
+	flux jobtap query mf_priority.so > query_5.json &&
+	test_debug "jq -S . <query_5.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 0" <query_5.json &&
+	jq -e ".mf_priority_map[0].banks[0].cur_active_jobs == 0" <query_5.json
 '
 
 test_done

--- a/t/t1020-mf-priority-issue262.t
+++ b/t/t1020-mf-priority-issue262.t
@@ -53,8 +53,8 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 '
 
 test_expect_success 'submit a sleep 180 job and ensure it is running' '
-    jobid1=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
-    test $(flux jobs -no {state} ${jobid1}) = RUN
+	jobid1=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
+	flux job wait-event -vt 60 $jobid1 alloc
 '
 
 test_expect_success 'stop scheduler from allocating resources to jobs' '
@@ -62,10 +62,10 @@ test_expect_success 'stop scheduler from allocating resources to jobs' '
 '
 
 test_expect_success 'submit 2 more sleep 180 jobs; ensure both are in SCHED state' '
-    jobid2=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
-    jobid3=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
-    test $(flux jobs -no {state} ${jobid2}) = SCHED &&
-    test $(flux jobs -no {state} ${jobid3}) = SCHED
+	jobid2=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
+	jobid3=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
+	flux job wait-event -vt 60 $jobid2 priority &&
+	flux job wait-event -vt 60 $jobid3 priority
 '
 
 test_expect_success 'ensure current running and active jobs are correct: 1 running, 3 active' '

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -55,7 +55,7 @@ test_expect_success 'submit a job with no user/bank info loaded to plugin' '
 '
 
 test_expect_success 'make sure job is held in state PRIORITY' '
-	test $(flux jobs -no {state} ${jobid1}) = PRIORITY
+	flux job wait-event -vt 60 $jobid1 depend
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
@@ -63,7 +63,7 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 '
 
 test_expect_success 'check that held job transitions to RUN' '
-	test $(flux jobs -no {state} ${jobid1}) = RUN
+	flux job wait-event -vt 60 $jobid1 alloc
 '
 
 test_expect_success 'cancel job' '

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -33,12 +33,12 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'submit a job with no user/bank info loaded to plugin' '
 	jobid1=$(flux python ${SUBMIT_AS} 5001 --wait-event=depend hostname) &&
-	test $(flux jobs -no {state} ${jobid1}) = PRIORITY
+	flux job wait-event -vt 60 $jobid1 depend
 '
 
 test_expect_success 'submit a job as another user, check that it is also in state PRIORITY' '
 	jobid2=$(flux python ${SUBMIT_AS} 5002 --wait-event=depend hostname) &&
-	test $(flux jobs -no {state} ${jobid2}) = PRIORITY
+	flux job wait-event -vt 60 $jobid2 depend
 '
 
 test_expect_success 'add banks, users to flux-accounting DB' '
@@ -53,8 +53,8 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 '
 
 test_expect_success 'check that jobs transition to RUN' '
-	test $(flux jobs -no {state} ${jobid1}) = RUN &&
-	test $(flux jobs -no {state} ${jobid2}) = RUN
+	flux job wait-event -vt 60 $jobid1 alloc &&
+	flux job wait-event -vt 60 $jobid2 alloc
 '
 
 test_expect_success 'submitting a job under invalid user while plugin has data fails' '
@@ -75,7 +75,7 @@ test_expect_success 'add the previously invalid user to flux-accounting DB, plug
 
 test_expect_success 'previously invalid user can now submit jobs' '
 	jobid3=$(flux python ${SUBMIT_AS} 9999 hostname) &&
-	test $(flux jobs -no {state} ${jobid3}) = RUN &&
+	flux job wait-event -vt 60 $jobid3 alloc &&
 	flux job cancel $jobid3
 '
 


### PR DESCRIPTION
#### Problem

As mentioned in #390, there are some tests in the flux-accounting testsuite that might produce a race condition when run under `valgrind`. Some of the tests look at specific job states, but there is a chance the job may not have reached a certain state, like DEPEND, by the time `flux job info` is run. It might be better to use `flux job wait-event` to look for `depend` or `alloc` events instead of looking at DEPEND or RUN states of jobs.

---

This PR makes a number of changes to the testsuite so that flux-accounting tests can be run under `valgrind`. The first commit changes the checks for certain job states to use `flux job wait-event` and `flux job info $jobid eventlog` to check for certain events and states in the tests.

The next commit removes a couple of checks for specific job usage values because running this set of tests in `t1011-job-archive-interface.t` under `valgrind` might cause the job usage values as a result of the submitted job to be different than what is checked.

The third commit changes the order of job cancellations of the submitted jobs in `t1019-mf-priority-info-fetch.t` because we don't want the last submitted job to enter the `alloc` event while the first two jobs are being canceled, since in this test we're checking for certain `running_jobs` and `active_jobs` values in the tests.

The last commit just converts `t1020-mf-priority-issue262.t` to use tabs instead of spaces, which would make it consistent with the rest of the tests in the flux-accounting testsuite.

If desired, perhaps I could add a `valgrind` builder to the GitHub actions for flux-accounting in this PR? Is that possible? I can't remember if flux-core has one; I tried doing a quick GitHub search but couldn't find anything.

 