### PR TITLE
NEWS: add release notes for `v0.35.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+flux-accounting version 0.35.0 - 2024-07-10
+-------------------------------------------
+
+#### Fixes
+
+* t: move python unit tests to `t/python/` directory (#462)
+
+* python: clean job-archive interface code (#463)
+
+* `conf.update`: add missing bracket in format string (#465)
+
+#### Testsuite
+
+* testsuite: fix on systems with flux-accounting already installed (#467)
+
 flux-accounting version 0.34.0 - 2024-07-02
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.35.0`.

---

This PR adds some release notes. I'll create an annotated tag once this lands with:

```
git tag -a v0.35.0 -m "Tag v0.35.0" && git push upstream v0.35.0
```