### PR TITLE
NEWS: add release notes for `v0.29.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+flux-accounting version 0.29.0 - 2024-01-08
+-------------------------------------------
+
+#### Fixes
+
+* plugin: keep jobs in `PRIORITY` after reprioritization (#407)
+
+* plugin: add callback specific for validating an updated queue (#399)
+
+#### Testsuite
+
+* feat: developer container environment (#398)
+
 flux-accounting version 0.28.0 - 2023-10-02
 -------------------------------------------
 


### PR DESCRIPTION
This PR adds release notes for flux-accounting `v0.29.0`. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.29.0 -m "Tag v0.29.0" && git push upstream v0.29.0
```