### PR TITLE
NEWS: add release notes for `v0.34.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+flux-accounting version 0.34.0 - 2024-07-02
+-------------------------------------------
+
+#### Fixes
+
+* `inactive_cb ()`: remove unused iterator variables (#457)
+
+* plugin: initialize factor weights on plugin load (#458)
+
+* job archive interface: clean up a couple helper functions (#460)
+
+#### Features
+
+* database: add the ability to remove old records from `jobs` table (#459)
+
 flux-accounting version 0.33.0 - 2024-06-04
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.34.0`.

---

This PR adds some release notes. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.34.0 -m "Tag v0.34.0" && git push upstream v0.34.0
```