### PR TITLE
plugin: add project information to Association information in plugin

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -187,3 +187,23 @@ bool check_map_for_dne_only (std::map<int, std::map<std::string, Association>>
 
     return true;
 }
+
+
+int get_project_info (const char *project,
+                      std::vector<std::string> &permissible_projects,
+                      std::vector<std::string> projects)
+{
+    auto it = std::find (projects.begin (), projects.end (), project);
+    if (it == projects.end ())
+        // project is unknown to flux-accounting
+        return UNKNOWN_PROJECT;
+
+    it = std::find (permissible_projects.begin (),
+                    permissible_projects.end (),
+                    project);
+    if (it == permissible_projects.end ())
+        // association doesn't have access to submit jobs under this project
+        return INVALID_PROJECT;
+
+    return 0;
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -32,16 +32,18 @@ extern "C" {
 class Association {
 public:
     // attributes
-    std::string bank_name;           // name of bank
-    double fairshare;                // fair share value
-    int max_run_jobs;                // max number of running jobs
-    int cur_run_jobs;                // current number of running jobs 
-    int max_active_jobs;             // max number of active jobs
-    int cur_active_jobs;             // current number of active jobs
-    std::vector<long int> held_jobs; // list of currently held job ID's
-    std::vector<std::string> queues; // list of accessible queues
-    int queue_factor;                // priority factor associated with queue
-    int active;                      // active status
+    std::string bank_name;             // name of bank
+    double fairshare;                  // fair share value
+    int max_run_jobs;                  // max number of running jobs
+    int cur_run_jobs;                  // current number of running jobs
+    int max_active_jobs;               // max number of active jobs
+    int cur_active_jobs;               // current number of active jobs
+    std::vector<long int> held_jobs;   // list of currently held job ID's
+    std::vector<std::string> queues;   // list of accessible queues
+    int queue_factor;                  // priority factor associated with queue
+    int active;                        // active status
+    std::vector<std::string> projects; // list of accessible projects
+    std::string def_project;           // default project
 
     // methods
     json_t* to_json () const;    // convert object to JSON string

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -58,6 +58,12 @@ public:
 #define NO_QUEUE_SPECIFIED 0
 #define INVALID_QUEUE -6
 
+// - UNKNOWN_PROJECT: a project that flux-accounting doesn't know about
+// - INVALID_PROJECT: a project that the association doesn't have permission
+// to charge jobs under
+#define UNKNOWN_PROJECT -6
+#define INVALID_PROJECT -7
+
 // min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
 // currently used or enforced in this plugin, so their values have no
 // effect in queue limit enforcement.
@@ -97,5 +103,10 @@ int get_queue_info (char *queue,
 bool check_map_for_dne_only (std::map<int, std::map<std::string, Association>>
                                &users,
                              std::map<int, std::string> &users_def_bank);
+
+// validate a potentially passed-in project by an association
+int get_project_info (const char *project,
+                      std::vector<std::string> &permissible_projects,
+                      std::vector<std::string> projects);
 
 #endif // ACCOUNTING_H

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1060,9 +1060,9 @@ static const struct flux_plugin_handler tab[] = {
 extern "C" int flux_plugin_init (flux_plugin_t *p)
 {
     if (flux_plugin_register (p, "mf_priority", tab) < 0
-        || flux_jobtap_service_register (p, "rec_update", rec_update_cb, p)
-        || flux_jobtap_service_register (p, "reprioritize", reprior_cb, p)
-        || flux_jobtap_service_register (p, "rec_q_update", rec_q_cb, p)
+        || flux_jobtap_service_register (p, "rec_update", rec_update_cb, p) < 0
+        || flux_jobtap_service_register (p, "reprioritize", reprior_cb, p) < 0
+        || flux_jobtap_service_register (p, "rec_q_update", rec_q_cb, p) < 0
         || flux_jobtap_service_register (p, "rec_proj_update", rec_proj_cb, p)
         < 0)
         return -1;

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -50,7 +50,9 @@ void add_user_to_map (
         a.held_jobs,
         a.queues,
         a.queue_factor,
-        a.active
+        a.active,
+        a.projects,
+        a.def_project
     };
 }
 
@@ -61,8 +63,8 @@ void add_user_to_map (
 void initialize_map (
     std::map<int, std::map<std::string, Association>> &users)
 {
-    Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {}, {}, 0, 1};
-    Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {}, {}, 0, 1};
+    Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {}, {}, 0, 1, {"*"}, "*"};
+    Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {}, {}, 0, 1, {"*"}, "*"};
 
     add_user_to_map (users, 1001, "bank_A", user1);
     users_def_bank[1001] = "bank_A";
@@ -204,7 +206,7 @@ static void test_check_map_dne_true ()
     users.clear ();
     users_def_bank.clear ();
 
-    Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {}, {}, 0, 1};
+    Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {}, {}, 0, 1, {"*"}, "*"};
     add_user_to_map (users, 9999, "DNE", tmp_user);
     users_def_bank[9999] = "DNE";
 

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -28,6 +28,8 @@ std::map<int, std::map<std::string, Association>> users;
 std::map<int, std::string> users_def_bank;
 // define a test queues map
 std::map<std::string, Queue> queues;
+// define a vector of chargeable projects
+std::vector<std::string> projects;
 
 
 /*
@@ -81,6 +83,17 @@ void initialize_queues () {
     queues["bronze"] = {0, 5, 60, 100};
     queues["silver"] = {0, 5, 60, 200};
     queues["gold"] = {0, 5, 60, 300};
+}
+
+
+/*
+ * helper function to add test projects to the projects vector
+ */
+void initialize_projects () {
+    projects.push_back ("*");
+    projects.push_back ("A");
+    projects.push_back ("B");
+    projects.push_back ("C");
 }
 
 
@@ -191,6 +204,54 @@ static void test_get_queue_info_invalid_queue ()
 }
 
 
+// ensure user has access to a default project
+static void test_get_project_info_success_default ()
+{
+    Association a = users[1001]["bank_A"];
+    const char *p = "*";
+    int result = get_project_info (p, a.projects, projects);
+
+    ok (result == 0, "association has access to default project");
+}
+
+
+// ensure we can access projects that we add to an association
+static void test_get_project_info_success_specified ()
+{
+    Association a = users[1001]["bank_A"];
+    a.projects = {"*", "A"};
+    const char *p = "A";
+
+    int result = get_project_info (p, a.projects, projects);
+
+    ok (result == 0, "association has access to a specified project");
+}
+
+
+// ensure UNKNOWN_PROJECT is returned when an unrecognized project is passed in
+static void test_get_project_info_unknown_project ()
+{
+    Association a = users[1001]["bank_A"];
+    const char *p = "foo";
+    int result = get_project_info (p, a.projects, projects);
+
+    ok (result == UNKNOWN_PROJECT,
+        "UNKNOWN_PROJECT is returned when an unrecognized project is passed in");
+}
+
+
+// ensure INVALID_PROJECT is returned when an invalid project is passed in
+static void test_get_project_info_invalid_project ()
+{
+    Association a = users[1001]["bank_A"];
+    const char *p = "B";
+    int result = get_project_info (p, a.projects, projects);
+
+    ok (result == INVALID_PROJECT,
+        "INVALID_PROJECT is returned when an inaccessible project is passed in");
+}
+
+
 // ensure false is returned because we have valid flux-accounting data in map
 static void test_check_map_dne_false ()
 {
@@ -219,12 +280,14 @@ static void test_check_map_dne_true ()
 int main (int argc, char* argv[])
 {
     // declare the number of tests that we plan to run
-    plan (11);
+    plan (15);
 
     // add users to the test map
     initialize_map (users);
     // add queues to the test queues map
     initialize_queues ();
+    // add projects to the test projects vector
+    initialize_projects ();
 
     test_direct_map_access (users);
     test_get_association_success ();
@@ -235,6 +298,10 @@ int main (int argc, char* argv[])
     test_get_queue_info_no_queue_specified ();
     test_get_queue_info_unknown_queue ();
     test_get_queue_info_invalid_queue ();
+    test_get_project_info_success_default ();
+    test_get_project_info_success_specified ();
+    test_get_project_info_unknown_project ();
+    test_get_project_info_invalid_project ();
     test_check_map_dne_false ();
     test_check_map_dne_true ();
 

--- a/t/expected/sample_payloads/same_fairshare.json
+++ b/t/expected/sample_payloads/same_fairshare.json
@@ -8,7 +8,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5012,
@@ -18,7 +20,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5013,
@@ -29,7 +33,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5021,
@@ -39,7 +45,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5022,
@@ -49,7 +57,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5031,
@@ -59,7 +69,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5032,
@@ -69,7 +81,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       }
     ]
 }

--- a/t/expected/sample_payloads/small_no_tie.json
+++ b/t/expected/sample_payloads/small_no_tie.json
@@ -8,7 +8,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5012,
@@ -18,7 +20,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5013,
@@ -28,7 +32,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5021,
@@ -38,7 +44,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5022,
@@ -48,7 +56,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5031,
@@ -58,7 +68,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5032,
@@ -68,7 +80,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       }
     ]
 }

--- a/t/expected/sample_payloads/small_tie.json
+++ b/t/expected/sample_payloads/small_tie.json
@@ -8,7 +8,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5012,
@@ -18,7 +20,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5013,
@@ -28,7 +32,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5021,
@@ -38,7 +44,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5022,
@@ -48,7 +56,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5023,
@@ -58,7 +68,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5031,
@@ -68,7 +80,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       },
       {
         "userid": 5032,
@@ -78,7 +92,9 @@
         "max_running_jobs": 5,
         "max_active_jobs": 7,
         "queues": "",
-        "active": 1
+        "active": 1,
+        "projects": "*",
+        "def_project": "*"
       }
     ]
 }

--- a/t/expected/sample_payloads/small_tie_all.json
+++ b/t/expected/sample_payloads/small_tie_all.json
@@ -8,7 +8,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5012,
@@ -18,7 +20,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5013,
@@ -28,7 +32,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5021,
@@ -38,7 +44,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5022,
@@ -48,7 +56,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5023,
@@ -58,7 +68,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5031,
@@ -68,7 +80,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5032,
@@ -78,7 +92,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         },
         {
           "userid": 5033,
@@ -88,7 +104,9 @@
           "max_running_jobs": 5,
           "max_active_jobs": 7,
           "queues": "",
-          "active": 1
+          "active": 1,
+          "projects": "*",
+          "def_project": "*"
         }
     ]
 }

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -51,7 +51,10 @@ test_expect_success 'create fake_payload.py' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 10,
 				"max_active_jobs": 12,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			},
 			{
 				"userid": userid,
@@ -60,7 +63,10 @@ test_expect_success 'create fake_payload.py' '
 				"fairshare": 0.11345,
 				"max_running_jobs": 10,
 				"max_active_jobs": 12,
-				"queues": "standby"
+				"queues": "standby",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -167,7 +173,10 @@ test_expect_success 'pass special key to user/bank struct to nullify information
 				"fairshare": 0.45321,
 				"max_running_jobs": -1,
 				"max_active_jobs": 12,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -195,7 +204,10 @@ test_expect_success 'resend user/bank information with valid data and successful
 				"fairshare": 0.45321,
 				"max_running_jobs": 2,
 				"max_active_jobs": 4,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -32,7 +32,10 @@ test_expect_success 'create fake_user.json' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 2,
 				"max_active_jobs": 4,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			},
 			{
 				"userid": 5011,
@@ -41,7 +44,10 @@ test_expect_success 'create fake_user.json' '
 				"fairshare": 0.11345,
 				"max_running_jobs": 1,
 				"max_active_jobs": 2,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -123,7 +129,10 @@ test_expect_success 'increase the max jobs count of the user' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 3,
 				"max_active_jobs": 4,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -172,7 +181,10 @@ test_expect_success 'update max_active_jobs limit' '
 				"fairshare": 0.45321,
 				"max_running_jobs": 3,
 				"max_active_jobs": 5,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}
@@ -229,7 +241,10 @@ test_expect_success 'create another user with the same limits in multiple banks'
 				"fairshare": 0.45321,
 				"max_running_jobs": 1,
 				"max_active_jobs": 2,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			},
 			{
 				"userid": 5012,
@@ -238,7 +253,10 @@ test_expect_success 'create another user with the same limits in multiple banks'
 				"fairshare": 0.11345,
 				"max_running_jobs": 1,
 				"max_active_jobs": 2,
-				"queues": ""
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -32,8 +32,30 @@ test_expect_success 'create fake_payload.py' '
 	# create an array of JSON payloads
 	bulk_update_data = {
 		"data" : [
-			{"userid": userid, "bank": "account3", "def_bank": "account3", "fairshare": 0.45321, "max_running_jobs": 1, "max_active_jobs": 3},
-			{"userid": userid, "bank": "account2", "def_bank": "account3", "fairshare": 0.11345, "max_running_jobs": 1, "max_active_jobs": 3}
+			{
+				"userid": userid,
+				"bank": "account3",
+				"def_bank": "account3",
+				"fairshare": 0.45321,
+				"max_running_jobs": 1,
+				"max_active_jobs": 3,
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
+			},
+			{
+				"userid": userid,
+				"bank": "account2",
+				"def_bank": "account3",
+				"fairshare": 0.11345,
+				"max_running_jobs": 1,
+				"max_active_jobs": 3,
+				"queues": "",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
+			}
 		]
 	}
 	flux.Flux().rpc("job-manager.mf_priority.rec_update", json.dumps(bulk_update_data)).get()

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -63,7 +63,10 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 				"fairshare": 0.45321,
 				"max_running_jobs": 10,
 				"max_active_jobs": 12,
-				"queues": "standby,special"
+				"queues": "standby,special",
+				"active": 1,
+				"projects": "*",
+				"def_project": "*"
 			}
 		]
 	}


### PR DESCRIPTION
#### Background

flux-accounting has the ability to define and list projects for associations in the database, but the plugin does not know about or interact with them. Eventually, the plugin will need to support associating jobs with projects. This is the first step to getting there.

---

This PR looks to start the process of adding project support to the priority plugin by just adding project information to the flux-accounting information that gets sent from the database to the plugin. Each `Association` object now has two new member fields: `projects` and  `def_project`, fields to store their list of projects and their default project, respectively. This info, along with the list of all registered projects, is sent and unpacked and stored in the plugin. At the moment, it is not utilized anywhere in the plugin, it is simply just unpacked and added to each `Association` object. Future PRs will look to integrate actual support for associating jobs with projects.

The other piece of this PR is to add a helper function to `accounting.cpp` to help validate projects for a given association. The plan with this function is to use it when validating a job that charges a certain project. Unit tests are also added for this helper function.