### PR TITLE
plugin: move `split_string ()` out of plugin code

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -125,3 +125,18 @@ json_t* convert_map_to_json (std::map<int, std::map<std::string, Association>>
 
     return accounting_data;
 }
+
+
+void split_string_and_push_back (const char *list,
+                                 std::vector<std::string> &vec)
+{
+    std::stringstream s_stream;
+
+    s_stream << list; // create string stream from string
+
+    while (s_stream.good ()) {
+        std::string substr;
+        getline (s_stream, substr, ','); // get string delimited by comma
+        vec.push_back (substr);
+    }
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <string>
 #include <map>
 #include <iterator>
+#include <sstream>
 
 // all attributes are per-user/bank
 class Association {
@@ -56,5 +57,9 @@ Association* get_association (int userid,
 // iterate through the users map and construct a JSON object of each user/bank
 json_t* convert_map_to_json (std::map<int, std::map<std::string, Association>>
                                  &users);
+
+// split a list of items and add them to a vector in an Association object
+void split_string_and_push_back (const char *list,
+                                 std::vector<std::string> &vec);
 
 #endif // ACCOUNTING_H

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -375,7 +375,7 @@ static void rec_update_cb (flux_t *h,
 
         // split queues comma-delimited string and add it to b->queues vector
         b->queues.clear ();
-        split_string (queues, b);
+        split_string_and_push_back (queues, b->queues);
 
         users_def_bank[uid] = def_bank;
     }

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -326,7 +326,7 @@ static void rec_update_cb (flux_t *h,
                            const flux_msg_t *msg,
                            void *arg)
 {
-    char *bank, *def_bank, *queues = NULL;
+    char *bank, *def_bank, *assoc_queues = NULL;
     int uid, max_running_jobs, max_active_jobs = 0;
     double fshare = 0.0;
     json_t *data, *jtemp = NULL;
@@ -360,7 +360,7 @@ static void rec_update_cb (flux_t *h,
                             "fairshare", &fshare,
                             "max_running_jobs", &max_running_jobs,
                             "max_active_jobs", &max_active_jobs,
-                            "queues", &queues,
+                            "queues", &assoc_queues,
                             "active", &active) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
@@ -375,7 +375,7 @@ static void rec_update_cb (flux_t *h,
 
         // split queues comma-delimited string and add it to b->queues vector
         b->queues.clear ();
-        split_string_and_push_back (queues, b->queues);
+        split_string_and_push_back (assoc_queues, b->queues);
 
         users_def_bank[uid] = def_bank;
     }

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -113,10 +113,22 @@ static void test_get_association_no_default_bank ()
 }
 
 
+// ensure split_string_and_push_back () works with a list of items
+static void split_string_and_push_back_success ()
+{
+    const char *assoc_queues = "bronze,silver,gold";
+    std::vector<std::string> expected_queues = {"bronze", "silver", "gold"};
+
+    split_string_and_push_back (assoc_queues, users[1001]["bank_A"].queues);
+    ok (users[1001]["bank_A"].queues == expected_queues,
+        "split_string_and_push_back () works");
+}
+
+
 int main (int argc, char* argv[])
 {
     // declare the number of tests that we plan to run
-    plan (4);
+    plan (5);
 
     // add users to the test map
     initialize_map (users);
@@ -125,6 +137,7 @@ int main (int argc, char* argv[])
     test_get_association_success ();
     test_get_association_noexist ();
     test_get_association_no_default_bank ();
+    split_string_and_push_back_success ();
 
     // indicate we are done testing
     done_testing ();


### PR DESCRIPTION
#### Background

The `split_string ()` helper function can only accept a list of queues to parse when unpacking user/bank information from the
flux-accounting DB, but there will also exist a need in the future to be able to parse other string lists as well (e.g projects). Since both lists can be parsed the same way, this helper function should be expanded. Also, this helper function is specific to parsing flux-accounting data. It might make more sense to instead place this in `accounting.cpp`.

---

This PR moves the function definition out of the priority plugin code and into `accounting.cpp`. It also expands the `split_string ()` helper function to accept a general string list of items and renames it to `split_string_and_push_back ()`.

A unit test is also added for this function.