### PR TITLE
plugin: add node count tracking for an association's running jobs

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -10,4 +10,5 @@ jobtapdir = \
 jobtap_LTLIBRARIES = mf_priority.la
 mf_priority_la_SOURCES = mf_priority.cpp accounting.cpp
 mf_priority_la_CPPFLAGS = -I$(top_srcdir)/src/plugins
+mf_priority_la_LIBADD = $(FLUX_HOSTLIST_LIBS)
 mf_priority_la_LDFLAGS = $(fluxplugin_ldflags) -module

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -85,8 +85,8 @@ json_t* Association::to_json () const
     }
 
     // 'o' steals the reference for both held_job_ids and user_queues
-    json_t *u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i,"
-                           " s:o, s:o, s:i, s:o, s:s, s:i, s:i}",
+    json_t *u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i, s:o"
+                           " s:o, s:i, s:o, s:s, s:i, s:i, s:i}",
                            "bank_name", bank_name.c_str (),
                            "fairshare", fairshare,
                            "max_run_jobs", max_run_jobs,
@@ -99,6 +99,7 @@ json_t* Association::to_json () const
                            "projects", user_projects,
                            "def_project", def_project.c_str (),
                            "max_nodes", max_nodes,
+                           "cur_nodes", cur_nodes,
                            "active", active);
 
     if (!u)

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -45,6 +45,7 @@ public:
     std::vector<std::string> projects; // list of accessible projects
     std::string def_project;           // default project
     int max_nodes;                     // max num nodes across all running jobs
+    int cur_nodes;                     // cur num nodes across all running jobs
 
     // methods
     json_t* to_json () const;    // convert object to JSON string

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -154,6 +154,7 @@ static void add_special_association (flux_plugin_t *p, flux_t *h, int userid)
     a->active = 1;
     a->held_jobs = std::vector<long int>();
     a->max_nodes = INT16_MAX;
+    a->cur_nodes = 0;
 
     if (flux_jobtap_job_aux_set (p,
                                  FLUX_JOBTAP_CURRENT_JOB,

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -55,7 +55,8 @@ void add_user_to_map (
         a.active,
         a.projects,
         a.def_project,
-        a.max_nodes
+        a.max_nodes,
+        a.cur_nodes
     };
 }
 
@@ -67,9 +68,9 @@ void initialize_map (
     std::map<int, std::map<std::string, Association>> &users)
 {
     Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {},
-                         {}, 0, 1, {"*"}, "*", 2147483647};
+                         {}, 0, 1, {"*"}, "*", 2147483647, 0};
     Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {},
-                         {}, 0, 1, {"*"}, "*", 2147483647};
+                         {}, 0, 1, {"*"}, "*", 2147483647, 0};
 
     add_user_to_map (users, 1001, "bank_A", user1);
     users_def_bank[1001] = "bank_A";
@@ -271,7 +272,7 @@ static void test_check_map_dne_true ()
     users_def_bank.clear ();
 
     Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {},
-                            {}, 0, 1, {"*"}, "*", 2147483647};
+                            {}, 0, 1, {"*"}, "*", 2147483647, 0};
     add_user_to_map (users, 9999, "DNE", tmp_user);
     users_def_bank[9999] = "DNE";
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -35,6 +35,7 @@ TESTSCRIPTS = \
 	t1031-mf-priority-issue406.t \
 	t1032-mf-priority-update-bank.t \
 	t1033-mf-priority-update-job.t \
+	t1034-mf-priority-max-nodes.t \
 	t5000-valgrind.t \
 	python/t1000-example.py
 

--- a/t/expected/plugin_state/internal_state_1.expected
+++ b/t/expected/plugin_state/internal_state_1.expected
@@ -19,6 +19,7 @@
         ],
         "def_project": "*",
         "max_nodes": 2147483647,
+        "cur_nodes": 0,
         "active": 1
       },
       {
@@ -38,6 +39,7 @@
         ],
         "def_project": "*",
         "max_nodes": 2147483647,
+        "cur_nodes": 0,
         "active": 1
       }
     ]

--- a/t/expected/plugin_state/internal_state_3.expected
+++ b/t/expected/plugin_state/internal_state_3.expected
@@ -19,6 +19,7 @@
         ],
         "def_project": "*",
         "max_nodes": 2147483647,
+        "cur_nodes": 0,
         "active": 1
       },
       {
@@ -38,6 +39,7 @@
         ],
         "def_project": "*",
         "max_nodes": 2147483647,
+        "cur_nodes": 0,
         "active": 1
       }
     ]
@@ -64,6 +66,7 @@
         ],
         "def_project": "A",
         "max_nodes": 10,
+        "cur_nodes": 0,
         "active": 1
       }
     ]

--- a/t/t1034-mf-priority-max-nodes.t
+++ b/t/t1034-mf-priority-max-nodes.t
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+test_description='test tracking node counts for associations in the priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 5 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add a user to the DB' '
+	flux account add-user \
+		--username=user1 \
+		--userid=5001 \
+		--bank=A \
+		--max-nodes=5
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'submit a 1-node sleep job' '
+	job1=$(flux python ${SUBMIT_AS} 5001 -N1 sleep 60) &&
+	flux job wait-event -f json $job1 priority
+'
+
+test_expect_success 'check that association is using 1 node' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_nodes == 1" <query.json
+'
+
+test_expect_success 'cancel job' '
+	flux cancel $job1 &&
+	flux job wait-event -vt 10 $job1 clean
+'
+
+test_expect_success 'check that association is using 0 nodes after job cleans up' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_nodes == 0" <query.json
+'
+
+test_expect_success 'submit multiple jobs that use multiple nodes' '
+	job1=$(flux python ${SUBMIT_AS} 5001 -N2 sleep 60) &&
+	job2=$(flux python ${SUBMIT_AS} 5001 -N3 sleep 60) &&
+	flux job wait-event -f json $job1 priority &&
+	flux job wait-event -f json $job2 priority
+'
+
+test_expect_success 'check that association is using 5 nodes' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_nodes == 5" <query.json
+'
+
+test_expect_success 'cancel 1 job and check that cur_nodes == 3' '
+	flux cancel $job1 &&
+	flux job wait-event -vt 10 $job1 clean &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_nodes == 3" <query.json
+'
+
+test_expect_success 'cancel the other job and check that cur_nodes == 0' '
+	flux cancel $job2 &&
+	flux job wait-event -vt 10 $job2 clean &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".mf_priority_map[0].banks[0].cur_nodes == 0" <query.json
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Background

The priority plugin has no way to track the number of nodes an association is using across all of their running jobs.

---

This PR looks to add basic node count tracking to the priority plugin, specifically in the callbacks for `job.state.run` and `job.state.inactive`.

Two new helper functions are added to the plugin to help do this - `extract_nodelist ()` and `process_nodelist ()`. `extract_nodelist ()` will look for the `"nodelist"` key-value pair and `process_nodelist ()` will take that string and use flux-core's hostlist library to count the number of nodes. Then, the `cur_nodes` count for the association is incremented by the number of nodes returning by `process_nodelist ()`. A similar process is followed in the `job.state.inactive` callback where the number of nodes returned by `process_nodelist ()` is decremented from the association's total current nodes count.

A basic set of tests are also added to simulate submitting a couple of different-sized jobs and ensuring that the priority plugin can accurately keep track of them as they are submitted and finish running.

Note that this PR does not look to add actual enforcement of an association's `max_nodes` limit, but rather just looks to track the `cur_nodes` number for an association. Once this looks good, I can create a follow-up PR that tries to add the actual enforcement of a node count limit.