### PR TITLE
t: add `active` column, move sample payloads

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -102,7 +102,12 @@ EXTRA_DIST= \
 	expected/job_usage/post_update1.expected \
 	expected/job_usage/post_update2.expected \
 	expected/plugin_state/internal_state_1.expected \
-	expected/plugin_state/internal_state_3.expected
+	expected/plugin_state/internal_state_3.expected \
+	expected/plugin_state/internal_state_3.expected \
+	expected/sample_payloads/same_fairshare.json \
+	expected/sample_payloads/small_no_tie.json \
+	expected/sample_payloads/small_tie_all.json \
+	expected/sample_payloads/small_tie.json
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output

--- a/t/expected/sample_payloads/same_fairshare.json
+++ b/t/expected/sample_payloads/same_fairshare.json
@@ -1,0 +1,75 @@
+{
+    "data" : [
+      {
+        "userid": 5011,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5012,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5013,
+        "bank": "account1",
+        "def_bank":
+        "account1",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5021,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5022,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5031,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5032,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      }
+    ]
+}

--- a/t/expected/sample_payloads/small_no_tie.json
+++ b/t/expected/sample_payloads/small_no_tie.json
@@ -1,0 +1,74 @@
+{
+    "data" : [
+      {
+        "userid": 5011,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.285714,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5012,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.142857,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5013,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.428571,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5021,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.714286,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5022,
+        "bank": "account2", 
+        "def_bank": "account2",
+        "fairshare": 0.571429,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5031,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 1.0,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5032,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 0.857143,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      }
+    ]
+}

--- a/t/expected/sample_payloads/small_tie.json
+++ b/t/expected/sample_payloads/small_tie.json
@@ -1,0 +1,84 @@
+{
+    "data" : [
+      {
+        "userid": 5011,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5012,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5013,
+        "bank": "account1",
+        "def_bank": "account1",
+        "fairshare": 0.75,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5021,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5022,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.5,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5023,
+        "bank": "account2",
+        "def_bank": "account2",
+        "fairshare": 0.75,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5031,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 1.0,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      },
+      {
+        "userid": 5032,
+        "bank": "account3",
+        "def_bank": "account3",
+        "fairshare": 0.875,
+        "max_running_jobs": 5,
+        "max_active_jobs": 7,
+        "queues": "",
+        "active": 1
+      }
+    ]
+}

--- a/t/expected/sample_payloads/small_tie_all.json
+++ b/t/expected/sample_payloads/small_tie_all.json
@@ -1,0 +1,94 @@
+{
+    "data" : [
+        {
+          "userid": 5011,
+          "bank": "account1",
+          "def_bank": "account1",
+          "fairshare": 0.666667,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5012,
+          "bank": "account1",
+          "def_bank": "account1",
+          "fairshare": 0.666667,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5013,
+          "bank": "account1",
+          "def_bank": "account1",
+          "fairshare": 1,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5021,
+          "bank": "account2",
+          "def_bank": "account2",
+          "fairshare": 0.666667,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5022,
+          "bank": "account2",
+          "def_bank": "account2",
+          "fairshare": 0.666667,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5023,
+          "bank": "account2",
+          "def_bank": "account2",
+          "fairshare": 1,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5031,
+          "bank": "account3",
+          "def_bank": "account3",
+          "fairshare": 0.666667,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5032,
+          "bank": "account3",
+          "def_bank": "account3",
+          "fairshare": 0.666667,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        },
+        {
+          "userid": 5033,
+          "bank": "account3",
+          "def_bank": "account3",
+          "fairshare": 1,
+          "max_running_jobs": 5,
+          "max_active_jobs": 7,
+          "queues": "",
+          "active": 1
+        }
+    ]
+}

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -6,6 +6,7 @@ test_description='Test multi-factor priority plugin order with no ties'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+SMALL_NO_TIE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_no_tie.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
@@ -21,24 +22,8 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create a group of users with unique fairshare values' '
-	cat <<-EOF >fake_small_no_tie.json
-	{
-		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.285714, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.142857, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.428571, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.714286, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.571429, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.857143, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
-		]
-	}
-	EOF
-'
-
 test_expect_success 'send the user information to the plugin' '
-	flux python ${SEND_PAYLOAD} fake_small_no_tie.json
+	flux python ${SEND_PAYLOAD} ${SMALL_NO_TIE}
 '
 
 test_expect_success 'add a default queue and send it to the plugin' '

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -6,6 +6,7 @@ test_description='Test multi-factor priority plugin with some ties'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+SMALL_TIE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_tie.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
@@ -21,25 +22,8 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create a group of users with some ties in fairshare values' '
-	cat <<-EOF >fake_small_tie.json
-	{
-		"data" : [
-			{"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.5, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 0.75, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 1.0, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-			{"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.875, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
-		]
-	}
-	EOF
-'
-
 test_expect_success 'send the user information to the plugin' '
-	flux python ${SEND_PAYLOAD} fake_small_tie.json
+	flux python ${SEND_PAYLOAD} ${SMALL_TIE}
 '
 
 test_expect_success 'add a default queue and send it to the plugin' '

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -6,6 +6,7 @@ test_description='Test multi-factor priority plugin with many ties'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
+SMALL_TIE_ALL=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_tie_all.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
@@ -21,26 +22,8 @@ test_expect_success 'check that mf_priority plugin is loaded' '
 	flux jobtap list | grep mf_priority
 '
 
-test_expect_success 'create a group of users with many ties in fairshare values' '
-	cat <<-EOF >fake_small_tie_all.json
-	{
-	    "data" : [
-	        {"userid": 5011, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5012, "bank": "account1", "def_bank": "account1", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5013, "bank": "account1", "def_bank": "account1", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5021, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5022, "bank": "account2", "def_bank": "account2", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5023, "bank": "account2", "def_bank": "account2", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5031, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5032, "bank": "account3", "def_bank": "account3", "fairshare": 0.666667, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""},
-	        {"userid": 5033, "bank": "account3", "def_bank": "account3", "fairshare": 1, "max_running_jobs": 5, "max_active_jobs": 7, "queues": ""}
-	    ]
-	}
-	EOF
-'
-
 test_expect_success 'send the user information to the plugin' '
-	flux python ${SEND_PAYLOAD} fake_small_tie_all.json
+	flux python ${SEND_PAYLOAD} ${SMALL_TIE_ALL}
 '
 
 test_expect_success 'add a default queue and send it to the plugin' '


### PR DESCRIPTION
#### Problem(s)

Some sharness tests in flux-accounting's testsuite don't contain the `active` column in the payloads that get sent to the priority plugin.

These sample payloads are starting to grow very large because they have a lot of fields per-user, and they clog up the test files.

---

This PR adds the `active` column to the key-value pairs of the test payloads that get sent to the priority plugin in the sharness tests.

It also moves these key-value pairs to separate JSON files that get loaded into their respective test files instead of creating them within the test directly.