### PR TITLE
`conf.update`: add missing bracket in format string

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -191,7 +191,7 @@ static int conf_update_cb (flux_plugin_t *p,
     // unpack the various factors to be used in job priority calculation
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s?{s?{s?{s?i, s?i}}}",
+                                "{s?{s?{s?{s?i, s?i}}}}",
                                 "conf", "accounting", "factor-weights",
                                 "fairshare", &fshare_weight,
                                 "queue", &queue_weight) < 0) {

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -198,6 +198,7 @@ static int conf_update_cb (flux_plugin_t *p,
         flux_log_error (flux_jobtap_get_flux (p),
                         "mf_priority: conf.update: flux_plugin_arg_unpack: %s",
                         flux_plugin_arg_strerror (args));
+        return -1;
     }
 
     // assign unpacked weights into priority_weights map


### PR DESCRIPTION
#### Problem

The format string for unpacking the various weights for priority factors in a config file is missing a closing bracket.

---

This PR adds it.

As an aside, I'm not sure why the testsuite never caught this before. I have a dedicated testing file for `conf_update_cb ()` (`t1034-mf-priority-config.t`) that **should** be testing different configuration files, but apparently it passed all of those. Is there maybe a different kind of test I could add that maybe comprehensively checks the format string? 🤷 