### PR TITLE
[WIP] plugin: improve `job.state.priority` callback

### DIFF
--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -57,7 +57,7 @@ test_expect_success 'submitting a job specifying an incorrect bank with no user 
 	jobid0=$(flux submit --setattr=system.bank=account4 -n1 sleep 60) &&
 	flux python fake_payload.py &&
 	flux job wait-event -v ${jobid0} exception > exception.test &&
-	grep "not a member of account4" exception.test
+	grep "cannot find user/bank or user/default bank entry for uid:" exception.test
 '
 
 test_expect_success 'unload and reload mf_priority.so' '


### PR DESCRIPTION
#### Background

Continuing the improvement process on the priority plugin. The callback for `job.state.priority` uses a manual lookup for associations in the case where we need to re-look up a user's accounting information, but accounting.cpp has a cleanly defined implementation of this now.

---

This PR reformats the `job.state.priority` callback to make use of the new external lookup function defined in `job.state.priority`. It improves some of the comments throughout the function and adds new ones. Finally, it adjusts the test that checks for an exception message in `job.state.priority` to account for the new message format (it matches the exception message in `job.validate`).