### PR TITLE
`inactive_cb`: remove unused iterator variables

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1028,8 +1028,6 @@ static int inactive_cb (flux_plugin_t *p,
 {
     int userid;
     Association *b;
-    std::map<int, std::map<std::string, Association>>::iterator it;
-    std::map<std::string, Association>::iterator bank_it;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,


### PR DESCRIPTION
#### Problem

There are a couple of unused iterator variables left over in the callback for `job.state.inactive` that were never removed when I was cleaning up and abstracting stuff out of the plugin and into an external class.

---

This PR removes these unused iterator variables.