### PR TITLE
t: update descriptions of sharness tests

### DIFF
--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Tests for update-usage command'
+test_description='test fetching jobs and updating the fair share values for a group of users'
 
 . $(dirname $0)/sharness.sh
 

--- a/t/t1016-export-db.t
+++ b/t/t1016-export-db.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test flux-account commands'
+test_description='test exporting flux-accounting database data into .csv files'
 . `dirname $0`/sharness.sh
 
 DB_PATHv1=$(pwd)/FluxAccountingTestv1.db

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test submitting jobs to queues after queue access is changed'
+test_description='test handling jobs correctly with no or some flux-accounting data in plugin'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t1027-mf-priority-issue376.t
+++ b/t/t1027-mf-priority-issue376.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test submitting jobs to queues after queue access is changed'
+test_description='test updating attributes of a job with flux-accounting limits imposed'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-test_description='Test submitting jobs to queues after queue access is changed'
+test_description='test handling jobs when plugin only has temporary flux-accounting data'
 
 . `dirname $0`/sharness.sh
 


### PR DESCRIPTION
#### Problem

Some of the descriptions of the sharness tests in flux-accounting are misleading because they were copied over from another test file and were never updated.

---

This PR updates the descriptions of a number of the sharness tests.