### PR TITLE
[experimental] plugn: add new `bank_info` class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,8 @@ noinst_HEADERS = \
 	fairness/reader/data_reader_db.hpp \
 	fairness/writer/data_writer_base.hpp \
 	fairness/writer/data_writer_db.hpp \
-	fairness/writer/data_writer_stdout.hpp
+	fairness/writer/data_writer_stdout.hpp \
+	plugins/bank_info.hpp
 
 fairness_libweighted_tree_la_SOURCES = \
 	fairness/account/account.cpp \

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -8,5 +8,6 @@ jobtapdir = \
   $(fluxlibdir)/job-manager/plugins/
 
 jobtap_LTLIBRARIES = mf_priority.la
-mf_priority_la_SOURCES = mf_priority.cpp
+mf_priority_la_SOURCES = mf_priority.cpp bank_info.cpp
+mf_priority_la_CPPFLAGS = -I$(top_srcdir)/src/plugins
 mf_priority_la_LDFLAGS = $(fluxplugin_ldflags) -module

--- a/src/plugins/bank_info.cpp
+++ b/src/plugins/bank_info.cpp
@@ -1,0 +1,11 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include "bank_info.hpp"

--- a/src/plugins/bank_info.cpp
+++ b/src/plugins/bank_info.cpp
@@ -9,3 +9,43 @@
 \************************************************************/
 
 #include "bank_info.hpp"
+
+int user_bank_lookup (int userid, char *bank)
+{
+    auto it = users.find (userid);
+    if (it == users.end ()) {
+        return BANK_USER_NOT_FOUND;
+    }
+
+    // make sure user belongs to bank they specified; if no bank was passed in,
+    // look up their default bank
+    if (bank != NULL) {
+        auto bank_it = it->second.find (std::string (bank));
+        if (bank_it == it->second.end ())
+            return BANK_INVALID;
+    } else {
+        bank = const_cast<char*> (users_def_bank[userid].c_str ());
+        auto bank_it = it->second.find (std::string (bank));
+        if (bank_it == it->second.end ())
+            return BANK_NO_DEFAULT;
+    }
+
+    return BANK_SUCCESS;
+}
+
+
+user_bank_info get_user_info (int userid, char *bank)
+{
+    std::map<std::string, user_bank_info>::iterator bank_it;
+
+    auto it = users.find (userid);
+
+    if (bank != NULL) {
+        bank_it = it->second.find (std::string (bank));
+    } else {
+        bank = const_cast<char*> (users_def_bank[userid].c_str ());
+        bank_it = it->second.find (std::string (bank));
+    }
+
+    return bank_it->second;
+}

--- a/src/plugins/bank_info.hpp
+++ b/src/plugins/bank_info.hpp
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+// header file for the bank_info class
+
+#ifndef BANK_INFO_H
+#define BANK_INFO_H
+
+#include <vector>
+#include <string>
+
+// all attributes are per-user/bank
+class user_bank_info {
+public:
+    std::string bank_name;           // name of bank
+    double fairshare;                // fair share value
+    int max_run_jobs;                // max number of running jobs
+    int cur_run_jobs;                // current number of running jobs 
+    int max_active_jobs;             // max number of active jobs
+    int cur_active_jobs;             // current number of active jobs
+    std::vector<long int> held_jobs; // list of currently held job ID's
+    std::vector<std::string> queues; // list of accessible queues
+    int queue_factor;                // priority factor associated with queue
+    int active;                      // active status
+};
+
+#endif // BANK_INFO_H

--- a/src/plugins/bank_info.hpp
+++ b/src/plugins/bank_info.hpp
@@ -15,6 +15,8 @@
 
 #include <vector>
 #include <string>
+#include <map>
+#include <iterator>
 
 // all attributes are per-user/bank
 class user_bank_info {
@@ -30,5 +32,29 @@ public:
     int queue_factor;                // priority factor associated with queue
     int active;                      // active status
 };
+
+// different codes to return as a result of looking up user/bank information:
+//
+// BANK_SUCCESS: we found an entry for the passed-in user/bank
+// BANK_USER_NOT_FOUND: the user could not be found in the plugin map
+// BANK_INVALID: the user specified a bank they don't belong to
+// BANK_NO_DEFAULT: the user does not have a default bank in the plugin map
+enum bank_info_codes {
+    BANK_SUCCESS,
+    BANK_USER_NOT_FOUND,
+    BANK_INVALID,
+    BANK_NO_DEFAULT
+};
+
+// these data structures are defined in the priority plugin
+extern std::map<int, std::map<std::string, user_bank_info>> users;
+extern std::map<int, std::string> users_def_bank;
+
+// check if a user has an entry in the users map
+int user_bank_lookup (int userid, char *bank);
+
+// get a user_bank_info object that points to user/bank
+// information in users map
+user_bank_info get_user_info (int userid, char *bank);
 
 #endif // BANK_INFO_H

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -65,6 +65,7 @@ std::map<std::string, struct queue_info> queues;
 std::map<int, std::string> users_def_bank;
 
 struct bank_info {
+    std::string bank_name;
     double fairshare;
     int max_run_jobs;
     int cur_run_jobs;
@@ -524,6 +525,7 @@ static void rec_update_cb (flux_t *h,
         struct bank_info *b;
         b = &users[uid][bank];
 
+        b->bank_name = bank;
         b->fairshare = fshare;
         b->max_run_jobs = max_running_jobs;
         b->max_active_jobs = max_active_jobs;
@@ -753,6 +755,7 @@ static void add_missing_bank_info (flux_plugin_t *p, flux_t *h, int userid)
     b = &users[userid]["DNE"];
     users_def_bank[userid] = "DNE";
 
+    b->bank_name = "DNE";
     b->fairshare = 0.1;
     b->max_run_jobs = BANK_INFO_MISSING;
     b->cur_run_jobs = 0;

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -20,6 +20,9 @@ extern "C" {
 #include <jansson.h>
 }
 
+// custom bank_info class file
+#include "bank_info.hpp"
+
 #include <map>
 #include <iterator>
 #include <cmath>
@@ -58,24 +61,11 @@ enum bank_info_codes {
     BANK_NO_DEFAULT
 };
 
-typedef std::pair<bank_info_codes, std::map<std::string, struct bank_info>::iterator> bank_info_result;
+typedef std::pair<bank_info_codes, std::map<std::string, user_bank_info>::iterator> bank_info_result;
 
-std::map<int, std::map<std::string, struct bank_info>> users;
+std::map<int, std::map<std::string, user_bank_info>> users;
 std::map<std::string, struct queue_info> queues;
 std::map<int, std::string> users_def_bank;
-
-struct bank_info {
-    std::string bank_name;
-    double fairshare;
-    int max_run_jobs;
-    int cur_run_jobs;
-    int max_active_jobs;
-    int cur_active_jobs;
-    std::vector<long int> held_jobs;
-    std::vector<std::string> queues;
-    int queue_factor;
-    int active;
-};
 
 // min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
 // currently used or enforced in this plugin, so their values have no
@@ -113,7 +103,7 @@ int64_t priority_calculation (flux_plugin_t *p,
     double fshare_factor = 0.0, priority = 0.0;
     int queue_factor = 0;
     int fshare_weight, queue_weight;
-    struct bank_info *b;
+    user_bank_info *b;
 
     fshare_weight = 100000;
     queue_weight = 10000;
@@ -124,7 +114,7 @@ int64_t priority_calculation (flux_plugin_t *p,
     if (urgency == FLUX_JOB_URGENCY_EXPEDITE)
         return FLUX_JOB_PRIORITY_MAX;
 
-    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+    b = static_cast<user_bank_info *> (flux_jobtap_job_aux_get (
                                                     p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
@@ -152,7 +142,7 @@ int64_t priority_calculation (flux_plugin_t *p,
 
 static int get_queue_info (
                       char *queue,
-                      std::map<std::string, struct bank_info>::iterator bank_it)
+                      std::map<std::string, user_bank_info>::iterator bank_it)
 {
     std::map<std::string, struct queue_info>::iterator q_it;
 
@@ -184,7 +174,7 @@ static int get_queue_info (
 }
 
 
-static void split_string (char *queues, struct bank_info *b)
+static void split_string (char *queues, user_bank_info *b)
 {
     std::stringstream s_stream;
 
@@ -218,7 +208,7 @@ int check_queue_factor (flux_plugin_t *p,
  * Add held job IDs to a JSON array to be added to a bank_info JSON object.
  */
 static json_t *add_held_jobs (
-                            const std::pair<std::string, struct bank_info> &b)
+                            const std::pair<std::string, user_bank_info> &b)
 {
     json_t *held_jobs = NULL;
 
@@ -249,7 +239,7 @@ error:
  * Create a JSON object for a bank that a user belongs to.
  */
 static json_t *pack_bank_info_object (
-                            const std::pair<std::string, struct bank_info> &b)
+                            const std::pair<std::string, user_bank_info> &b)
 {
     json_t *bank_info, *held_jobs = NULL;
 
@@ -282,7 +272,7 @@ error:
  */
 static json_t *banks_to_json (
                     flux_plugin_t *p,
-                    std::pair<int, std::map<std::string, struct bank_info>> &u)
+                    std::pair<int, std::map<std::string, user_bank_info>> &u)
 {
     json_t *bank_info, *banks = NULL;
 
@@ -314,7 +304,7 @@ error:
  */
 static json_t *user_to_json (
                     flux_plugin_t *p,
-                    std::pair<int, std::map<std::string, struct bank_info>> u)
+                    std::pair<int, std::map<std::string, user_bank_info>> u)
 {
     json_t *user = json_object (); // JSON object for one user
     json_t *userid, *banks = NULL;
@@ -373,7 +363,7 @@ static bool check_map_for_dne_only ()
 static int update_jobspec_bank (flux_plugin_t *p, int userid)
 {
     char *bank = NULL;
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
+    std::map<int, std::map<std::string, user_bank_info>>::iterator it;
 
     it = users.find (userid);
     if (it == users.end ()) {
@@ -401,8 +391,8 @@ static int update_jobspec_bank (flux_plugin_t *p, int userid)
 // associated with the submitted job
 static bank_info_result get_bank_info (int userid, char *bank)
 {
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    std::map<int, std::map<std::string, user_bank_info>>::iterator it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
 
     it = users.find (userid);
     if (it == users.end ()) {
@@ -479,7 +469,7 @@ static int query_cb (flux_plugin_t *p,
  * Unpack a payload from an external bulk update service and place it in the
  * multimap datastructure.
  */
-static void rec_update_cb (flux_t *h,
+static void rec_update_cb(flux_t *h,
                            flux_msg_handler_t *mh,
                            const flux_msg_t *msg,
                            void *arg)
@@ -522,7 +512,7 @@ static void rec_update_cb (flux_t *h,
                             "active", &active) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
-        struct bank_info *b;
+        user_bank_info *b;
         b = &users[uid][bank];
 
         b->bank_name = bank;
@@ -633,7 +623,7 @@ static int priority_cb (flux_plugin_t *p,
     char *bank = NULL;
     char *queue = NULL;
     int64_t priority;
-    struct bank_info *b;
+    user_bank_info *b;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -650,7 +640,7 @@ static int priority_cb (flux_plugin_t *p,
         return -1;
     }
 
-    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+    b = static_cast<user_bank_info *> (flux_jobtap_job_aux_get (
                                                     p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
@@ -662,8 +652,8 @@ static int priority_cb (flux_plugin_t *p,
         return -1;
     }
 
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    std::map<int, std::map<std::string, user_bank_info>>::iterator it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
 
     if (b->max_run_jobs == BANK_INFO_MISSING) {
         // try to look up user again
@@ -750,7 +740,7 @@ static int priority_cb (flux_plugin_t *p,
 
 static void add_missing_bank_info (flux_plugin_t *p, flux_t *h, int userid)
 {
-    struct bank_info *b;
+    user_bank_info *b;
 
     b = &users[userid]["DNE"];
     users_def_bank[userid] = "DNE";
@@ -791,9 +781,9 @@ static int validate_cb (flux_plugin_t *p,
     double fairshare = 0.0;
     bool only_dne_data;
 
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
-    std::map<std::string, struct bank_info>::iterator bank_it;
-    std::map<std::string, struct queue_info>::iterator q_it;
+    std::map<int, std::map<std::string, user_bank_info>>::iterator it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
+    std::map<std::string, user_bank_info>::iterator q_it;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -886,10 +876,10 @@ static int new_cb (flux_plugin_t *p,
     char *queue = NULL;
     int max_run_jobs, cur_active_jobs, max_active_jobs = 0;
     double fairshare = 0.0;
-    struct bank_info *b;
+    user_bank_info *b;
 
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    std::map<int, std::map<std::string, user_bank_info>>::iterator it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -901,7 +891,7 @@ static int new_cb (flux_plugin_t *p,
         return flux_jobtap_reject_job (p, args, "unable to unpack bank arg");
     }
 
-    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+    b = static_cast<user_bank_info *> (flux_jobtap_job_aux_get (
                                                     p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
@@ -1003,7 +993,7 @@ static int depend_cb (flux_plugin_t *p,
 {
     int userid;
     long int id;
-    struct bank_info *b;
+    user_bank_info *b;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1017,7 +1007,7 @@ static int depend_cb (flux_plugin_t *p,
         return -1;
     }
 
-    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+    b = static_cast<user_bank_info *> (flux_jobtap_job_aux_get (
                                                     p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
@@ -1055,9 +1045,9 @@ static int run_cb (flux_plugin_t *p,
                    void *data)
 {
     int userid;
-    struct bank_info *b;
+    user_bank_info *b;
 
-    b = static_cast<bank_info *>
+    b = static_cast<user_bank_info *>
         (flux_jobtap_job_aux_get (p,
                                   FLUX_JOBTAP_CURRENT_JOB,
                                   "mf_priority:bank_info"));
@@ -1086,12 +1076,12 @@ static int job_updated (flux_plugin_t *p,
                         flux_plugin_arg_t *args,
                         void *data)
 {
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
     int userid;
     char *bank = NULL;
     char *new_bank = NULL;
     char *queue = NULL;
-    struct bank_info *b;
+    user_bank_info *b;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1106,7 +1096,7 @@ static int job_updated (flux_plugin_t *p,
         return flux_jobtap_error (p, args, "unable to unpack plugin args");
 
     // grab bank_info struct for user/bank (if any)
-    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+    b = static_cast<user_bank_info *> (flux_jobtap_job_aux_get (
                                                     p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));
@@ -1193,7 +1183,7 @@ static int update_queue_cb (flux_plugin_t *p,
                             flux_plugin_arg_t *args,
                             void *data)
 {
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
     int userid;
     char *bank = NULL;
     char *queue = NULL;
@@ -1255,7 +1245,7 @@ static int update_bank_cb (flux_plugin_t *p,
                            flux_plugin_arg_t *args,
                            void *data)
 {
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
     int userid;
     char *bank = NULL;
 
@@ -1319,9 +1309,9 @@ static int inactive_cb (flux_plugin_t *p,
                         void *data)
 {
     int userid;
-    struct bank_info *b;
-    std::map<int, std::map<std::string, struct bank_info>>::iterator it;
-    std::map<std::string, struct bank_info>::iterator bank_it;
+    user_bank_info *b;
+    std::map<int, std::map<std::string, user_bank_info>>::iterator it;
+    std::map<std::string, user_bank_info>::iterator bank_it;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1335,7 +1325,7 @@ static int inactive_cb (flux_plugin_t *p,
         return -1;
     }
 
-    b = static_cast<bank_info *> (flux_jobtap_job_aux_get (
+    b = static_cast<user_bank_info *> (flux_jobtap_job_aux_get (
                                                     p,
                                                     FLUX_JOBTAP_CURRENT_JOB,
                                                     "mf_priority:bank_info"));

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -127,9 +127,8 @@ int64_t priority_calculation (flux_plugin_t *p,
 }
 
 
-static int get_queue_info (
-                      char *queue,
-                      std::map<std::string, user_bank_info>::iterator bank_it)
+static int get_queue_info (char *queue,
+                           std::vector<std::string> permissible_queues)
 {
     std::map<std::string, struct queue_info>::iterator q_it;
 
@@ -146,10 +145,10 @@ static int get_queue_info (
 
         // check #2) the queue passed in is a valid option to pass for user
         std::vector<std::string>::iterator vect_it;
-        vect_it = std::find (bank_it->second.queues.begin (),
-                             bank_it->second.queues.end (), queue);
+        vect_it = std::find (permissible_queues.begin (),
+                             permissible_queues.end (), queue);
 
-        if (vect_it == bank_it->second.queues.end ())
+        if (vect_it == permissible_queues.end ())
             return INVALID_QUEUE;
         else
             // add priority associated with the passed in queue to bank_info
@@ -675,7 +674,7 @@ static int priority_cb (flux_plugin_t *p,
             }
 
             // fetch priority associated with passed-in queue (or default queue)
-            bank_it->second.queue_factor = get_queue_info (queue, bank_it);
+            bank_it->second.queue_factor = get_queue_info (queue, bank_it->second.queues);
             if (check_queue_factor (p,
                                     bank_it->second.queue_factor,
                                     queue) < 0)
@@ -828,9 +827,9 @@ static int validate_cb (flux_plugin_t *p,
 
     // validate the queue if one is passed in; if the user does not have access
     // to the queue they specified, reject the job
-    queue_factor = get_queue_info (queue, bank_it);
+    // queue_factor = get_queue_info (queue, user_bank.queues);
 
-    if (queue_factor == INVALID_QUEUE)
+    if (get_queue_info (queue, user_bank.queues) == INVALID_QUEUE)
         return flux_jobtap_reject_job (p, args, "Queue not valid for user: %s",
                                        queue);
 
@@ -936,7 +935,7 @@ static int new_cb (flux_plugin_t *p,
 
     // assign priority associated with validated queue to bank_info struct
     // associated with job
-    b->queue_factor = get_queue_info (queue, bank_it);
+    b->queue_factor = get_queue_info (queue, b->queues);
 
     // if a user/bank has reached their max_active_jobs limit, subsequently
     // submitted jobs will be rejected
@@ -1149,7 +1148,7 @@ static int job_updated (flux_plugin_t *p,
     // if the queue for the job has been updated, fetch the priority of the
     // validated queue and assign it to the associated bank_info struct
     if (queue != NULL) {
-        int queue_factor = get_queue_info (queue, bank_it);
+        int queue_factor = get_queue_info (queue, bank_it->second.queues);
         b->queue_factor = queue_factor;
     }
 
@@ -1204,7 +1203,7 @@ static int update_queue_cb (flux_plugin_t *p,
 
         // validate the updated queue and make sure the user/bank has
         // access to it; if not, reject the update
-        if (get_queue_info (queue, bank_it) == INVALID_QUEUE)
+        if (get_queue_info (queue, bank_it->second.queues) == INVALID_QUEUE)
             return flux_jobtap_error (p,
                                       args,
                                       "mf_priority: queue not valid for user: %s",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -33,6 +33,7 @@ TESTSCRIPTS = \
 	t1029-mf-priority-default-bank.t \
 	t1030-mf-priority-update-queue.t \
 	t1031-mf-priority-update-bank.t \
+	t1032-mf-priority-update-job.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -32,6 +32,7 @@ TESTSCRIPTS = \
 	t1028-mf-priority-issue385.t \
 	t1029-mf-priority-default-bank.t \
 	t1030-mf-priority-update-queue.t \
+	t1031-mf-priority-update-bank.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/t1031-mf-priority-update-bank.t
+++ b/t/t1031-mf-priority-update-bank.t
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+test_description='test updating the bank for a pending job in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user \
+		--username=user1 \
+		--userid=5001 \
+		--bank=A &&
+	flux account add-user \
+		--username=user1 \
+		--userid=5001 \
+		--bank=B \
+		--max-active-jobs=3 \
+		--max-running-jobs=2
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit one job under default bank, two under non-default bank' '
+	job1=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
+	job2=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --urgency=0 sleep 30) &&
+	job3=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --urgency=0 sleep 30)
+'
+
+test_expect_success 'update of bank of pending job works' '
+	flux update $job1 bank=B &&
+	flux job wait-event -t 30 $job1 priority &&
+	flux job eventlog $job1 > eventlog.out &&
+	grep "attributes.system.bank=\"B\"" eventlog.out
+'
+
+test_expect_success 'trying to update to a bank user does not have access to fails in job.validate' '
+	test_must_fail flux update $job1 bank=C > invalid_bank.out 2>&1 &&
+	test_debug "cat invalid_bank.out" &&
+	grep "not a member of C" invalid_bank.out
+'
+
+test_expect_success 'trying to update to a bank that does not exist fails in job.validate' '
+	test_must_fail flux update $job1 bank=foo > nonexistent_bank.out 2>&1 &&
+	test_debug "cat nonexistent_bank.out" &&
+	grep "mf_priority: not a member of foo" nonexistent_bank.out
+'
+
+test_expect_success 'update a job to another bank that is at max-active-jobs limit' '
+	job4=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
+	test_must_fail flux update $job4 bank=B > max_active_jobs.out 2>&1 &&
+	test_debug "cat max_active_jobs.out" &&
+	grep "new bank is already at max-active-jobs limit" max_active_jobs.out &&
+	flux job cancel $job4
+'
+
+test_expect_success 'cancel one of the jobs so bank is not at max-active-jobs limit' '
+	flux job cancel $job3
+'
+
+test_expect_success 'update urgency of held jobs so they transition to RUN' '
+	flux job urgency $job1 default &&
+	flux job urgency $job2 default &&
+	flux job wait-event -t 10 $job1 alloc &&
+	flux job wait-event -t 10 $job2 alloc
+'
+
+test_expect_success 'update a job to another bank that is at max-run-jobs limit' '
+	job5=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
+	test_must_fail flux update $job5 bank=B > max_run_jobs.out 2>&1 &&
+	test_debug "cat max_run_jobs.out" &&
+	grep "new bank is already at max-run-jobs limit" max_run_jobs.out &&
+	flux job cancel $job5
+'
+
+test_expect_success 'cancel jobs' '
+	flux job cancel $job1 &&
+	flux job cancel $job2
+'
+
+test_expect_success 'submit job under non-default bank' '
+	job6=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --urgency=0 sleep 30)
+'
+
+test_expect_success 'updating job to default bank works' '
+	flux update $job6 bank=A &&
+	flux job wait-event -t 30 $job6 priority &&
+	flux job eventlog $job6 > eventlog.out &&
+	grep "attributes.system.bank=\"A\"" eventlog.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done

--- a/t/t1032-mf-priority-update-job.t
+++ b/t/t1032-mf-priority-update-job.t
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+test_description='test updating a combination of queue and bank for a pending job in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze --priority=100 &&
+	flux account add-queue silver --priority=200 &&
+	flux account add-queue gold --priority=300
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user --username=user5001 \
+		--userid=5001 \
+		--bank=A \
+		--queues="bronze,silver" &&
+	flux account add-user --username=user5001 \
+		--userid=5001 \
+		--bank=B \
+		--queues="bronze,silver"
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'configure flux with some queues' '
+	cat >conf.d/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	[queues.gold]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'submit job for testing' '
+	jobid=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
+	flux job wait-event -f json $jobid priority
+'
+
+test_expect_success 'update both queue and bank successfully' '
+	flux update $jobid queue=silver bank=B &&
+	flux job wait-event -f json $jobid priority &&
+	flux job eventlog $jobid > eventlog.out &&
+	grep "attributes.system.queue=\"silver\"" eventlog.out &&
+	grep 2050000 eventlog.out &&
+    grep "attributes.system.bank=\"B\"" eventlog.out &&
+    flux job cancel $jobid
+'
+
+test_expect_success 'submit another job for testing' '
+    jobid=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
+	flux job wait-event -f json $jobid priority
+'
+
+test_expect_success 'update job with invalid combination (invalid bank)' '
+    test_must_fail flux update $jobid queue=silver bank=foo > nonexistent_bank.out 2>&1 &&
+	test_debug "cat nonexistent_bank.out" &&
+	grep "mf_priority: not a member of foo" nonexistent_bank.out
+'
+
+test_expect_success 'check that job is still in original queue' '
+    flux job info $jobid jobspec > jobspec.out &&
+    grep "\"queue\":\"bronze\"" jobspec.out
+'
+
+test_expect_success 'update job with invalud combination (invalid queue)' '
+    test_must_fail flux update $jobid bank=B queue=gold > unavail_queue.out 2>&1 &&
+	test_debug "cat unavail_queue.out" &&
+	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
+'
+
+test_expect_success 'check that job is still under original bank' '
+    flux job eventlog $jobid > eventlog.out &&
+	grep "attributes.system.bank=\"A\"" eventlog.out &&
+    flux job cancel $jobid
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
### Background

The plugin uses its own `bank_info` struct to hold user/bank information and has a number of methods for access and modification of these objects. As the plugin's feature set has grown, so have the requirements for the `bank_info` struct, resulting in a very large and hard-to-parse piece of code.

---

This is more of an experimental PR based on some of the feedback in #400 that suggested considering creating a class for the `bank_info` object. For now, I've just built this on top of #400 with one additional commit that does the following:

A new `.hpp` and `.cpp` file are added to the `plugins/` directory called **bank_info.cpp** and **bank_info.hpp**. This set of files stores a new class called `user_bank_info`, which is made up of the same attributes as the original `bank_info` struct. They are `#include`d to the plugin file and the definition of the struct is thus removed from the plugin and instances of that struct are replaced with the use of the new class.

For now, this class file just has the definition of the `user_bank_info` object, but, if this is the right idea, then I can begin to slowly move some of the related functionality that is currently defined in the plugin over to this new class file.