### PR TITLE
plugin: move flux-accounting-specific helper functions, remove unused ones

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -143,8 +143,8 @@ void split_string_and_push_back (const char *list,
 
 
 int get_queue_info (char *queue,
-                    std::vector<std::string> permissible_queues,
-                    std::map<std::string, struct queue_info> queues)
+                    const std::vector<std::string> &permissible_queues,
+                    const std::map<std::string, Queue> &queues)
 {
     if (queue != NULL) {
         // check #1) the queue passed in exists in the queues map;
@@ -163,7 +163,11 @@ int get_queue_info (char *queue,
             // the queue passed in is not valid for the association
             return INVALID_QUEUE;
 
-        return queues[queue].priority;
+        try {
+            return queues.at (queue).priority;
+        } catch (const std::out_of_range &e) {
+            return UNKNOWN_QUEUE;
+        }
     }
 
     // no queue was specified, so just use a default queue factor

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -146,31 +146,26 @@ int get_queue_info (char *queue,
                     std::vector<std::string> permissible_queues,
                     std::map<std::string, struct queue_info> queues)
 {
-    std::map<std::string, struct queue_info>::iterator q_it;
-
-    // make sure that if a queue is passed in, it is a valid queue for the
-    // user to run jobs in
     if (queue != NULL) {
         // check #1) the queue passed in exists in the queues map;
         // if the queue cannot be found, this means that flux-accounting
         // does not know about the queue, and thus should return a default
         // factor
-        q_it = queues.find (queue);
+        auto q_it = queues.find (queue);
         if (q_it == queues.end ())
             return UNKNOWN_QUEUE;
 
-        // check #2) the queue passed in is a valid option to pass for user
-        std::vector<std::string>::iterator vect_it;
-        vect_it = std::find (permissible_queues.begin (),
-                             permissible_queues.end (), queue);
-
+        // check #2) the queue passed in is valid for the association
+        auto vect_it = std::find (permissible_queues.begin (),
+                                  permissible_queues.end (),
+                                  queue);
         if (vect_it == permissible_queues.end ())
+            // the queue passed in is not valid for the association
             return INVALID_QUEUE;
-        else
-            // add priority associated with the passed in queue to bank_info
-            return queues[queue].priority;
-    } else {
-        // no queue was specified, so just use a default queue factor
-        return NO_QUEUE_SPECIFIED;
+
+        return queues[queue].priority;
     }
+
+    // no queue was specified, so just use a default queue factor
+    return NO_QUEUE_SPECIFIED;
 }

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -173,3 +173,17 @@ int get_queue_info (char *queue,
     // no queue was specified, so just use a default queue factor
     return NO_QUEUE_SPECIFIED;
 }
+
+
+bool check_map_for_dne_only (std::map<int, std::map<std::string, Association>>
+                               &users,
+                             std::map<int, std::string> &users_def_bank)
+{
+    for (const auto& entry : users) {
+        auto it = users_def_bank.find(entry.first);
+        if (it != users_def_bank.end() && it->second != "DNE")
+            return false;
+    }
+
+    return true;
+}

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -140,3 +140,37 @@ void split_string_and_push_back (const char *list,
         vec.push_back (substr);
     }
 }
+
+
+int get_queue_info (char *queue,
+                    std::vector<std::string> permissible_queues,
+                    std::map<std::string, struct queue_info> queues)
+{
+    std::map<std::string, struct queue_info>::iterator q_it;
+
+    // make sure that if a queue is passed in, it is a valid queue for the
+    // user to run jobs in
+    if (queue != NULL) {
+        // check #1) the queue passed in exists in the queues map;
+        // if the queue cannot be found, this means that flux-accounting
+        // does not know about the queue, and thus should return a default
+        // factor
+        q_it = queues.find (queue);
+        if (q_it == queues.end ())
+            return UNKNOWN_QUEUE;
+
+        // check #2) the queue passed in is a valid option to pass for user
+        std::vector<std::string>::iterator vect_it;
+        vect_it = std::find (permissible_queues.begin (),
+                             permissible_queues.end (), queue);
+
+        if (vect_it == permissible_queues.end ())
+            return INVALID_QUEUE;
+        else
+            // add priority associated with the passed in queue to bank_info
+            return queues[queue].priority;
+    } else {
+        // no queue was specified, so just use a default queue factor
+        return NO_QUEUE_SPECIFIED;
+    }
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -26,6 +26,7 @@ extern "C" {
 #include <map>
 #include <iterator>
 #include <sstream>
+#include <algorithm>
 
 // all attributes are per-user/bank
 class Association {
@@ -46,6 +47,25 @@ public:
     json_t* to_json () const;    // convert object to JSON string
 };
 
+// - UKNOWN_QUEUE: a queue is specified for a submitted job that flux-accounting
+// does not know about
+// - NO_QUEUE_SPECIFIED: no queue was specified for this job
+// - INVALID_QUEUE: the association does not have permission to run jobs under
+// this queue
+#define UNKNOWN_QUEUE 0
+#define NO_QUEUE_SPECIFIED 0
+#define INVALID_QUEUE -6
+
+// min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
+// currently used or enforced in this plugin, so their values have no
+// effect in queue limit enforcement.
+struct queue_info {
+    int min_nodes_per_job;
+    int max_nodes_per_job;
+    int max_time_per_job;
+    int priority;
+};
+
 // get an Association object that points to user/bank in the users map;
 // return nullptr on failure
 Association* get_association (int userid,
@@ -61,5 +81,11 @@ json_t* convert_map_to_json (std::map<int, std::map<std::string, Association>>
 // split a list of items and add them to a vector in an Association object
 void split_string_and_push_back (const char *list,
                                  std::vector<std::string> &vec);
+
+// validate a potentially passed-in queue by an association and return the
+// integer priority associated with the queue
+int get_queue_info (char *queue,
+                    std::vector<std::string> permissible_queues,
+                    std::map<std::string, struct queue_info> queues);
 
 #endif // ACCOUNTING_H

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -59,7 +59,8 @@ public:
 // min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
 // currently used or enforced in this plugin, so their values have no
 // effect in queue limit enforcement.
-struct queue_info {
+class Queue {
+public:
     int min_nodes_per_job;
     int max_nodes_per_job;
     int max_time_per_job;
@@ -85,7 +86,7 @@ void split_string_and_push_back (const char *list,
 // validate a potentially passed-in queue by an association and return the
 // integer priority associated with the queue
 int get_queue_info (char *queue,
-                    std::vector<std::string> permissible_queues,
-                    std::map<std::string, struct queue_info> queues);
+                    const std::vector<std::string> &permissible_queues,
+                    const std::map<std::string, Queue> &queues);
 
 #endif // ACCOUNTING_H

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -89,4 +89,11 @@ int get_queue_info (char *queue,
                     const std::vector<std::string> &permissible_queues,
                     const std::map<std::string, Queue> &queues);
 
+// check the contents of the users map to see if every user's bank is a
+// temporary "DNE" value; if it is, the plugin is still waiting on
+// flux-accounting data
+bool check_map_for_dne_only (std::map<int, std::map<std::string, Association>>
+                               &users,
+                             std::map<int, std::string> &users_def_bank);
+
 #endif // ACCOUNTING_H

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -104,23 +104,6 @@ int64_t priority_calculation (flux_plugin_t *p,
 }
 
 
-int check_queue_factor (flux_plugin_t *p,
-                        int queue_factor,
-                        char *queue,
-                        char *prefix = (char *) "")
-{
-    if (queue_factor == INVALID_QUEUE) {
-        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
-                                     "mf_priority", 0,
-                                     "%sQueue not valid for user: %s",
-                                     prefix, queue);
-        return -1;
-    }
-
-    return 0;
-}
-
-
 // Scan the users map and look at each user's default bank to see if any one
 // of them have a valid bank (i.e one that is not "DNE"; if any of the users do
 // do have a valid bank, it will return false)

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -38,7 +38,7 @@ extern "C" {
 #define BANK_INFO_MISSING 999
 
 std::map<int, std::map<std::string, Association>> users;
-std::map<std::string, struct queue_info> queues;
+std::map<std::string, Queue> queues;
 std::map<int, std::string> users_def_bank;
 
 /******************************************************************************
@@ -315,7 +315,7 @@ static void rec_q_cb (flux_t *h,
                             "priority", &priority) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
-        struct queue_info *q;
+        Queue *q;
         q = &queues[queue];
 
         q->min_nodes_per_job = min_nodes_per_job;

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -158,19 +158,6 @@ static int get_queue_info (char *queue,
 }
 
 
-static void split_string (char *queues, Association *b)
-{
-    std::stringstream s_stream;
-
-    s_stream << queues; // create string stream from string
-    while (s_stream.good ()) {
-        std::string substr;
-        getline (s_stream, substr, ','); // get string delimited by comma
-        b->queues.push_back (substr);
-    }
-}
-
-
 int check_queue_factor (flux_plugin_t *p,
                         int queue_factor,
                         char *queue,

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -104,25 +104,6 @@ int64_t priority_calculation (flux_plugin_t *p,
 }
 
 
-// Scan the users map and look at each user's default bank to see if any one
-// of them have a valid bank (i.e one that is not "DNE"; if any of the users do
-// do have a valid bank, it will return false)
-static bool check_map_for_dne_only ()
-{
-    // the users map iterated through in this for-loop, along with the
-    // users_def_bank map used to look up a user's default bank, are
-    // both global variables
-    for (const auto& entry : users) {
-        auto def_bank_it = users_def_bank.find(entry.first);
-        if (def_bank_it != users_def_bank.end() &&
-                def_bank_it->second != "DNE")
-            return false;
-    }
-
-    return true;
-}
-
-
 /*
  * Update the jobspec with the default bank the association used to
  * submit their job under.
@@ -383,7 +364,7 @@ static int priority_cb (flux_plugin_t *p,
                                               users,
                                               users_def_bank);
         if (assoc == nullptr) {
-            if (check_map_for_dne_only () == true)
+            if (check_map_for_dne_only (users, users_def_bank) == true)
                 // the plugin is still waiting on flux-accounting data to be
                 // loaded in; keep the job in PRIORITY
                 return flux_jobtap_priority_unavail (p, args);
@@ -531,7 +512,7 @@ static int validate_cb (flux_plugin_t *p,
         // the assocation could not be found in the plugin's internal map,
         // so perform a check to see if the map has any loaded
         // flux-accounting data before rejecting the job
-        bool only_dne_data = check_map_for_dne_only ();
+        bool only_dne_data = check_map_for_dne_only (users, users_def_bank);
 
         if (users.empty () || only_dne_data) {
             add_missing_bank_info (p, h, userid);

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -189,10 +189,35 @@ static void test_get_queue_info_invalid_queue ()
 }
 
 
+// ensure false is returned because we have valid flux-accounting data in map
+static void test_check_map_dne_false ()
+{
+    bool result = check_map_for_dne_only (users, users_def_bank);
+
+    ok (result == false, "valid flux-accounting data has been loaded");
+}
+
+
+// ensure true is returned because no flux-accounting data is loaded
+static void test_check_map_dne_true ()
+{
+    users.clear ();
+    users_def_bank.clear ();
+
+    Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {}, {}, 0, 1};
+    add_user_to_map (users, 9999, "DNE", tmp_user);
+    users_def_bank[9999] = "DNE";
+
+    bool result = check_map_for_dne_only (users, users_def_bank);
+
+    ok (result == true, "no flux-accounting data has been loaded");
+}
+
+
 int main (int argc, char* argv[])
 {
     // declare the number of tests that we plan to run
-    plan (9);
+    plan (11);
 
     // add users to the test map
     initialize_map (users);
@@ -208,6 +233,9 @@ int main (int argc, char* argv[])
     test_get_queue_info_no_queue_specified ();
     test_get_queue_info_unknown_queue ();
     test_get_queue_info_invalid_queue ();
+    test_check_map_dne_false ();
+    test_check_map_dne_true ();
+
     // indicate we are done testing
     done_testing ();
 

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -26,6 +26,8 @@ extern "C" {
 // define a test users map to run tests on
 std::map<int, std::map<std::string, Association>> users;
 std::map<int, std::string> users_def_bank;
+// define a test queues map
+std::map<std::string, Queue> queues;
 
 
 /*
@@ -67,6 +69,16 @@ void initialize_map (
 
     // purposely do not add user2 to the def_bank_map
     add_user_to_map (users, 1002, "bank_A", user2);
+}
+
+
+/*
+ * helper function to add test queues to the queues map
+ */
+void initialize_queues () {
+    queues["bronze"] = {0, 5, 60, 100};
+    queues["silver"] = {0, 5, 60, 200};
+    queues["gold"] = {0, 5, 60, 300};
 }
 
 
@@ -125,20 +137,77 @@ static void split_string_and_push_back_success ()
 }
 
 
+// ensure the correct priority factor is returned for a valid queue
+static void test_get_queue_info_success ()
+{
+    Association a = users[1001]["bank_A"];
+    a.queues = {"bronze", "silver"};
+    a.queue_factor = get_queue_info (const_cast<char *> ("bronze"),
+                                     a.queues,
+                                     queues);
+
+    ok (a.queue_factor == 100,
+        "get_queue_info () returns the associated priority on success");
+}
+
+
+// ensure NO_QUEUE_SPECIFIED is returned when queue is NULL
+static void test_get_queue_info_no_queue_specified ()
+{
+    Association a = users[1001]["bank_A"];
+    a.queue_factor = get_queue_info (NULL, a.queues, queues);
+
+    ok (a.queue_factor == NO_QUEUE_SPECIFIED,
+        "NO_QUEUE_SPECIFIED is returned when no queue is passed in");
+}
+
+
+// ensure UNKOWN_QUEUE is returned when an unrecognized queue is passed in
+static void test_get_queue_info_unknown_queue ()
+{
+    Association a = users[1001]["bank_A"];
+    a.queue_factor = get_queue_info (const_cast<char *> ("platinum"),
+                                     a.queues,
+                                     queues);
+
+    ok (a.queue_factor == UNKNOWN_QUEUE,
+        "UNKNOWN_QUEUE is returned when an unrecognized queue is passed in");
+}
+
+
+// ensure INVALID_QUEUE is returned when an unrecognized queue is passed in
+static void test_get_queue_info_invalid_queue ()
+{
+    Association a = users[1001]["bank_A"];
+    a.queues = {"bronze", "silver"};
+    a.queue_factor = get_queue_info (const_cast<char *> ("gold"),
+                                     a.queues,
+                                     queues);
+
+    ok (a.queue_factor == INVALID_QUEUE,
+        "INVALID_QUEUE is returned when an inaccessible queue is passed in");
+}
+
+
 int main (int argc, char* argv[])
 {
     // declare the number of tests that we plan to run
-    plan (5);
+    plan (9);
 
     // add users to the test map
     initialize_map (users);
+    // add queues to the test queues map
+    initialize_queues ();
 
     test_direct_map_access (users);
     test_get_association_success ();
     test_get_association_noexist ();
     test_get_association_no_default_bank ();
     split_string_and_push_back_success ();
-
+    test_get_queue_info_success ();
+    test_get_queue_info_no_queue_specified ();
+    test_get_queue_info_unknown_queue ();
+    test_get_queue_info_invalid_queue ();
     // indicate we are done testing
     done_testing ();
 

--- a/t/t1027-mf-priority-issue376.t
+++ b/t/t1027-mf-priority-issue376.t
@@ -54,6 +54,7 @@ test_expect_success 'submit job for testing' '
 
 test_expect_success 'update of duration of pending job works while at active jobs limit' '
 	flux update $jobid1 duration=1m &&
+	flux job wait-event -vt 10 $jobid1 priority &&
 	flux job eventlog $jobid1 \
 		| grep jobspec-update \
 		| grep duration=60


### PR DESCRIPTION
#### Background

Continuing to move/abstract things out of the plugin code and into `accounting.*`.

---

This PR moves the `get_queue_info` and `check_map_for_dne_only ()` definitions out of the plugin code and into the `accounting.*` files. It also converts the `struct queue_info` into a class `Queue` to match the structure of `class Association`.  It improves some of the comments in the `get_queue_info ()` function and cleans up a little bit of the `if-else` checks as well. Unit tests are also now added for the `get_queue_info ()` function.

A couple of unused helper functions previously defined in the plugin code `split_string ()` and `check_queue_factor ()` are also removed from the plugin code since they are no longer needed.

#### TODO

- [x] add unit tests for `check_map_for_dne_only ()`

Fixes #426