### PR TITLE
job-archive interface: wrap job usage updates into a single SQL transaction

### DIFF
--- a/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/test/test_job_archive_interface.py
@@ -367,29 +367,10 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(usage_factor, 2199.5)
 
-    # calling update_job_usage() in the same half-life period should NOT
-    # update usage factors for users
-    @mock.patch("time.time", mock.MagicMock(return_value=(10000000 + (604799))))
-    def test_17_update_job_usage_same_half_life_period(self):
-        s_stmt = """
-            SELECT job_usage FROM association_table
-            WHERE username='1002' AND bank='C'
-            """
-
-        cur.execute(s_stmt)
-        job_usage = cur.fetchone()[0]
-        self.assertEqual(job_usage, 17044.0)
-
-        jobs.update_job_usage(acct_conn, pdhl=1)
-
-        cur.execute(s_stmt)
-        job_usage = cur.fetchone()[0]
-        self.assertEqual(job_usage, 17044.0)
-
     # simulate a half-life period further; assure the new end of the
     # current half-life period gets updated
     @mock.patch("time.time", mock.MagicMock(return_value=(10000000 + (604800 * 2.1))))
-    def test_18_update_end_half_life_period(self):
+    def test_17_update_end_half_life_period(self):
         # fetch timestamp of the end of the current half-life period
         s_end_hl = """
             SELECT end_half_life_period
@@ -408,7 +389,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # removing a user from the flux-accounting DB should NOT remove their job
     # usage history from the job_usage_factor_table
-    def test_19_keep_job_usage_records_upon_delete(self):
+    def test_18_keep_job_usage_records_upon_delete(self):
         u.delete_user(acct_conn, username="1001", bank="C")
 
         select_stmt = """

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -179,6 +179,16 @@ test_expect_success 'check that job usage and fairshare values get updated' '
 	grep "account2" post_update2.test | grep "4" | grep "0.5"
 '
 
+# if update-usage is called in the same half-life period when no jobs are found
+# for a user, their job usage factor should be affected; this test is taken
+# from the set of job-archive interface Python unit tests
+test_expect_success 'call update-usage in the same half-life period where no jobs are run' '
+	flux account -p ${DB_PATH} update-usage &&
+	flux account-update-fshare -p ${DB_PATH} &&
+	flux account-shares -p $(pwd)/FluxAccountingTest.db > post_update3.test &&
+	grep "account2" post_update3.test | grep "4" | grep "0.5"
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

When flux-accounting needs to do a job usage update for all of the associations in the `association_table`, it needs to make a number of updates to a number of tables in the DB. If there are a lot of associations, this can slow down the performance of a number of other, much simpler commands, such as `flux account view-user`. This is because the job usage updates makes a separate transaction for each UPDATE statement performed, forcing other reads from the DB to wait until the updates are completed.

---

This PR drops the separate `commit()` calls from the various helper functions that execute UPDATE statements in `job_archive_interface.py` and instead wraps the entire set of database updates into a single SQLite transaction, which will only be committed to the DB after all of the updates are done. This should hopefully begin to relieve some of the headache mentioned in #451.