### PR TITLE
plugin: add `max_nodes` as an attribute per-association in plugin

### DIFF
--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -77,7 +77,7 @@ def bulk_update(path):
     for row in cur.execute(
         """SELECT userid, bank, default_bank,
            fairshare, max_running_jobs, max_active_jobs,
-           queues, active, projects, default_project
+           queues, active, projects, default_project, max_nodes
            FROM association_table"""
     ):
         # create a JSON payload with the results of the query
@@ -92,6 +92,7 @@ def bulk_update(path):
             "active": int(row[7]),
             "projects": str(row[8]),
             "def_project": str(row[9]),
+            "max_nodes": int(row[10]),
         }
         bulk_user_data.append(single_user_data)
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -86,7 +86,7 @@ json_t* Association::to_json () const
 
     // 'o' steals the reference for both held_job_ids and user_queues
     json_t *u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i,"
-                           " s:o, s:o, s:i, s:o, s:s, s:i}",
+                           " s:o, s:o, s:i, s:o, s:s, s:i, s:i}",
                            "bank_name", bank_name.c_str (),
                            "fairshare", fairshare,
                            "max_run_jobs", max_run_jobs,
@@ -98,6 +98,7 @@ json_t* Association::to_json () const
                            "queue_factor", queue_factor,
                            "projects", user_projects,
                            "def_project", def_project.c_str (),
+                           "max_nodes", max_nodes,
                            "active", active);
 
     if (!u)

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -44,6 +44,7 @@ public:
     int active;                        // active status
     std::vector<std::string> projects; // list of accessible projects
     std::string def_project;           // default project
+    int max_nodes;                     // max num nodes across all running jobs
 
     // methods
     json_t* to_json () const;    // convert object to JSON string

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include <cinttypes>
 #include <vector>
 #include <sstream>
+#include <cstdint>
 
 // custom bank_info class file
 #include "accounting.hpp"
@@ -152,6 +153,7 @@ static void add_special_association (flux_plugin_t *p, flux_t *h, int userid)
     a->cur_active_jobs = 0;
     a->active = 1;
     a->held_jobs = std::vector<long int>();
+    a->max_nodes = INT16_MAX;
 
     if (flux_jobtap_job_aux_set (p,
                                  FLUX_JOBTAP_CURRENT_JOB,
@@ -207,7 +209,7 @@ static void rec_update_cb (flux_t *h,
                            void *arg)
 {
     char *bank, *def_bank, *assoc_queues, *assoc_projects, *def_project = NULL;
-    int uid, max_running_jobs, max_active_jobs = 0;
+    int uid, max_running_jobs, max_active_jobs, max_nodes = 0;
     double fshare = 0.0;
     json_t *data, *jtemp = NULL;
     json_error_t error;
@@ -234,7 +236,7 @@ static void rec_update_cb (flux_t *h,
 
         if (json_unpack_ex (el, &error, 0,
                             "{s:i, s:s, s:s, s:F, s:i,"
-                            " s:i, s:s, s:i, s:s, s:s}",
+                            " s:i, s:s, s:i, s:s, s:s, s:i}",
                             "userid", &uid,
                             "bank", &bank,
                             "def_bank", &def_bank,
@@ -244,7 +246,8 @@ static void rec_update_cb (flux_t *h,
                             "queues", &assoc_queues,
                             "active", &active,
                             "projects", &assoc_projects,
-                            "def_project", &def_project) < 0)
+                            "def_project", &def_project,
+                            "max_nodes", &max_nodes) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
         Association *b;
@@ -256,6 +259,7 @@ static void rec_update_cb (flux_t *h,
         b->max_active_jobs = max_active_jobs;
         b->active = active;
         b->def_project = def_project;
+        b->max_nodes = max_nodes;
 
         // split queues comma-delimited string and add it to b->queues vector
         b->queues.clear ();

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -54,7 +54,8 @@ void add_user_to_map (
         a.queue_factor,
         a.active,
         a.projects,
-        a.def_project
+        a.def_project,
+        a.max_nodes
     };
 }
 
@@ -65,8 +66,10 @@ void add_user_to_map (
 void initialize_map (
     std::map<int, std::map<std::string, Association>> &users)
 {
-    Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {}, {}, 0, 1, {"*"}, "*"};
-    Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {}, {}, 0, 1, {"*"}, "*"};
+    Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {},
+                         {}, 0, 1, {"*"}, "*", 2147483647};
+    Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {},
+                         {}, 0, 1, {"*"}, "*", 2147483647};
 
     add_user_to_map (users, 1001, "bank_A", user1);
     users_def_bank[1001] = "bank_A";
@@ -267,7 +270,8 @@ static void test_check_map_dne_true ()
     users.clear ();
     users_def_bank.clear ();
 
-    Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {}, {}, 0, 1, {"*"}, "*"};
+    Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {},
+                            {}, 0, 1, {"*"}, "*", 2147483647};
     add_user_to_map (users, 9999, "DNE", tmp_user);
     users_def_bank[9999] = "DNE";
 

--- a/t/expected/plugin_state/internal_state_1.expected
+++ b/t/expected/plugin_state/internal_state_1.expected
@@ -18,6 +18,7 @@
           "*"
         ],
         "def_project": "*",
+        "max_nodes": 2147483647,
         "active": 1
       },
       {
@@ -36,6 +37,7 @@
           "*"
         ],
         "def_project": "*",
+        "max_nodes": 2147483647,
         "active": 1
       }
     ]

--- a/t/expected/plugin_state/internal_state_3.expected
+++ b/t/expected/plugin_state/internal_state_3.expected
@@ -18,6 +18,7 @@
           "*"
         ],
         "def_project": "*",
+        "max_nodes": 2147483647,
         "active": 1
       },
       {
@@ -36,6 +37,7 @@
           "*"
         ],
         "def_project": "*",
+        "max_nodes": 2147483647,
         "active": 1
       }
     ]
@@ -61,6 +63,7 @@
           "*"
         ],
         "def_project": "A",
+        "max_nodes": 10,
         "active": 1
       }
     ]

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -96,7 +96,8 @@ test_expect_success 'add another user to flux-accounting DB and send it to plugi
 		--userid=1002 \
 		--bank=account3 \
 		--queues="bronze" \
-		--projects="A,B" &&
+		--projects="A,B" \
+		--max-nodes=10 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 


### PR DESCRIPTION
~~_note: will keep this as [WIP] until after the next flux-accounting release targeted for next week_~~

#### Background

As mentioned in #436, the priority plugin currently does not have any information about max nodes counts per-association, which it will need in order for it to enforce a max nodes limit. The limit already exists per-association in the flux-accounting DB, so it just needs to be added to the other info that is sent during an update.

---

This PR does just that - it adds `max_nodes` to the set of information that is sent per-association from the flux-accounting DB to the plugin. Adjustments to the `Association` class, the callback responsible for unpacking flux-accounting data, the callback responsible for returning loaded flux-accounting information (`plugin.query`), and appropriate tests are made to account for the addition of `max_nodes`.

This PR will set some of the groundwork needed to begin enforcing a `max_nodes` limit via the priority plugin.

Fixes #436