### PR TITLE
`view-bank`: fix `-t` option for a sub bank with users in it

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -268,17 +268,8 @@ def view_bank(conn, bank, tree=False, users=False):
                 + "\n"
             )
 
-            # get all potential sub banks
-            cur.execute("SELECT * FROM bank_table WHERE parent_bank=?", (name,))
-            result = cur.fetchall()
-
-            if result:
-                # traverse the user/bank hierarchy and add the information from all
-                # banks and users to the hiearchy string
-                hierarchy_str = print_hierarchy(cur, name, hierarchy_str, "")
-                bank_str += "\n" + hierarchy_str
-            else:
-                bank_str += "\n" + hierarchy_str
+            hierarchy_str = print_hierarchy(cur, name, hierarchy_str, "")
+            bank_str += "\n" + hierarchy_str
         # if users is passed in, print out all potential users under
         # the passed in bank
         if users is True:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -86,6 +86,7 @@ EXTRA_DIST= \
 	expected/test_dbs/FluxAccountingv0-25-0.db \
 	expected/flux_account/A_bank.expected \
 	expected/flux_account/D_bank.expected \
+	expected/flux_account/E_bank.expected \
 	expected/flux_account/full_hierarchy.expected \
 	expected/flux_account/root_bank.expected \
 	expected/flux_account/deleted_user.expected \

--- a/t/expected/flux_account/E_bank.expected
+++ b/t/expected/flux_account/E_bank.expected
@@ -1,0 +1,8 @@
+bank_id        bank           active         parent_bank    shares         job_usage      
+6              E              1              D              1              0.0            
+
+Bank                            Username           RawShares            RawUsage           Fairshare
+E                                                          1                 0.0
+ E                              user5030                   1                 0.0                 0.5
+ E                              user5031                   1                 0.0                 0.5
+

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -78,6 +78,13 @@ test_expect_success 'viewing a bank with sub banks should return a smaller hiera
 	test_cmp ${EXPECTED_FILES}/D_bank.expected D_bank.test
 '
 
+test_expect_success 'view a bank with sub banks with users in it' '
+	flux account add-user --username=user5030 --userid=5030 --bank=E &&
+	flux account add-user --username=user5031 --userid=5031 --bank=E &&
+	flux account -p ${DB_PATH} view-bank E -t > E_bank.test &&
+	test_cmp ${EXPECTED_FILES}/E_bank.expected E_bank.test
+'
+
 test_expect_success 'edit a field in a bank account' '
 	flux account edit-bank C --shares=50 &&
 	flux account view-bank C > edited_bank.out &&


### PR DESCRIPTION
#### Problem

As mentioned in #394, the `-t` option of the `view-bank` command does not print out a full hierarchy for a sub bank with users in it because there is an `if` check that looks to see if the bank has any sub banks in it before calling the recursive function that prints out any potential information under it `print_hierarchy()`, but it won't call this recursive function if it doesn't have any sub banks, when it really should be called all the time, whether it has additional sub banks, users, or nothing at all.

---

This PR just removes the `if` check before calling the recursive function `print_hierarchy()` so that it is always called whether a sub bank has any additional sub banks, users, or neither.

I've also added a test that uses the `-t` option for a sub bank with users under it to make sure that it works as intended.

Fixes #394 