### PR TITLE
plugin: add callback specific for validating an updated queue

### DIFF
--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -78,7 +78,7 @@ test_expect_success 'update of queue of pending job works' '
 test_expect_success 'updating a job using a queue the user does not belong to fails' '
 	test_must_fail flux update $jobid1 queue=gold > unavail_queue.out 2>&1 &&
 	test_debug "cat unavail_queue.out" &&
-	grep "ERROR: Queue not valid for user: gold" unavail_queue.out
+	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
 '
 
 test_expect_success 'cancel job' '

--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -31,7 +31,8 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'add some banks to the DB' '
 	flux account add-bank root 1 &&
-	flux account add-bank --parent-bank=root A 1
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1
 '
 
 test_expect_success 'add some queues to the DB' '
@@ -44,6 +45,10 @@ test_expect_success 'add a user to the DB' '
 	flux account add-user --username=user5001 \
 		--userid=5001 \
 		--bank=A \
+		--queues="bronze,silver" &&
+	flux account add-user --username=user5001 \
+		--userid=5001 \
+		--bank=B \
 		--queues="bronze,silver"
 '
 
@@ -83,6 +88,31 @@ test_expect_success 'updating a job using a queue the user does not belong to fa
 
 test_expect_success 'cancel job' '
 	flux job cancel $jobid1
+'
+
+test_expect_success 'submit job for testing under non-default bank' '
+	jobid2=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --queue=bronze sleep 30) &&
+	flux job wait-event -f json $jobid2 priority \
+		| jq '.context.priority' > job2_bronze.test &&
+	grep 1050000 job2_bronze.test
+'
+
+test_expect_success 'update of queue of pending job under a non-default bank works' '
+	flux update $jobid2 queue=silver &&
+	flux job wait-event -f json $jobid2 priority &&
+	flux job eventlog $jobid2 > eventlog.out &&
+	grep "attributes.system.queue=\"silver\"" eventlog.out &&
+	grep 2050000 eventlog.out
+'
+
+test_expect_success 'updating a job under non-default bank using a queue the user does not belong to fails' '
+	test_must_fail flux update $jobid2 queue=gold > unavail_queue.out 2>&1 &&
+	test_debug "cat unavail_queue.out" &&
+	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
+'
+
+test_expect_success 'cancel job' '
+	flux job cancel $jobid2
 '
 
 test_expect_success 'shut down flux-accounting service' '


### PR DESCRIPTION
#### Problem

The multi-factor priority plugin uses the same callback for both _validating_ an updated queue and for _actually updating_ the queue on a user/bank's job. This will be an issue when additional "updateable" attributes are added to the plugin, such as banks.

---

This PR adds a new callback to the plugin, `update_queue_cb ()`, which is responsible for validating an updated queue and will reject the update if it is not valid for the user/bank. It assigns this callback to the `"job.update.attributes.system.queue"` topic string.

As a result of adding the new `update_queue_cb ()` callback, the `job_updated ()` callback is also changed to unpack the "updates" JSON object when unpacking arguments and see if there is an update for the `queue` attribute. It checks its contents and applies its update to the job that requested the queue update.

Lastly, I've added comments at the top of both functions with a short description (mostly so I don't forget how this flow of updating job attributes works in the future 😆). 