### PR TITLE
[WIP] plugin: add support for updating bank of a pending job

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -65,6 +65,7 @@ std::map<std::string, struct queue_info> queues;
 std::map<int, std::string> users_def_bank;
 
 struct bank_info {
+    std::string bank_name;
     double fairshare;
     int max_run_jobs;
     int cur_run_jobs;
@@ -524,6 +525,7 @@ static void rec_update_cb (flux_t *h,
         struct bank_info *b;
         b = &users[uid][bank];
 
+        b->bank_name = bank;
         b->fairshare = fshare;
         b->max_run_jobs = max_running_jobs;
         b->max_active_jobs = max_active_jobs;
@@ -753,6 +755,7 @@ static void add_missing_bank_info (flux_plugin_t *p, flux_t *h, int userid)
     b = &users[userid]["DNE"];
     users_def_bank[userid] = "DNE";
 
+    b->bank_name = "DNE";
     b->fairshare = 0.1;
     b->max_run_jobs = BANK_INFO_MISSING;
     b->cur_run_jobs = 0;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -33,6 +33,7 @@ TESTSCRIPTS = \
 	t1029-mf-priority-default-bank.t \
 	t1030-mf-priority-update-queue.t \
 	t1031-mf-priority-update-bank.t \
+	t1032-mf-priority-update-job.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -32,6 +32,7 @@ TESTSCRIPTS = \
 	t1028-mf-priority-issue385.t \
 	t1029-mf-priority-default-bank.t \
 	t1030-mf-priority-update-queue.t \
+	t1031-mf-priority-update-bank.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/t1031-mf-priority-update-bank.t
+++ b/t/t1031-mf-priority-update-bank.t
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+test_description='test updating the bank for a pending job in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user \
+		--username=user1 \
+		--userid=5001 \
+		--bank=A &&
+	flux account add-user \
+		--username=user1 \
+		--userid=5001 \
+		--bank=B \
+		--max-active-jobs=3 \
+		--max-running-jobs=2
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit one job under default bank, two under non-default bank' '
+	job1=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
+	job2=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --urgency=0 sleep 30) &&
+	job3=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --urgency=0 sleep 30)
+'
+
+test_expect_success 'update of bank of pending job works' '
+	flux update $job1 bank=B &&
+	flux job wait-event -t 30 $job1 priority &&
+	flux job eventlog $job1 > eventlog.out &&
+	grep "attributes.system.bank=\"B\"" eventlog.out
+'
+
+test_expect_success 'trying to update to a bank user does not have access to fails in job.validate' '
+	test_must_fail flux update $job1 bank=C > invalid_bank.out 2>&1 &&
+	test_debug "cat invalid_bank.out" &&
+	grep "not a member of C" invalid_bank.out
+'
+
+test_expect_success 'trying to update to a bank that does not exist fails in job.validate' '
+	test_must_fail flux update $job1 bank=foo > nonexistent_bank.out 2>&1 &&
+	test_debug "cat nonexistent_bank.out" &&
+	grep "mf_priority: not a member of foo" nonexistent_bank.out
+'
+
+test_expect_success 'update a job to another bank that is at max-active-jobs limit' '
+	job4=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
+	test_must_fail flux update $job4 bank=B > max_active_jobs.out 2>&1 &&
+	test_debug "cat max_active_jobs.out" &&
+	grep "new bank is already at max-active-jobs limit" max_active_jobs.out &&
+	flux job cancel $job4
+'
+
+test_expect_success 'cancel one of the jobs so bank is not at max-active-jobs limit' '
+	flux job cancel $job3
+'
+
+test_expect_success 'update urgency of held jobs so they transition to RUN' '
+	flux job urgency $job1 default &&
+	flux job urgency $job2 default &&
+	flux job wait-event -t 10 $job1 alloc &&
+	flux job wait-event -t 10 $job2 alloc
+'
+
+test_expect_success 'update a job to another bank that is at max-run-jobs limit' '
+	job5=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
+	test_must_fail flux update $job5 bank=B > max_run_jobs.out 2>&1 &&
+	test_debug "cat max_run_jobs.out" &&
+	grep "new bank is already at max-run-jobs limit" max_run_jobs.out &&
+	flux job cancel $job5
+'
+
+test_expect_success 'cancel jobs' '
+	flux job cancel $job1 &&
+	flux job cancel $job2
+'
+
+test_expect_success 'submit job under non-default bank' '
+	job6=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --urgency=0 sleep 30)
+'
+
+test_expect_success 'updating job to default bank works' '
+	flux update $job6 bank=A &&
+	flux job wait-event -t 30 $job6 priority &&
+	flux job eventlog $job6 > eventlog.out &&
+	grep "attributes.system.bank=\"A\"" eventlog.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done

--- a/t/t1032-mf-priority-update-job.t
+++ b/t/t1032-mf-priority-update-job.t
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+test_description='test updating a combination of queue and bank for a pending job in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze --priority=100 &&
+	flux account add-queue silver --priority=200 &&
+	flux account add-queue gold --priority=300
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user --username=user5001 \
+		--userid=5001 \
+		--bank=A \
+		--queues="bronze,silver" &&
+	flux account add-user --username=user5001 \
+		--userid=5001 \
+		--bank=B \
+		--queues="bronze,silver"
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'configure flux with some queues' '
+	cat >conf.d/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	[queues.gold]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'submit job for testing' '
+	jobid=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
+	flux job wait-event -f json $jobid priority
+'
+
+test_expect_success 'update both queue and bank successfully' '
+	flux update $jobid queue=silver bank=B &&
+	flux job wait-event -f json $jobid priority &&
+	flux job eventlog $jobid > eventlog.out &&
+	grep "attributes.system.queue=\"silver\"" eventlog.out &&
+	grep 2050000 eventlog.out &&
+    grep "attributes.system.bank=\"B\"" eventlog.out &&
+    flux job cancel $jobid
+'
+
+test_expect_success 'submit another job for testing' '
+    jobid=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
+	flux job wait-event -f json $jobid priority
+'
+
+test_expect_success 'update job with invalid combination (invalid bank)' '
+    test_must_fail flux update $jobid queue=silver bank=foo > nonexistent_bank.out 2>&1 &&
+	test_debug "cat nonexistent_bank.out" &&
+	grep "mf_priority: not a member of foo" nonexistent_bank.out
+'
+
+test_expect_success 'check that job is still in original queue' '
+    flux job info $jobid jobspec > jobspec.out &&
+    grep "\"queue\":\"bronze\"" jobspec.out
+'
+
+test_expect_success 'update job with invalud combination (invalid queue)' '
+    test_must_fail flux update $jobid bank=B queue=gold > unavail_queue.out 2>&1 &&
+	test_debug "cat unavail_queue.out" &&
+	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
+'
+
+test_expect_success 'check that job is still under original bank' '
+    flux job eventlog $jobid > eventlog.out &&
+	grep "attributes.system.bank=\"A\"" eventlog.out &&
+    flux job cancel $jobid
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
~~note: this is built on top of #399, so I think it might be best to hold off on this PR until that one lands.~~ (#399 has now landed)

#### Problem

flux-accounting currently has no support for a user/bank to update the bank they want their pending job to run under.

---

This is a PR that adds support for updating the bank of a pending job. It adds a new callback to the plugin which looks for the `"job.update.attributes.system.bank"` topic string and validates the new bank that the user is trying to update their job to. If they have access to the bank they want to update their job to _but_ this new bank is currently at its max running jobs limit, the plugin will reject the update. Since `job.state.depend` is the final place where a job can have dependencies added to it (and adding/removing dependencies is how the plugin handles running job limits), I've chosen to just reject the update and keep the job under its current bank.

Once a new bank has been validated, its attributes are then applied to the job's `bank_info` struct in the `job.update` callback. You'll notice that before the new attributes/limits are assigned to the job, the `active_jobs` count of the old bank is decremented. Then, just before the new attributes/limits are assigned to the job, the `active_jobs` count of the new bank is incremented (since this count usually gets incremented when the job is in `job.new`).

A new test file, `t1031-mf-priority-update-bank.t` is also added to the test suite which simulates submitting some jobs under default and non-default banks and updating the bank between each, while also making sure that a job being updated to a bank that is already at their current max running jobs limit gets rejected.

---

#### TODO

- [x] add a check in the test suite to ensure that active/running jobs limits are as expected after an update