### PR TITLE
`t1029`: remove brackets from `grep` tests

### DIFF
--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -55,7 +55,7 @@ test_expect_success 'add user to flux-accounting DB and update plugin' '
 test_expect_success 'check that bank was added to jobspec' '
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
-	grep "{\"attributes.system.bank\":\"account1\"}" eventlog.out &&
+	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
 	flux job cancel $jobid
 '
 
@@ -75,7 +75,7 @@ test_expect_success 'successfully submit a job under a default bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
-	grep "{\"attributes.system.bank\":\"account1\"}" eventlog.out &&
+	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
 	flux job cancel $jobid
 '
 
@@ -88,7 +88,7 @@ test_expect_success 'successfully submit a job under the new default bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
-	grep "{\"attributes.system.bank\":\"account2\"}" eventlog.out &&
+	grep "\"attributes.system.bank\":\"account2\"" eventlog.out &&
 	flux job cancel $jobid
 '
 


### PR DESCRIPTION
_was working on re-implementing project support in the plugin and noticed this commit that could be broken off_

#### Problem

The priority jobtap plugin will soon support `jobspec-update`s of both banks and projects, and the `jobspec-update` event in the eventlog holds both of these updates on one line, which breaks the assumption in `t1029-mf-priority-default-bank.t` that the `jobspec-update` of a user's default bank will be surrounded by brackets `{}`.

---

Remove the outer brackets from the tests in `t1029-mf-priority-default-bank.t` that `grep` for a certain bank.