### PR TITLE
feat: developer container environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+FROM fluxrm/flux-core:bookworm
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+USER root
+
+# Install extra buildrequires for flux-sched:
+RUN sudo apt-get update
+RUN sudo apt-get -qq install -y --no-install-recommends \
+        libboost-graph-dev \
+        libboost-system-dev \
+        libboost-filesystem-dev \
+        libboost-regex-dev \
+        python3-yaml \
+        libyaml-cpp-dev \
+        libedit-dev \
+        ninja-build \
+        curl
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/lib      
+ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
+
+# extra interactive utilities
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+    fd-find \
+    less \
+    bats \
+    ripgrep
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Flux Accounting Developer Environment",
+  "dockerFile": "Dockerfile",
+  "context": "../",
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+  },
+      "extensions": [
+         "ms-vscode.cmake-tools"
+      ]
+    }
+  },
+  "postStartCommand": "git config --global --add safe.directory /workspaces/flux-accounting"
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ priority plugin.
 
 ### Install Instructions
 
+For instructions for using a VSCode Development Container, see [this document in flux-core](https://github.com/flux-framework/flux-core/blob/master/vscode.md). You'll want to create the environment
+and proceed with the steps below to build.
+
 ##### Building From Source
 
 ```console


### PR DESCRIPTION
Problem: there is no easy way to develop (in a container) and this would be nice if we consider other kinds of bindings. Solution: add a .devcontainer setup.

This is the first step (I think at least) to thinking about Go bindings. I see this is a project in C++ (not C) so I'll look into good ways to do that.