### PR TITLE
testsuite: fix on systems with flux-accounting already installed

### DIFF
--- a/t/sharness.d/flux-accounting.sh
+++ b/t/sharness.d/flux-accounting.sh
@@ -12,8 +12,8 @@ prepend_colon_separated() {
 SRC_DIR=${SHARNESS_TEST_SRCDIR}/..
 
 prepend_colon_separated FLUX_EXEC_PATH_PREPEND ${SRC_DIR}/src/cmd
-prepend_colon_separated PYTHONPATH ${SRC_DIR}/src/bindings/python
+prepend_colon_separated FLUX_PYTHONPATH_PREPEND ${SRC_DIR}/src/bindings/python
 
-export FLUX_EXEC_PATH_PREPEND PYTHONPATH
+export FLUX_EXEC_PATH_PREPEND FLUX_PYTHONPATH_PREPEND
 
 # vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: When flux-accounting is already installed on a system, the sharness tests pull in the installed version of flux-accounting Python modules instead of the test version. This occurs because sharness prepends the source tree Python path to PYTHONPATH, which is then subverted by flux-core's `py-runner.py`, which prepends the system path in front of that before executing Python subcommands like the accounting service etc.

Use FLUX_PYTHONPATH_PREPEND instead of PYTHONPATH, which is preserved by the py-runner.py wrapper.