### PR TITLE
database: update schema version

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -1,5 +1,5 @@
 db_dir = "@X_LOCALSTATEDIR@/lib/flux/"
 db_path = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
-db_schema_version = 21
+db_schema_version = 22
 
 __all__ = ["db_dir", "db_path", "db_schema_version"]


### PR DESCRIPTION
#### Problem

The schema version of the flux-accounting database was never updated with the addition of the jobs table in #357. As a result, when newer versions of flux-accounting are installed on a system, the automatic update of the database is never triggered by the background processes of flux-accounting.

---

This PR updates the schema version number of the flux-accounting database.