### PR TITLE
job archive interface: clean up a couple helper functions

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_archive_interface.py
+++ b/src/bindings/python/fluxacct/accounting/job_archive_interface.py
@@ -123,7 +123,13 @@ def add_job_records(rows):
     job_records = []
 
     for row in rows:
-        rset = ResourceSet(row[6])  # fetch R
+        try:
+            # attempt to create a ResourceSet from R
+            rset = ResourceSet(row[6])
+            nnodes = rset.nnodes
+        except (ValueError, TypeError):
+            # can't convert R to a ResourceSet object; skip it
+            continue
 
         job_record = JobRecord(
             row[0],  # userid
@@ -132,7 +138,7 @@ def add_job_records(rows):
             row[2],  # t_submit
             row[3],  # t_run
             row[4],  # t_inactive
-            rset.nnodes,  # nnodes
+            nnodes,  # nnodes
             row[6],  # resources
         )
         job_records.append(job_record)


### PR DESCRIPTION
#### Problem

There are a few functions in `job_archive_interface.py` that could use some improvements to their error handling and parameter and string construction. There's also some opportunity for some duplicate code cleanup.

---

This PR just makes some minor cleanup in a couple of functions in `job_archive_interface.py`. Notably, it reduces a couple of unnecessary checks in `get_job_records()` and makes use of f-strings for the query construction.

Some duplicate code is cleaned up in the helper functions for filtering jobs by default/secondary banks by reducing them into just one `filter_jobs_by_bank()` function.

Some more explicit error handling is added to `add_job_records()` to handle the case where the construction of a `ResourceSet` object fails while parsing job records.