### PR TITLE
`plugin.query`: add projects, def_project to the information returned

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -67,8 +67,26 @@ json_t* Association::to_json () const
         }
     }
 
+    json_t *user_projects = json_array ();
+    if (!user_projects) {
+        json_decref (held_job_ids);
+        json_decref (user_queues);
+        return nullptr;
+    }
+    for (const auto &project : projects) {
+        json_t *temp;
+        if (!(temp = json_string (project.c_str ()))
+            || json_array_append_new (user_projects, temp) < 0) {
+            json_decref (held_job_ids);
+            json_decref (user_queues);
+            json_decref (user_projects);
+            return nullptr;
+        }
+    }
+
     // 'o' steals the reference for both held_job_ids and user_queues
-    json_t *u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i, s:o, s:o, s:i, s:i}",
+    json_t *u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i,"
+                           " s:o, s:o, s:i, s:o, s:s, s:i}",
                            "bank_name", bank_name.c_str (),
                            "fairshare", fairshare,
                            "max_run_jobs", max_run_jobs,
@@ -78,6 +96,8 @@ json_t* Association::to_json () const
                            "held_jobs", held_job_ids,
                            "queues", user_queues,
                            "queue_factor", queue_factor,
+                           "projects", user_projects,
+                           "def_project", def_project.c_str (),
                            "active", active);
 
     if (!u)

--- a/t/expected/plugin_state/internal_state_1.expected
+++ b/t/expected/plugin_state/internal_state_1.expected
@@ -14,6 +14,10 @@
           ""
         ],
         "queue_factor": 0,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*",
         "active": 1
       },
       {
@@ -28,6 +32,10 @@
           ""
         ],
         "queue_factor": 0,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*",
         "active": 1
       }
     ]

--- a/t/expected/plugin_state/internal_state_3.expected
+++ b/t/expected/plugin_state/internal_state_3.expected
@@ -14,6 +14,10 @@
           ""
         ],
         "queue_factor": 0,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*",
         "active": 1
       },
       {
@@ -28,6 +32,10 @@
           ""
         ],
         "queue_factor": 0,
+        "projects": [
+          "*"
+        ],
+        "def_project": "*",
         "active": 1
       }
     ]
@@ -47,6 +55,12 @@
           "bronze"
         ],
         "queue_factor": 0,
+        "projects": [
+          "A",
+          "B",
+          "*"
+        ],
+        "def_project": "A",
         "active": 1
       }
     ]

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -50,6 +50,11 @@ test_expect_success 'add some queues to the DB' '
 	flux account add-queue gold --priority=300
 '
 
+test_expect_success 'add some projects to the DB' '
+	flux account add-project A &&
+	flux account add-project B
+'
+
 test_expect_success 'add a user with two different banks to the DB' '
 	flux account add-user --username=user1001 --userid=1001 --bank=account1 --max-running-jobs=2 &&
 	flux account add-user --username=user1001 --userid=1001 --bank=account2
@@ -86,7 +91,12 @@ test_expect_success 'cancel jobs' '
 '
 
 test_expect_success 'add another user to flux-accounting DB and send it to plugin' '
-	flux account add-user --username=user1002 --userid=1002 --bank=account3 --queues="bronze" &&
+	flux account add-user \
+		--username=user1002 \
+		--userid=1002 \
+		--bank=account3 \
+		--queues="bronze" \
+		--projects="A,B" &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 


### PR DESCRIPTION
#### Background

Projects and default project information is now sent to the plugin, but the project information for each association is not returned in the `plugin.query` callback.

---

This PR adds the `projects` and `def_project` fields to the list of information returned for each association in the `plugin.query` callback.

It also adds the `projects` and `def_project` key-value pairs to the expected files for `t1019-mf-priority-info-fetch.t`. It adds some projects to one of the associations in the test and ensures those projects show up when looking at the ouptut of the `plugin.query` callback.