### PR TITLE
testsuite: replace `flux job cancel` --> `flux cancel`

### DIFF
--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -98,62 +98,62 @@ test_expect_success 'update plugin with sample test data' '
 
 test_expect_success 'submit a job with default urgency' '
 	jobid=$(flux submit --setattr=system.bank=account3 -n1 hostname) &&
-	flux job wait-event -f json $jobid priority | jq '.context.priority' > job1.test &&
+	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job1.test &&
 	cat <<-EOF >job1.expected &&
 	45321
 	EOF
 	test_cmp job1.expected job1.test &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit a job with custom urgency' '
 	jobid=$(flux submit --setattr=system.bank=account3 --urgency=15 -n1 hostname) &&
-	flux job wait-event -f json $jobid priority | jq '.context.priority' > job2.test &&
+	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	45320
 	EOF
 	test_cmp job2.expected job2.test &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit a job with urgency of 0' '
 	jobid=$(flux submit --setattr=system.bank=account3 --urgency=0 -n1 hostname) &&
-	flux job wait-event -f json $jobid priority | jq '.context.priority' > job3.test &&
+	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job3.test &&
 	cat <<-EOF >job3.expected &&
 	0
 	EOF
 	test_cmp job3.expected job3.test &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit a job with urgency of 31' '
 	jobid=$(flux submit --setattr=system.bank=account3 --urgency=31 -n1 hostname) &&
-	flux job wait-event -f json $jobid priority | jq '.context.priority' > job4.test &&
+	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job4.test &&
 	cat <<-EOF >job4.expected &&
 	4294967295
 	EOF
 	test_cmp job4.expected job4.test &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit a job with other bank' '
 	jobid=$(flux submit --setattr=system.bank=account2 -n1 hostname) &&
-	flux job wait-event -f json $jobid priority | jq '.context.priority' > job5.test &&
+	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job5.test &&
 	cat <<-EOF >job5.expected &&
 	11345
 	EOF
 	test_cmp job5.expected job5.test &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit a job using default bank' '
 	jobid=$(flux submit -n1 hostname) &&
-	flux job wait-event -f json $jobid priority | jq '.context.priority' > job6.test &&
+	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job6.test &&
 	cat <<-EOF >job6.expected &&
 	45321
 	EOF
 	test_cmp job6.expected job6.test &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit a job using a bank the user does not belong to' '
@@ -220,12 +220,12 @@ test_expect_success 'resend user/bank information with valid data and successful
 	EOF
 	flux python ${SEND_PAYLOAD} valid_info.json &&
 	jobid2=$(flux python ${SUBMIT_AS} 5011 sleep 10)
-	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
+	flux job wait-event -f json ${jobid2} priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	45321
 	EOF
 	test_cmp job2.expected job2.test &&
-	flux cancel $jobid2
+	flux cancel ${jobid2}
 '
 
 test_done

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -103,7 +103,7 @@ test_expect_success 'submit a job with default urgency' '
 	45321
 	EOF
 	test_cmp job1.expected job1.test &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit a job with custom urgency' '
@@ -113,7 +113,7 @@ test_expect_success 'submit a job with custom urgency' '
 	45320
 	EOF
 	test_cmp job2.expected job2.test &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit a job with urgency of 0' '
@@ -123,7 +123,7 @@ test_expect_success 'submit a job with urgency of 0' '
 	0
 	EOF
 	test_cmp job3.expected job3.test &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit a job with urgency of 31' '
@@ -133,7 +133,7 @@ test_expect_success 'submit a job with urgency of 31' '
 	4294967295
 	EOF
 	test_cmp job4.expected job4.test &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit a job with other bank' '
@@ -143,7 +143,7 @@ test_expect_success 'submit a job with other bank' '
 	11345
 	EOF
 	test_cmp job5.expected job5.test &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit a job using default bank' '
@@ -153,7 +153,7 @@ test_expect_success 'submit a job using default bank' '
 	45321
 	EOF
 	test_cmp job6.expected job6.test &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit a job using a bank the user does not belong to' '
@@ -225,7 +225,7 @@ test_expect_success 'resend user/bank information with valid data and successful
 	45321
 	EOF
 	test_cmp job2.expected job2.test &&
-	flux job cancel $jobid2
+	flux cancel $jobid2
 '
 
 test_done

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -94,14 +94,14 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	jobid3=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
-		$jobid3 dependency-add
+		${jobid3} dependency-add
 '
 
 test_expect_success 'a job transitioning to job.state.inactive should release a held job (if any)' '
-	flux cancel $jobid1 &&
-	flux job wait-event -vt 60 $jobid3 alloc &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid3
+	flux cancel ${jobid1} &&
+	flux job wait-event -vt 60 ${jobid3} alloc &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid3}
 '
 
 test_expect_success 'submit max number of jobs with other bank' '
@@ -112,9 +112,9 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	jobid2=$(flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account2 sleep 60) &&
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
-		$jobid2 dependency-add &&
-	flux cancel $jobid1 &&
-	flux cancel $jobid2
+		${jobid2} dependency-add &&
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2}
 '
 
 test_expect_success 'submit max number of jobs with a mix of default bank and explicity set bank' '
@@ -126,8 +126,8 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	jobid3=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
-		$jobid3 dependency-add &&
-	flux cancel $jobid3
+		${jobid3} dependency-add &&
+	flux cancel ${jobid3}
 '
 
 test_expect_success 'increase the max jobs count of the user' '
@@ -156,8 +156,8 @@ test_expect_success 'update plugin with same new sample test data' '
 '
 
 test_expect_success 'make sure jobs are still running' '
-	flux job wait-event -vt 10 $jobid1 alloc &&
-	flux job wait-event -vt 10 $jobid2 alloc
+	flux job wait-event -vt 10 ${jobid1} alloc &&
+	flux job wait-event -vt 10 ${jobid2} alloc
 '
 
 test_expect_success 'cancel all remaining jobs' '
@@ -176,10 +176,10 @@ test_expect_success '5th submitted job should be rejected because user has reach
 	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_active_jobs.out 2>&1 &&
 	test_debug "cat max_active_jobs.out" &&
 	grep "user has max active jobs" max_active_jobs.out &&
-	flux cancel $jobid1 &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid3 &&
-	flux cancel $jobid4
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid3} &&
+	flux cancel ${jobid4}
 '
 
 test_expect_success 'update max_active_jobs limit' '
@@ -222,12 +222,12 @@ test_expect_success '6th submitted job should be rejected because user has reach
 '
 
 test_expect_success 'cancel one of the active jobs' '
-	flux cancel $jobid5
+	flux cancel ${jobid5}
 '
 
 test_expect_success 'newly submitted job should now be accepted since user is under their max_active_jobs limit' '
 	jobid7=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
-	flux job wait-event -f json $jobid7 priority | jq '.context.priority' > job7.test &&
+	flux job wait-event -f json ${jobid7} priority | jq '.context.priority' > job7.test &&
 	cat <<-EOF >job7.expected &&
 	45321
 	EOF
@@ -235,11 +235,11 @@ test_expect_success 'newly submitted job should now be accepted since user is un
 '
 
 test_expect_success 'cancel all remaining active jobs' '
-	flux cancel $jobid1 &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid3 &&
-	flux cancel $jobid4 &&
-	flux cancel $jobid7
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid3} &&
+	flux cancel ${jobid4} &&
+	flux cancel ${jobid7}
 '
 
 test_expect_success 'create another user with the same limits in multiple banks' '
@@ -296,10 +296,10 @@ test_expect_success 'submitting a 3rd job under either bank should result in a j
 '
 
 test_expect_success 'cancel all remaining jobs' '
-	flux cancel $jobid1 &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid3 &&
-	flux cancel $jobid4
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid3} &&
+	flux cancel ${jobid4}
 '
 
 test_done

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -98,10 +98,10 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 '
 
 test_expect_success 'a job transitioning to job.state.inactive should release a held job (if any)' '
-	flux job cancel $jobid1 &&
+	flux cancel $jobid1 &&
 	flux job wait-event -vt 60 $jobid3 alloc &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid3
+	flux cancel $jobid2 &&
+	flux cancel $jobid3
 '
 
 test_expect_success 'submit max number of jobs with other bank' '
@@ -113,8 +113,8 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
 		$jobid2 dependency-add &&
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2
+	flux cancel $jobid1 &&
+	flux cancel $jobid2
 '
 
 test_expect_success 'submit max number of jobs with a mix of default bank and explicity set bank' '
@@ -127,7 +127,7 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
 		$jobid3 dependency-add &&
-	flux job cancel $jobid3
+	flux cancel $jobid3
 '
 
 test_expect_success 'increase the max jobs count of the user' '
@@ -161,8 +161,8 @@ test_expect_success 'make sure jobs are still running' '
 '
 
 test_expect_success 'cancel all remaining jobs' '
-	flux job cancel ${jobid1} &&
-	flux job cancel ${jobid2}
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2}
 '
 
 test_expect_success 'submit max number of jobs' '
@@ -176,10 +176,10 @@ test_expect_success '5th submitted job should be rejected because user has reach
 	test_must_fail flux python ${SUBMIT_AS} 5011 sleep 60 > max_active_jobs.out 2>&1 &&
 	test_debug "cat max_active_jobs.out" &&
 	grep "user has max active jobs" max_active_jobs.out &&
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid3 &&
-	flux job cancel $jobid4
+	flux cancel $jobid1 &&
+	flux cancel $jobid2 &&
+	flux cancel $jobid3 &&
+	flux cancel $jobid4
 '
 
 test_expect_success 'update max_active_jobs limit' '
@@ -222,7 +222,7 @@ test_expect_success '6th submitted job should be rejected because user has reach
 '
 
 test_expect_success 'cancel one of the active jobs' '
-	flux job cancel $jobid5
+	flux cancel $jobid5
 '
 
 test_expect_success 'newly submitted job should now be accepted since user is under their max_active_jobs limit' '
@@ -235,11 +235,11 @@ test_expect_success 'newly submitted job should now be accepted since user is un
 '
 
 test_expect_success 'cancel all remaining active jobs' '
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid3 &&
-	flux job cancel $jobid4 &&
-	flux job cancel $jobid7
+	flux cancel $jobid1 &&
+	flux cancel $jobid2 &&
+	flux cancel $jobid3 &&
+	flux cancel $jobid4 &&
+	flux cancel $jobid7
 '
 
 test_expect_success 'create another user with the same limits in multiple banks' '
@@ -296,10 +296,10 @@ test_expect_success 'submitting a 3rd job under either bank should result in a j
 '
 
 test_expect_success 'cancel all remaining jobs' '
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid3 &&
-	flux job cancel $jobid4
+	flux cancel $jobid1 &&
+	flux cancel $jobid2 &&
+	flux cancel $jobid3 &&
+	flux cancel $jobid4
 '
 
 test_done

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -86,9 +86,9 @@ test_expect_success 'load job-archive module' '
 
 test_expect_success 'submit a job that does not run' '
 	job=$(flux submit --urgency=0 sleep 60) &&
-	flux job wait-event -vt 10 $job priority &&
-	flux cancel $job &&
-	wait_db $job ${ARCHIVEDB}
+	flux job wait-event -vt 10 ${job} priority &&
+	flux cancel ${job} &&
+	wait_db ${job} ${ARCHIVEDB}
 '
 
 test_expect_success 'run scripts to update job usage and fair-share' '
@@ -113,10 +113,10 @@ test_expect_success 'submit some jobs so they populate flux-core job-archive' '
 	jobid2=$(flux submit -N 1 hostname) &&
 	jobid3=$(flux submit -N 2 hostname) &&
 	jobid4=$(flux submit -N 1 hostname) &&
-	wait_db $jobid1 ${ARCHIVEDB} &&
-	wait_db $jobid2 ${ARCHIVEDB} &&
-	wait_db $jobid3 ${ARCHIVEDB} &&
-	wait_db $jobid4 ${ARCHIVEDB}
+	wait_db ${jobid1} ${ARCHIVEDB} &&
+	wait_db ${jobid2} ${ARCHIVEDB} &&
+	wait_db ${jobid3} ${ARCHIVEDB} &&
+	wait_db ${jobid4} ${ARCHIVEDB}
 '
 
 test_expect_success 'call --copy argument to populate jobs table from job-archive DB' '
@@ -129,9 +129,9 @@ test_expect_success 'submit some sleep 1 jobs under one user' '
 	jobid1=$(flux submit -N 1 sleep 1) &&
 	jobid2=$(flux submit -N 1 sleep 1) &&
 	jobid3=$(flux submit -n 2 -N 2 sleep 1) &&
-	wait_db $jobid1 ${ARCHIVEDB} &&
-	wait_db $jobid2 ${ARCHIVEDB} &&
-	wait_db $jobid3 ${ARCHIVEDB}
+	wait_db ${jobid1} ${ARCHIVEDB} &&
+	wait_db ${jobid2} ${ARCHIVEDB} &&
+	wait_db ${jobid3} ${ARCHIVEDB}
 '
 
 test_expect_success 'run fetch-job-records script' '
@@ -160,9 +160,9 @@ test_expect_success 'submit some sleep 1 jobs under the secondary bank of the sa
 	jobid1=$(flux submit --setattr=system.bank=account2 -N 1 sleep 1) &&
 	jobid2=$(flux submit --setattr=system.bank=account2 -N 1 sleep 1) &&
 	jobid3=$(flux submit --setattr=system.bank=account2 -n 2 -N 2 sleep 1) &&
-	wait_db $jobid1 ${ARCHIVEDB} &&
-	wait_db $jobid2 ${ARCHIVEDB} &&
-	wait_db $jobid3 ${ARCHIVEDB}
+	wait_db ${jobid1} ${ARCHIVEDB} &&
+	wait_db ${jobid2} ${ARCHIVEDB} &&
+	wait_db ${jobid3} ${ARCHIVEDB}
 '
 
 test_expect_success 'run custom job-list script' '

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -93,7 +93,7 @@ test_expect_success 'submit sleep 60 jobs with no data update' '
 '
 
 test_expect_success 'check that submitted job is in state PRIORITY' '
-	flux job wait-event -vt 60 $jobid1 depend
+	flux job wait-event -vt 60 ${jobid1} depend
 '
 
 test_expect_success 'update plugin with sample test data again' '
@@ -101,7 +101,7 @@ test_expect_success 'update plugin with sample test data again' '
 '
 
 test_expect_success 'check that previously held job transitions to RUN' '
-	flux job wait-event -vt 60 $jobid1 alloc
+	flux job wait-event -vt 60 ${jobid1} alloc
 '
 
 test_expect_success 'submit 2 more sleep jobs' '
@@ -110,21 +110,21 @@ test_expect_success 'submit 2 more sleep jobs' '
 '
 
 test_expect_success 'check flux jobs - should have 1 running job, 2 pending jobs' '
-	flux job wait-event -vt 60 $jobid1 alloc &&
+	flux job wait-event -vt 60 ${jobid1} alloc &&
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
-		$jobid2 dependency-add &&
+		${jobid2} dependency-add &&
 	flux job wait-event -vt 60 \
 		--match-context=description="max-running-jobs-user-limit" \
-		$jobid3 dependency-add
+		${jobid3} dependency-add
 '
 
 test_expect_success 'cancel running jobs one at a time and check that each pending job transitions to RUN' '
-	flux cancel $jobid1 &&
-	flux job wait-event -vt 60 $jobid2 alloc &&
-	flux cancel $jobid2 &&
-	flux job wait-event -vt 60 $jobid3 alloc &&
-	flux cancel $jobid3
+	flux cancel ${jobid1} &&
+	flux job wait-event -vt 60 ${jobid2} alloc &&
+	flux cancel ${jobid2} &&
+	flux job wait-event -vt 60 ${jobid3} alloc &&
+	flux cancel ${jobid3}
 '
 
 test_expect_success 'unload mf_priority.so' '
@@ -133,12 +133,12 @@ test_expect_success 'unload mf_priority.so' '
 
 test_expect_success 'submit a job with no plugin loaded' '
 	jobid4=$(flux submit -n 1 sleep 60) &&
-	flux job wait-event -vt 60 $jobid4 depend
+	flux job wait-event -vt 60 ${jobid4} depend
 '
 
 test_expect_success 'reload mf_priority.so with a job still in job.state.priority' '
 	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
-	flux job wait-event -vt 60 $jobid4 depend
+	flux job wait-event -vt 60 ${jobid4} depend
 '
 
 test_expect_success 'update plugin with sample test data again' '
@@ -146,8 +146,8 @@ test_expect_success 'update plugin with sample test data again' '
 '
 
 test_expect_success 'check that originally pending job transitions to RUN' '
-	flux job wait-event -vt 60 $jobid4 alloc &&
-	flux cancel $jobid4
+	flux job wait-event -vt 60 ${jobid4} alloc &&
+	flux cancel ${jobid4}
 '
 
 test_done

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -120,11 +120,11 @@ test_expect_success 'check flux jobs - should have 1 running job, 2 pending jobs
 '
 
 test_expect_success 'cancel running jobs one at a time and check that each pending job transitions to RUN' '
-	flux job cancel $jobid1 &&
+	flux cancel $jobid1 &&
 	flux job wait-event -vt 60 $jobid2 alloc &&
-	flux job cancel $jobid2 &&
+	flux cancel $jobid2 &&
 	flux job wait-event -vt 60 $jobid3 alloc &&
-	flux job cancel $jobid3
+	flux cancel $jobid3
 '
 
 test_expect_success 'unload mf_priority.so' '
@@ -147,7 +147,7 @@ test_expect_success 'update plugin with sample test data again' '
 
 test_expect_success 'check that originally pending job transitions to RUN' '
 	flux job wait-event -vt 60 $jobid4 alloc &&
-	flux job cancel $jobid4
+	flux cancel $jobid4
 '
 
 test_done

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -75,12 +75,12 @@ test_expect_success 'users can run jobs without specifying a queue' '
 	flux account add-queue default --priority=1000 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
 	jobid0=$(flux python ${SUBMIT_AS} 5011 -n1 hostname) &&
-	flux job wait-event -f json $jobid0 priority | jq '.context.priority' > job0.test &&
+	flux job wait-event -f json ${jobid0} priority | jq '.context.priority' > job0.test &&
 	cat <<-EOF >job0.expected &&
 	50000
 	EOF
 	test_cmp job0.expected job0.test &&
-	flux cancel $jobid0
+	flux cancel ${jobid0}
 '
 
 # Include "foo" queue that accounting doesn't know about for test below
@@ -107,7 +107,7 @@ test_expect_success 'submit a job using a queue the user does not belong to' '
 test_expect_success 'submit a job using standby queue, which should not increase job priority' '
 	jobid1=$(flux python ${SUBMIT_AS} 5011 --job-name=standby \
 		--setattr=system.bank=account1 --queue=standby -n1 hostname) &&
-	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
+	flux job wait-event -f json ${jobid1} priority | jq '.context.priority' > job1.test &&
 	cat <<-EOF >job1.expected &&
 	50000
 	EOF
@@ -117,7 +117,7 @@ test_expect_success 'submit a job using standby queue, which should not increase
 test_expect_success 'submit a job using expedite queue, which should increase priority' '
 	jobid2=$(flux python ${SUBMIT_AS} 5011 --job-name=expedite \
 		--setattr=system.bank=account1 --queue=expedite -n1 hostname) &&
-	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
+	flux job wait-event -f json ${jobid2} priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	100050000
 	EOF
@@ -143,11 +143,11 @@ test_expect_success 'check order of job queue' '
 '
 
 test_expect_success 'cancel existing jobs' '
-	flux cancel $jobid1 &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid3 &&
-	flux cancel $jobid4 &&
-	flux cancel $jobid5
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid3} &&
+	flux cancel ${jobid4} &&
+	flux cancel ${jobid5}
 '
 
 test_expect_success 'unload mf_priority.so' '
@@ -156,17 +156,17 @@ test_expect_success 'unload mf_priority.so' '
 
 test_expect_success 'submit a job to a nonexistent queue with no plugin information loaded' '
 	jobid6=$(flux python ${SUBMIT_AS} 5011 --queue=foo -n1 hostname) &&
-	flux job wait-event -vt 60 $jobid6 depend
+	flux job wait-event -vt 60 ${jobid6} depend
 '
 
 test_expect_success 'reload mf_priority.so and update it with the sample test data again' '
 	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
-	flux job wait-event -vt 60 $jobid6 depend &&
+	flux job wait-event -vt 60 ${jobid6} depend &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
 '
 
 test_expect_success 'cancel final job' '
-	flux cancel $jobid6
+	flux cancel ${jobid6}
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -80,7 +80,7 @@ test_expect_success 'users can run jobs without specifying a queue' '
 	50000
 	EOF
 	test_cmp job0.expected job0.test &&
-	flux job cancel $jobid0
+	flux cancel $jobid0
 '
 
 # Include "foo" queue that accounting doesn't know about for test below
@@ -143,11 +143,11 @@ test_expect_success 'check order of job queue' '
 '
 
 test_expect_success 'cancel existing jobs' '
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid3 &&
-	flux job cancel $jobid4 &&
-	flux job cancel $jobid5
+	flux cancel $jobid1 &&
+	flux cancel $jobid2 &&
+	flux cancel $jobid3 &&
+	flux cancel $jobid4 &&
+	flux cancel $jobid5
 '
 
 test_expect_success 'unload mf_priority.so' '
@@ -166,7 +166,7 @@ test_expect_success 'reload mf_priority.so and update it with the sample test da
 '
 
 test_expect_success 'cancel final job' '
-	flux job cancel $jobid6
+	flux cancel $jobid6
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -25,15 +25,15 @@ test_expect_success 'submit a number of jobs with no user/bank info loaded to pl
 '
 
 test_expect_success 'make sure jobs get held in state PRIORITY' '
-	flux job wait-event -vt 60 $jobid1 depend &&
-	flux job wait-event -vt 60 $jobid2 depend &&
-	flux job wait-event -vt 60 $jobid3 depend
+	flux job wait-event -vt 60 ${jobid1} depend &&
+	flux job wait-event -vt 60 ${jobid2} depend &&
+	flux job wait-event -vt 60 ${jobid3} depend
 '
 
 test_expect_success 'cancel held jobs' '
-	flux cancel $jobid1 &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid3
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid3}
 '
 
 test_expect_success 'submit job #1 with no user/bank info loaded to plugin' '
@@ -41,7 +41,7 @@ test_expect_success 'submit job #1 with no user/bank info loaded to plugin' '
 '
 
 test_expect_success 'check that job #1 is in state PRIORITY' '
-	flux job wait-event -vt 60 $jobid1 depend
+	flux job wait-event -vt 60 ${jobid1} depend
 '
 
 test_expect_success 'send the user/bank information to the plugin without reprioritizing all active jobs' '
@@ -89,11 +89,11 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 
 test_expect_success 'submit job #2 which should run before job #1' '
 	jobid2=$(flux submit hostname) &&
-	flux job wait-event -t 15 $jobid2 clean
+	flux job wait-event -t 15 ${jobid2} clean
 '
 
 test_expect_success 'cancel job #1' '
-	flux cancel $jobid1
+	flux cancel ${jobid1}
 '
 
 test_done

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -31,9 +31,9 @@ test_expect_success 'make sure jobs get held in state PRIORITY' '
 '
 
 test_expect_success 'cancel held jobs' '
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid3
+	flux cancel $jobid1 &&
+	flux cancel $jobid2 &&
+	flux cancel $jobid3
 '
 
 test_expect_success 'submit job #1 with no user/bank info loaded to plugin' '
@@ -93,7 +93,7 @@ test_expect_success 'submit job #2 which should run before job #1' '
 '
 
 test_expect_success 'cancel job #1' '
-	flux job cancel $jobid1
+	flux cancel $jobid1
 '
 
 test_done

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -106,7 +106,7 @@ test_expect_success 'disabling a user while they have an active job should not k
 	flux account delete-user $username account2 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
 	flux job wait-event -vt 60 $jobid5 alloc &&
-	flux job cancel $jobid5
+	flux cancel $jobid5
 '
 
 test_expect_success 'trying to submit a job now should result in a job rejection' '

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -46,7 +46,7 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 
 test_expect_success 'submit a job successfully under default bank' '
 	jobid1=$(flux submit -n1 hostname) &&
-	flux job wait-event -f json $jobid1 priority | jq '.context.priority' > job1.test &&
+	flux job wait-event -f json ${jobid1} priority | jq '.context.priority' > job1.test &&
 	cat <<-EOF >job1.expected &&
 	50000
 	EOF
@@ -55,7 +55,7 @@ test_expect_success 'submit a job successfully under default bank' '
 
 test_expect_success 'submit a job successfully under second bank' '
 	jobid2=$(flux submit --setattr=system.bank=account2 -n1 hostname) &&
-	flux job wait-event -f json $jobid2 priority | jq '.context.priority' > job2.test &&
+	flux job wait-event -f json ${jobid2} priority | jq '.context.priority' > job2.test &&
 	cat <<-EOF >job2.expected &&
 	50000
 	EOF
@@ -80,7 +80,7 @@ test_expect_success 're-add second user/bank entry and update-plugin' '
 
 test_expect_success 'submit a job successfully under second bank' '
 	jobid3=$(flux submit --setattr=system.bank=account2 -n1 hostname) &&
-	flux job wait-event -f json $jobid3 priority | jq '.context.priority' > job3.test &&
+	flux job wait-event -f json ${jobid3} priority | jq '.context.priority' > job3.test &&
 	cat <<-EOF >job3.expected &&
 	50000
 	EOF
@@ -94,7 +94,7 @@ test_expect_success 'disable first (and default) bank entry for user (will updat
 
 test_expect_success 'try to submit job under new default user/bank entry' '
 	jobid4=$(flux submit -n1 hostname) &&
-	flux job wait-event -f json $jobid4 priority | jq '.context.priority' > job4.test &&
+	flux job wait-event -f json ${jobid4} priority | jq '.context.priority' > job4.test &&
 	cat <<-EOF >job4.expected &&
 	50000
 	EOF
@@ -105,8 +105,8 @@ test_expect_success 'disabling a user while they have an active job should not k
 	jobid5=$(flux submit -n1 sleep 60) &&
 	flux account delete-user $username account2 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
-	flux job wait-event -vt 60 $jobid5 alloc &&
-	flux cancel $jobid5
+	flux job wait-event -vt 60 ${jobid5} alloc &&
+	flux cancel ${jobid5}
 '
 
 test_expect_success 'trying to submit a job now should result in a job rejection' '

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -91,9 +91,9 @@ test_expect_success HAVE_JQ 'fetch plugin state and make sure that jobs are refl
 '
 
 test_expect_success 'cancel jobs in reverse order so last job does not get alloc event' '
-	flux job cancel $jobid3 &&
-	flux job cancel $jobid2 &&
-	flux job cancel $jobid1
+	flux cancel $jobid3 &&
+	flux cancel $jobid2 &&
+	flux cancel $jobid1
 '
 
 test_expect_success 'add another user to flux-accounting DB and send it to plugin' '

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -91,9 +91,9 @@ test_expect_success HAVE_JQ 'fetch plugin state and make sure that jobs are refl
 '
 
 test_expect_success 'cancel jobs in reverse order so last job does not get alloc event' '
-	flux cancel $jobid3 &&
-	flux cancel $jobid2 &&
-	flux cancel $jobid1
+	flux cancel ${jobid3} &&
+	flux cancel ${jobid2} &&
+	flux cancel ${jobid1}
 '
 
 test_expect_success 'add another user to flux-accounting DB and send it to plugin' '

--- a/t/t1020-mf-priority-issue262.t
+++ b/t/t1020-mf-priority-issue262.t
@@ -54,7 +54,7 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 
 test_expect_success 'submit a sleep 180 job and ensure it is running' '
 	jobid1=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
-	flux job wait-event -vt 60 $jobid1 alloc
+	flux job wait-event -vt 60 ${jobid1} alloc
 '
 
 test_expect_success 'stop scheduler from allocating resources to jobs' '
@@ -64,8 +64,8 @@ test_expect_success 'stop scheduler from allocating resources to jobs' '
 test_expect_success 'submit 2 more sleep 180 jobs; ensure both are in SCHED state' '
 	jobid2=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
 	jobid3=$(flux python ${SUBMIT_AS} 1001 sleep 180) &&
-	flux job wait-event -vt 60 $jobid2 priority &&
-	flux job wait-event -vt 60 $jobid3 priority
+	flux job wait-event -vt 60 ${jobid2} priority &&
+	flux job wait-event -vt 60 ${jobid3} priority
 '
 
 test_expect_success 'ensure current running and active jobs are correct: 1 running, 3 active' '
@@ -84,9 +84,9 @@ test_expect_success 'update the plugin and ensure current running and active job
 '
 
 test_expect_success 'change the priority of one of the jobs' '
-	flux job urgency $jobid2 31 &&
+	flux job urgency ${jobid2} 31 &&
 	flux account-priority-update -p $(pwd)/FluxAccountingTest.db &&
-	flux job eventlog $jobid2 | grep ^priority | tail -n 1 | priority=4294967295
+	flux job eventlog ${jobid2} | grep ^priority | tail -n 1 | priority=4294967295
 '
 
 test_expect_success 'ensure job counts are still the same: 1 running, 3 active' '
@@ -97,7 +97,7 @@ test_expect_success 'ensure job counts are still the same: 1 running, 3 active' 
 '
 
 test_expect_success 'cancel one of the scheduled jobs, check job counts are correct: 1 running, 2 active' '
-	flux cancel $jobid2 &&
+	flux cancel ${jobid2} &&
 	flux jobtap query mf_priority.so > query_4.json &&
 	test_debug "jq -S . <query_4.json" &&
 	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_4.json &&
@@ -105,8 +105,8 @@ test_expect_success 'cancel one of the scheduled jobs, check job counts are corr
 '
 
 test_expect_success 'cancel sleep 180 job(s), check job counts: 0 running, 0 active' '
-	flux cancel $jobid1 &&
-	flux cancel $jobid3 &&
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid3} &&
 	flux jobtap query mf_priority.so > query_5.json &&
 	test_debug "jq -S . <query_5.json" &&
 	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 0" <query_5.json &&

--- a/t/t1020-mf-priority-issue262.t
+++ b/t/t1020-mf-priority-issue262.t
@@ -97,7 +97,7 @@ test_expect_success 'ensure job counts are still the same: 1 running, 3 active' 
 '
 
 test_expect_success 'cancel one of the scheduled jobs, check job counts are correct: 1 running, 2 active' '
-	flux job cancel $jobid2 &&
+	flux cancel $jobid2 &&
 	flux jobtap query mf_priority.so > query_4.json &&
 	test_debug "jq -S . <query_4.json" &&
 	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 1" <query_4.json &&
@@ -105,8 +105,8 @@ test_expect_success 'cancel one of the scheduled jobs, check job counts are corr
 '
 
 test_expect_success 'cancel sleep 180 job(s), check job counts: 0 running, 0 active' '
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid3 &&
+	flux cancel $jobid1 &&
+	flux cancel $jobid3 &&
 	flux jobtap query mf_priority.so > query_5.json &&
 	test_debug "jq -S . <query_5.json" &&
 	jq -e ".mf_priority_map[0].banks[0].cur_run_jobs == 0" <query_5.json &&

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -67,7 +67,7 @@ test_expect_success 'check that held job transitions to RUN' '
 '
 
 test_expect_success 'cancel job' '
-	flux job cancel $jobid1
+	flux cancel $jobid1
 '
 
 test_expect_success 'submit a job to plugin while not having an entry in the plugin' '

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -55,7 +55,7 @@ test_expect_success 'submit a job with no user/bank info loaded to plugin' '
 '
 
 test_expect_success 'make sure job is held in state PRIORITY' '
-	flux job wait-event -vt 60 $jobid1 depend
+	flux job wait-event -vt 60 ${jobid1} depend
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
@@ -63,11 +63,11 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 '
 
 test_expect_success 'check that held job transitions to RUN' '
-	flux job wait-event -vt 60 $jobid1 alloc
+	flux job wait-event -vt 60 ${jobid1} alloc
 '
 
 test_expect_success 'cancel job' '
-	flux cancel $jobid1
+	flux cancel ${jobid1}
 '
 
 test_expect_success 'submit a job to plugin while not having an entry in the plugin' '

--- a/t/t1027-mf-priority-issue376.t
+++ b/t/t1027-mf-priority-issue376.t
@@ -59,9 +59,9 @@ test_expect_success 'submit job for testing' '
 '
 
 test_expect_success 'update of duration of pending job works while at active jobs limit' '
-	flux update $jobid1 duration=1m &&
-	flux job wait-event -vt 10 $jobid1 priority &&
-	flux job eventlog $jobid1 \
+	flux update ${jobid1} duration=1m &&
+	flux job wait-event -vt 10 ${jobid1} priority &&
+	flux job eventlog ${jobid1} \
 		| grep jobspec-update \
 		| grep duration=60
 '

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -64,8 +64,8 @@ test_expect_success 'submitting a job under invalid user while plugin has data f
 '
 
 test_expect_success 'cancel running jobs' '
-	flux job cancel $jobid1 &&
-	flux job cancel $jobid2
+	flux cancel $jobid1 &&
+	flux cancel $jobid2
 '
 
 test_expect_success 'add the previously invalid user to flux-accounting DB, plugin' '
@@ -76,7 +76,7 @@ test_expect_success 'add the previously invalid user to flux-accounting DB, plug
 test_expect_success 'previously invalid user can now submit jobs' '
 	jobid3=$(flux python ${SUBMIT_AS} 9999 hostname) &&
 	flux job wait-event -vt 60 $jobid3 alloc &&
-	flux job cancel $jobid3
+	flux cancel $jobid3
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -33,12 +33,12 @@ test_expect_success 'load multi-factor priority plugin' '
 
 test_expect_success 'submit a job with no user/bank info loaded to plugin' '
 	jobid1=$(flux python ${SUBMIT_AS} 5001 --wait-event=depend hostname) &&
-	flux job wait-event -vt 60 $jobid1 depend
+	flux job wait-event -vt 60 ${jobid1} depend
 '
 
 test_expect_success 'submit a job as another user, check that it is also in state PRIORITY' '
 	jobid2=$(flux python ${SUBMIT_AS} 5002 --wait-event=depend hostname) &&
-	flux job wait-event -vt 60 $jobid2 depend
+	flux job wait-event -vt 60 ${jobid2} depend
 '
 
 test_expect_success 'add banks, users to flux-accounting DB' '
@@ -53,8 +53,8 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 '
 
 test_expect_success 'check that jobs transition to RUN' '
-	flux job wait-event -vt 60 $jobid1 alloc &&
-	flux job wait-event -vt 60 $jobid2 alloc
+	flux job wait-event -vt 60 ${jobid1} alloc &&
+	flux job wait-event -vt 60 ${jobid2} alloc
 '
 
 test_expect_success 'submitting a job under invalid user while plugin has data fails' '
@@ -64,8 +64,8 @@ test_expect_success 'submitting a job under invalid user while plugin has data f
 '
 
 test_expect_success 'cancel running jobs' '
-	flux cancel $jobid1 &&
-	flux cancel $jobid2
+	flux cancel ${jobid1} &&
+	flux cancel ${jobid2}
 '
 
 test_expect_success 'add the previously invalid user to flux-accounting DB, plugin' '
@@ -75,8 +75,8 @@ test_expect_success 'add the previously invalid user to flux-accounting DB, plug
 
 test_expect_success 'previously invalid user can now submit jobs' '
 	jobid3=$(flux python ${SUBMIT_AS} 9999 hostname) &&
-	flux job wait-event -vt 60 $jobid3 alloc &&
-	flux cancel $jobid3
+	flux job wait-event -vt 60 ${jobid3} alloc &&
+	flux cancel ${jobid3}
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -62,7 +62,7 @@ test_expect_success 'check that bank was added to jobspec' '
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
 	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
@@ -74,7 +74,7 @@ test_expect_success 'successfully submit a job under a specified bank' '
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid jobspec > jobspec.out &&
 	grep "account2" jobspec.out &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'successfully submit a job under a default bank' '
@@ -82,7 +82,7 @@ test_expect_success 'successfully submit a job under a default bank' '
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
 	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'update the default bank for the user' '
@@ -95,7 +95,7 @@ test_expect_success 'successfully submit a job under the new default bank' '
 	flux job wait-event -f json $jobid priority &&
 	flux job info $jobid eventlog > eventlog.out &&
 	grep "\"attributes.system.bank\":\"account2\"" eventlog.out &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -48,8 +48,8 @@ test_expect_success 'add a user to the DB' '
 
 test_expect_success 'submit a job before plugin has any flux-accounting information' '
 	jobid=$(flux python ${SUBMIT_AS} 1002 hostname) &&
-	flux job wait-event -vt 60 $jobid depend &&
-	flux job info $jobid eventlog > eventlog.out &&
+	flux job wait-event -vt 60 ${jobid} depend &&
+	flux job info ${jobid} eventlog > eventlog.out &&
 	grep "depend" eventlog.out
 '
 
@@ -59,10 +59,10 @@ test_expect_success 'add user to flux-accounting DB and update plugin' '
 '
 
 test_expect_success 'check that bank was added to jobspec' '
-	flux job wait-event -f json $jobid priority &&
-	flux job info $jobid eventlog > eventlog.out &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux job info ${jobid} eventlog > eventlog.out &&
 	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
@@ -71,18 +71,18 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 
 test_expect_success 'successfully submit a job under a specified bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 --setattr=system.bank=account2 hostname) &&
-	flux job wait-event -f json $jobid priority &&
-	flux job info $jobid jobspec > jobspec.out &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux job info ${jobid} jobspec > jobspec.out &&
 	grep "account2" jobspec.out &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'successfully submit a job under a default bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
-	flux job wait-event -f json $jobid priority &&
-	flux job info $jobid eventlog > eventlog.out &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux job info ${jobid} eventlog > eventlog.out &&
 	grep "\"attributes.system.bank\":\"account1\"" eventlog.out &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'update the default bank for the user' '
@@ -92,10 +92,10 @@ test_expect_success 'update the default bank for the user' '
 
 test_expect_success 'successfully submit a job under the new default bank' '
 	jobid=$(flux python ${SUBMIT_AS} 1001 hostname) &&
-	flux job wait-event -f json $jobid priority &&
-	flux job info $jobid eventlog > eventlog.out &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux job info ${jobid} eventlog > eventlog.out &&
 	grep "\"attributes.system.bank\":\"account2\"" eventlog.out &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -73,52 +73,52 @@ test_expect_success 'configure flux with some queues' '
 
 test_expect_success 'submit job for testing' '
 	jobid1=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
-	flux job wait-event -f json $jobid1 priority \
+	flux job wait-event -f json ${jobid1} priority \
 		| jq '.context.priority' > job1_bronze.test &&
  	grep 1050000 job1_bronze.test
 '
 
 test_expect_success 'update of queue of pending job works' '
-	flux update $jobid1 queue=silver &&
-	flux job wait-event -f json $jobid1 priority &&
-	flux job eventlog $jobid1 > eventlog.out &&
+	flux update ${jobid1} queue=silver &&
+	flux job wait-event -f json ${jobid1} priority &&
+	flux job eventlog ${jobid1} > eventlog.out &&
 	grep "attributes.system.queue=\"silver\"" eventlog.out &&
 	grep 2050000 eventlog.out
 '
 
 test_expect_success 'updating a job using a queue the user does not belong to fails' '
-	test_must_fail flux update $jobid1 queue=gold > unavail_queue.out 2>&1 &&
+	test_must_fail flux update ${jobid1} queue=gold > unavail_queue.out 2>&1 &&
 	test_debug "cat unavail_queue.out" &&
 	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
 '
 
 test_expect_success 'cancel job' '
-	flux cancel $jobid1
+	flux cancel ${jobid1}
 '
 
 test_expect_success 'submit job for testing under non-default bank' '
 	jobid2=$(flux python ${SUBMIT_AS} 5001 --setattr=bank=B --queue=bronze sleep 30) &&
-	flux job wait-event -f json $jobid2 priority \
+	flux job wait-event -f json ${jobid2} priority \
 		| jq '.context.priority' > job2_bronze.test &&
 	grep 1050000 job2_bronze.test
 '
 
 test_expect_success 'update of queue of pending job under a non-default bank works' '
-	flux update $jobid2 queue=silver &&
-	flux job wait-event -f json $jobid2 priority &&
-	flux job eventlog $jobid2 > eventlog.out &&
+	flux update ${jobid2} queue=silver &&
+	flux job wait-event -f json ${jobid2} priority &&
+	flux job eventlog ${jobid2} > eventlog.out &&
 	grep "attributes.system.queue=\"silver\"" eventlog.out &&
 	grep 2050000 eventlog.out
 '
 
 test_expect_success 'updating a job under non-default bank using a queue the user does not belong to fails' '
-	test_must_fail flux update $jobid2 queue=gold > unavail_queue.out 2>&1 &&
+	test_must_fail flux update ${jobid2} queue=gold > unavail_queue.out 2>&1 &&
 	test_debug "cat unavail_queue.out" &&
 	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
 '
 
 test_expect_success 'cancel job' '
-	flux cancel $jobid2
+	flux cancel ${jobid2}
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -93,7 +93,7 @@ test_expect_success 'updating a job using a queue the user does not belong to fa
 '
 
 test_expect_success 'cancel job' '
-	flux job cancel $jobid1
+	flux cancel $jobid1
 '
 
 test_expect_success 'submit job for testing under non-default bank' '
@@ -118,7 +118,7 @@ test_expect_success 'updating a job under non-default bank using a queue the use
 '
 
 test_expect_success 'cancel job' '
-	flux job cancel $jobid2
+	flux cancel $jobid2
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1031-mf-priority-issue406.t
+++ b/t/t1031-mf-priority-issue406.t
@@ -103,9 +103,9 @@ test_expect_success 'make sure job 3 is still in PRIORITY state' '
 '
 
 test_expect_success 'cancel jobs' '
-	flux job cancel $job1 &&
-	flux job cancel $job2 &&
-	flux job cancel $job3
+	flux cancel $job1 &&
+	flux cancel $job2 &&
+	flux cancel $job3
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1031-mf-priority-issue406.t
+++ b/t/t1031-mf-priority-issue406.t
@@ -58,9 +58,9 @@ test_expect_success 'submit jobs as three different users' '
 '
 
 test_expect_success 'check that the jobs successfully received their priority' '
-	flux job wait-event -vt 5 $job1 priority &&
-	flux job wait-event -vt 5 $job2 priority &&
-	flux job wait-event -vt 5 $job3 priority
+	flux job wait-event -vt 5 ${job1} priority &&
+	flux job wait-event -vt 5 ${job2} priority &&
+	flux job wait-event -vt 5 ${job3} priority
 '
 
 test_expect_success 'unload plugin' '
@@ -82,30 +82,30 @@ test_expect_success 'reprioritize jobs' '
 '
 
 test_expect_success 'make sure job 1 is still in PRIORITY state' '
-	flux job wait-event -vt 10 $job1 depend &&
-	flux job info $job1 eventlog > eventlog.out &&
+	flux job wait-event -vt 10 ${job1} depend &&
+	flux job info ${job1} eventlog > eventlog.out &&
 	cat eventlog.out &&
 	grep "depend" eventlog.out
 '
 
 test_expect_success 'make sure job 2 is still in PRIORITY state' '
-	flux job wait-event -vt 10 $job2 depend &&
-	flux job info $job2 eventlog > eventlog.out &&
+	flux job wait-event -vt 10 ${job2} depend &&
+	flux job info ${job2} eventlog > eventlog.out &&
 	cat eventlog.out &&
 	grep "depend" eventlog.out
 '
 
 test_expect_success 'make sure job 3 is still in PRIORITY state' '
-	flux job wait-event -vt 10 $job3 depend &&
-	flux job info $job3 eventlog > eventlog.out &&
+	flux job wait-event -vt 10 ${job3} depend &&
+	flux job info ${job3} eventlog > eventlog.out &&
 	cat eventlog.out &&
 	grep "depend" eventlog.out
 '
 
 test_expect_success 'cancel jobs' '
-	flux cancel $job1 &&
-	flux cancel $job2 &&
-	flux cancel $job3
+	flux cancel ${job1} &&
+	flux cancel ${job2} &&
+	flux cancel ${job3}
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1032-mf-priority-update-bank.t
+++ b/t/t1032-mf-priority-update-bank.t
@@ -65,54 +65,54 @@ test_expect_success 'submit one job under default bank, two under non-default ba
 '
 
 test_expect_success 'update of bank of pending job works' '
-	flux update $job1 bank=B &&
-	flux job wait-event -t 30 $job1 priority &&
-	flux job eventlog $job1 > eventlog.out &&
+	flux update ${job1} bank=B &&
+	flux job wait-event -t 30 ${job1} priority &&
+	flux job eventlog ${job1} > eventlog.out &&
 	grep "attributes.system.bank=\"B\"" eventlog.out
 '
 
 test_expect_success 'trying to update to a bank user does not have access to fails in job.validate' '
-	test_must_fail flux update $job1 bank=C > invalid_bank.out 2>&1 &&
+	test_must_fail flux update ${job1} bank=C > invalid_bank.out 2>&1 &&
 	test_debug "cat invalid_bank.out" &&
 	grep "cannot find user/bank or user/default bank entry for uid:" invalid_bank.out
 '
 
 test_expect_success 'trying to update to a bank that does not exist fails in job.validate' '
-	test_must_fail flux update $job1 bank=foo > nonexistent_bank.out 2>&1 &&
+	test_must_fail flux update ${job1} bank=foo > nonexistent_bank.out 2>&1 &&
 	test_debug "cat nonexistent_bank.out" &&
 	grep "cannot find user/bank or user/default bank entry for uid:" nonexistent_bank.out
 '
 
 test_expect_success 'update a job to another bank that is at max-active-jobs limit' '
 	job4=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
-	test_must_fail flux update $job4 bank=B > max_active_jobs.out 2>&1 &&
+	test_must_fail flux update ${job4} bank=B > max_active_jobs.out 2>&1 &&
 	test_debug "cat max_active_jobs.out" &&
 	grep "new bank is already at max-active-jobs limit" max_active_jobs.out &&
-	flux cancel $job4
+	flux cancel ${job4}
 '
 
 test_expect_success 'cancel one of the jobs so bank is not at max-active-jobs limit' '
-	flux cancel $job3
+	flux cancel ${job3}
 '
 
 test_expect_success 'update urgency of held jobs so they transition to RUN' '
-	flux job urgency $job1 default &&
-	flux job urgency $job2 default &&
-	flux job wait-event -t 10 $job1 alloc &&
-	flux job wait-event -t 10 $job2 alloc
+	flux job urgency ${job1} default &&
+	flux job urgency ${job2} default &&
+	flux job wait-event -t 10 ${job1} alloc &&
+	flux job wait-event -t 10 ${job2} alloc
 '
 
 test_expect_success 'update a job to another bank that is at max-run-jobs limit' '
 	job5=$(flux python ${SUBMIT_AS} 5001 --urgency=0 sleep 30) &&
-	test_must_fail flux update $job5 bank=B > max_run_jobs.out 2>&1 &&
+	test_must_fail flux update ${job5} bank=B > max_run_jobs.out 2>&1 &&
 	test_debug "cat max_run_jobs.out" &&
 	grep "already at max-run-jobs limit is not allowed" max_run_jobs.out &&
-	flux cancel $job5
+	flux cancel ${job5}
 '
 
 test_expect_success 'cancel jobs' '
-	flux cancel $job1 &&
-	flux cancel $job2
+	flux cancel ${job1} &&
+	flux cancel ${job2}
 '
 
 test_expect_success 'submit job under non-default bank' '
@@ -120,9 +120,9 @@ test_expect_success 'submit job under non-default bank' '
 '
 
 test_expect_success 'updating job to default bank works' '
-	flux update $job6 bank=A &&
-	flux job wait-event -t 30 $job6 priority &&
-	flux job eventlog $job6 > eventlog.out &&
+	flux update ${job6} bank=A &&
+	flux job wait-event -t 30 ${job6} priority &&
+	flux job eventlog ${job6} > eventlog.out &&
 	grep "attributes.system.bank=\"A\"" eventlog.out
 '
 

--- a/t/t1033-mf-priority-update-job.t
+++ b/t/t1033-mf-priority-update-job.t
@@ -73,47 +73,47 @@ test_expect_success 'configure flux with some queues' '
 
 test_expect_success 'submit job for testing' '
 	jobid=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
-	flux job wait-event -f json $jobid priority &&
-	flux job eventlog $jobid > eventlog.out &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux job eventlog ${jobid} > eventlog.out &&
 	grep "1050000" eventlog.out
 '
 
 test_expect_success 'update both queue and bank successfully' '
-	flux update $jobid queue=silver bank=B &&
-	flux job wait-event -f json $jobid priority &&
-	flux job eventlog $jobid > eventlog.out &&
+	flux update ${jobid} queue=silver bank=B &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux job eventlog ${jobid} > eventlog.out &&
 	grep "attributes.system.queue=\"silver\"" eventlog.out &&
 	grep 2050000 eventlog.out &&
 	grep "attributes.system.bank=\"B\"" eventlog.out &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'submit another job for testing' '
 	jobid=$(flux python ${SUBMIT_AS} 5001 --queue=bronze sleep 30) &&
-	flux job wait-event -f json $jobid priority
+	flux job wait-event -f json ${jobid} priority
 '
 
 test_expect_success 'update job with invalid combination (invalid bank)' '
-	test_must_fail flux update $jobid queue=silver bank=foo > nonexistent_bank.out 2>&1 &&
+	test_must_fail flux update ${jobid} queue=silver bank=foo > nonexistent_bank.out 2>&1 &&
 	test_debug "cat nonexistent_bank.out" &&
 	grep "cannot find user/bank or user/default bank entry for uid:" nonexistent_bank.out
 '
 
 test_expect_success 'check that job is still in original queue' '
-	flux job info $jobid jobspec > jobspec.out &&
+	flux job info ${jobid} jobspec > jobspec.out &&
 	grep "\"queue\": \"bronze\"" jobspec.out
 '
 
 test_expect_success 'update job with invalud combination (invalid queue)' '
-	test_must_fail flux update $jobid bank=B queue=gold > unavail_queue.out 2>&1 &&
+	test_must_fail flux update ${jobid} bank=B queue=gold > unavail_queue.out 2>&1 &&
 	test_debug "cat unavail_queue.out" &&
 	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out
 '
 
 test_expect_success 'check that job is still under original bank' '
-	flux job eventlog $jobid > eventlog.out &&
+	flux job eventlog ${jobid} > eventlog.out &&
 	grep "attributes.system.bank=\"A\"" eventlog.out &&
-	flux cancel $jobid
+	flux cancel ${jobid}
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1033-mf-priority-update-job.t
+++ b/t/t1033-mf-priority-update-job.t
@@ -85,7 +85,7 @@ test_expect_success 'update both queue and bank successfully' '
 	grep "attributes.system.queue=\"silver\"" eventlog.out &&
 	grep 2050000 eventlog.out &&
 	grep "attributes.system.bank=\"B\"" eventlog.out &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'submit another job for testing' '
@@ -113,7 +113,7 @@ test_expect_success 'update job with invalud combination (invalid queue)' '
 test_expect_success 'check that job is still under original bank' '
 	flux job eventlog $jobid > eventlog.out &&
 	grep "attributes.system.bank=\"A\"" eventlog.out &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1034-mf-priority-config.t
+++ b/t/t1034-mf-priority-config.t
@@ -50,9 +50,9 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 
 test_expect_success 'no configured priority factors will use default weights' '
 	job1=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
-	flux job wait-event -f json $job1 priority | jq '.context.priority' > job1.test &&
+	flux job wait-event -f json ${job1} priority | jq '.context.priority' > job1.test &&
 	grep "50000" job1.test &&
-	flux cancel $job1
+	flux cancel ${job1}
 '
 
 test_expect_success 'set up new configuration for multi-factor priority plugin' '
@@ -66,9 +66,9 @@ test_expect_success 'set up new configuration for multi-factor priority plugin' 
 
 test_expect_success 'successfully submit a job with loaded configuration' '
 	job2=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
-	flux job wait-event -f json $job2 priority | jq '.context.priority' > job2.test &&
+	flux job wait-event -f json ${job2} priority | jq '.context.priority' > job2.test &&
 	grep "500" job2.test &&
-	flux cancel $job2
+	flux cancel ${job2}
 '
 
 test_expect_success 'change the configuration for the priority factors' '
@@ -82,9 +82,9 @@ test_expect_success 'change the configuration for the priority factors' '
 
 test_expect_success 'successfully submit a job with the new configuration' '
 	job3=$(flux python ${SUBMIT_AS} 1001 -n1 hostname) &&
-	flux job wait-event -f json $job3 priority | jq '.context.priority' > job3.test &&
+	flux job wait-event -f json ${job3} priority | jq '.context.priority' > job3.test &&
 	grep "250" job3.test &&
-	flux cancel $job3
+	flux cancel ${job3}
 '
 
 test_expect_success 'shut down flux-accounting service' '


### PR DESCRIPTION
#### Problem

There are a number of tests in the flux-accounting testsuite that still use `flux job cancel`, but this is outdated in favor for `flux cancel`.

---

This PR replaces the use of `flux job cancel` with `flux cancel` in the flux-accounting testsuite.