### PR TITLE
NEWS: add release notes for `v0.30.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+flux-accounting version 0.30.0 - 2024-03-04
+-------------------------------------------
+
+#### Fixes
+
+* plugin: improve callback for `job.validate` (#415)
+
+* plugin: move helper functions for `plugin.query` callback (#417)
+
+* plugin: move `split_string ()` out of plugin code (#418)
+
+* plugin: improve callback for `job.new` (#421)
+
+* plugin: improve `job.update/job.update...queue` callbacks (#423)
+
+* plugin: improve `job.state.priority` callback (#425)
+
+#### Features
+
+* plugin: add external `Association` class to be used in plugin (#412)
+
 flux-accounting version 0.29.0 - 2024-01-08
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.30.0`.

---

This PR adds some release notes. None of the currently open PRs are necessarily required to be landed before this can go in. I've set the release date to Monday, though, just in case. 👍 