### PR TITLE
plugin: move `flux_respond ()` to end of functions

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -263,9 +263,6 @@ static void rec_update_cb (flux_t *h,
         goto error;
     }
 
-    if (flux_respond (h, msg, NULL) < 0)
-        flux_log_error (h, "flux_respond");
-
     if (!data || !json_is_array (data)) {
         flux_log (h, LOG_ERR, "mf_priority: invalid bulk_update payload");
         goto error;
@@ -312,6 +309,8 @@ static void rec_update_cb (flux_t *h,
         users_def_bank[uid] = def_bank;
     }
 
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "flux_respond");
     return;
 error:
     flux_respond_error (h, msg, errno, flux_msg_last_error (msg));
@@ -336,9 +335,6 @@ static void rec_q_cb (flux_t *h,
         flux_log_error (h, "failed to unpack custom_priority.trigger msg");
         goto error;
     }
-
-    if (flux_respond (h, msg, NULL) < 0)
-        flux_log_error (h, "flux_respond");
 
     if (!data || !json_is_array (data)) {
         flux_log (h, LOG_ERR, "mf_priority: invalid queue info payload");
@@ -370,6 +366,8 @@ static void rec_q_cb (flux_t *h,
         q->priority = priority;
     }
 
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "flux_respond");
     return;
 error:
     flux_respond_error (h, msg, errno, flux_msg_last_error (msg));


### PR DESCRIPTION
#### Problem

There are a couple callbacks in the plugin that call `flux_respond ()` before they are done processing.

---

This PR moves these calls to just before the functions call `return`.