### PR TITLE
plugin: improve callback for `job.validate`

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -10,3 +10,28 @@
 
 #include "accounting.hpp"
 
+Association* get_association (int userid,
+                              const char *bank,
+                              std::map<int, std::map<std::string, Association>>
+                                &users,
+                              std::map<int, std::string> &users_def_bank)
+{
+    auto it = users.find (userid);
+    if (it == users.end ())
+        // user could not be found
+        return nullptr;
+
+    std::string b;
+    if (bank != NULL)
+        b = bank;
+    else
+        // get the default bank of this user
+        b = users_def_bank[userid];
+
+    auto bank_it = it->second.find (b);
+    if (bank_it == it->second.end ())
+        // user does not have accounting information under the specified bank
+        return nullptr;
+
+    return &bank_it->second;
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -33,4 +33,12 @@ public:
     int active;                      // active status
 };
 
+// get an Association object that points to user/bank in the users map;
+// return nullptr on failure
+Association* get_association (int userid,
+                              const char *bank,
+                              std::map<int, std::map<std::string, Association>>
+                                &users,
+                              std::map<int, std::string> &users_def_bank);
+
 #endif // ACCOUNTING_H

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -79,15 +79,52 @@ static void test_direct_map_access (
 }
 
 
+// ensure an Assocation* is returned on success
+static void test_get_association_success ()
+{
+    // retrieve user_bank_info object
+    Association *user1 = get_association (1001,
+                                          const_cast<char *> ("bank_A"),
+                                          users,
+                                          users_def_bank);
+    ok (user1->bank_name == "bank_A",
+        "get_association () successfully returns a pointer to an Association");
+}
+
+
+// ensure nullptr is returned when a user cannot be found in the map
+static void test_get_association_noexist ()
+{
+    Association *user_foo = get_association (9999,
+                                             const_cast<char *> ("bank_A"),
+                                             users,
+                                             users_def_bank);
+    ok (user_foo == nullptr,
+        "get_association () fails when an association cannot be found");
+}
+
+
+// ensure nullptr is returned when a user does not have a default bank
+static void test_get_association_no_default_bank ()
+{
+    Association *user2 = get_association (1002, NULL, users, users_def_bank);
+    ok (user2 == nullptr,
+        "get_association () fails when a user does not have a default bank");
+}
+
+
 int main (int argc, char* argv[])
 {
     // declare the number of tests that we plan to run
-    plan (1);
+    plan (4);
 
     // add users to the test map
     initialize_map (users);
 
     test_direct_map_access (users);
+    test_get_association_success ();
+    test_get_association_noexist ();
+    test_get_association_no_default_bank ();
 
     // indicate we are done testing
     done_testing ();

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -147,7 +147,7 @@ test_expect_success 'submit a job using default bank' '
 test_expect_success 'submit a job using a bank the user does not belong to' '
 	test_must_fail flux submit --setattr=system.bank=account1 -n1 hostname > bad_bank.out 2>&1 &&
 	test_debug "cat bad_bank.out" &&
-	grep "user does not belong to specified bank" bad_bank.out
+	grep "cannot find user/bank or user/default bank entry for uid:" bad_bank.out
 '
 
 test_expect_success 'reject job when invalid bank format is passed in' '

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -66,7 +66,7 @@ test_expect_success 'cancel job' '
 
 test_expect_success 'submit a job to plugin while not having an entry in the plugin' '
 	test_must_fail flux python ${SUBMIT_AS} 1003 hostname > no_user_entry.out 2>&1 &&
-	grep "no bank found for user" no_user_entry.out
+	grep "cannot find user/bank or user/default bank entry for uid:" no_user_entry.out
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -54,7 +54,7 @@ test_expect_success 'check that jobs transition to RUN' '
 test_expect_success 'submitting a job under invalid user while plugin has data fails' '
 	test_must_fail flux python ${SUBMIT_AS} 9999 hostname > invalid_user.out 2>&1 &&
 	test_debug "cat invalid_user.out" &&
-	grep "flux-job: no bank found for user: 9999" invalid_user.out
+	grep "cannot find user/bank or user/default bank entry for uid: 9999" invalid_user.out
 '
 
 test_expect_success 'cancel running jobs' '


### PR DESCRIPTION
#### Background

There are now helper functions available for the plugin to make use of to help with lookups and access of the internal map for users and banks, but the plugin does not make use of them.

---

This PR adds a new standalone helper function to `association.cpp` called `get_association ()`, which is just a lookup function of accounting information for a user ID and an optional bank. On success, the address of the `Association` object in the plugin's internal map is returned. On failure (if the user ID cannot be found **or** a particular user ID/bank combination cannot be found), `nullptr` is returned.

A couple basic unit tests are also added for `get_association ()`.

I've also added a small commit that changes one of the parameters for a helper function that validates a queue for a given `Association` to expect the list of permissible queues for the `Association` instead of the entire object. Eventually, I think this might be better to move out of the plugin, but for the sake of keeping this PR's scope as narrow as possible, I'll save that for a later date. :-)

Finally, some basic cleanup of `job.validate` is added using this new standalone helper function, as well as some improvements to comment structure within the callback.
