### PR TITLE
plugin: improve `job.validate` callback, clean up unused variables

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -784,13 +784,10 @@ static int validate_cb (flux_plugin_t *p,
     char *bank = NULL;
     char *queue = NULL;
     flux_job_state_t state;
-    int max_run_jobs, cur_active_jobs, max_active_jobs, queue_factor = 0;
-    double fairshare = 0.0;
+    int cur_active_jobs, max_active_jobs = 0;
     bool only_dne_data;
 
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
     std::map<std::string, struct bank_info>::iterator bank_it;
-    std::map<std::string, struct queue_info>::iterator q_it;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -849,14 +846,10 @@ static int validate_cb (flux_plugin_t *p,
 
     // validate the queue if one is passed in; if the user does not have access
     // to the queue they specified, reject the job
-    queue_factor = get_queue_info (queue, bank_it);
-
-    if (queue_factor == INVALID_QUEUE)
+    if (get_queue_info (queue, bank_it) == INVALID_QUEUE)
         return flux_jobtap_reject_job (p, args, "Queue not valid for user: %s",
                                        queue);
 
-    max_run_jobs = bank_it->second.max_run_jobs;
-    fairshare = bank_it->second.fairshare;
     cur_active_jobs = bank_it->second.cur_active_jobs;
     max_active_jobs = bank_it->second.max_active_jobs;
 


### PR DESCRIPTION
#### Background

While working on some other stuff in the plugin, I noticed there were either unused or unneeded variables in `validate_cb ()` because the things they were originally used for were moved to other callbacks in the priority plugin. For example, the `queue_factor` variable that used to store a result of calling `get_queue_info ()` could be removed in favor of just using the function call directly in its place.

Furthermore, the lookup of the user/bank information can be cleaned up to use the new helper function in the plugin that was added in #389.

---

This is a relatively low-priority PR that just cleans up the `job.validate` callback by removing some unused/unneeded variables as well as makes use of the new user/bank lookup helper function. IMHO, it makes reading the `validate_cb ()` function easier and clearer about what it is checking. 