### PR TITLE
python: change function descriptions to follow docstring convention

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -19,8 +19,9 @@ from fluxacct.accounting import user_subcommands as u
 #                                                             #
 ###############################################################
 
-# helper function to print user information in a table format
+
 def print_user_rows(cur, rows, bank):
+    """Print user information in a table format."""
     user_str = "\nUsers Under Bank {bank_name}:\n\n".format(bank_name=bank)
     user_headers = [description[0] for description in cur.description]
     # print column names of association_table
@@ -35,8 +36,8 @@ def print_user_rows(cur, rows, bank):
     return user_str
 
 
-# helper function to print bank information in a table format
 def get_bank_rows(cur, rows, bank):
+    """Print bank information in a table format."""
     bank_str = ""
     bank_headers = [description[0] for description in cur.description]
     # bank has sub banks, so list them
@@ -51,8 +52,8 @@ def get_bank_rows(cur, rows, bank):
     return bank_str
 
 
-# helper function to traverse the bank table and delete all sub banks and users
 def print_sub_banks(conn, bank, bank_str, indent=""):
+    """Traverse the bank table and print all sub banks ansd users."""
     select_stmt = "SELECT bank FROM bank_table WHERE parent_bank=?"
     cur = conn.cursor()
     cur.execute(select_stmt, (bank,))
@@ -86,9 +87,8 @@ def validate_parent_bank(cur, parent_bank):
         raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
 
 
-# check if bank already exists and is active in bank_table;
-# if so, return True
 def bank_is_active(cur, bank, parent_bank):
+    """Check if the bank already exists and is active."""
     cur.execute(
         "SELECT active FROM bank_table WHERE bank=? AND parent_bank=?",
         (
@@ -103,9 +103,11 @@ def bank_is_active(cur, bank, parent_bank):
     return False
 
 
-# check if bank already exists but was disabled first; if so,
-# just update the 'active' column in already existing row
 def check_if_bank_disabled(cur, bank, parent_bank):
+    """
+    Check if the bank already exists but was disabled first. If so, just
+    update the 'active' column in the alread existing row.
+    """
     cur.execute(
         "SELECT * FROM bank_table WHERE bank=? AND parent_bank=?",
         (bank, parent_bank),
@@ -117,8 +119,8 @@ def check_if_bank_disabled(cur, bank, parent_bank):
     return False
 
 
-# re-enable bank in bank_table by setting "active" to 1
 def reactivate_bank(conn, cur, bank, parent_bank):
+    """Re-enable the bank by setting 'active' to 1."""
     cur.execute(
         "UPDATE bank_table SET active=1 WHERE bank=? AND parent_bank=?",
         (

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -334,10 +334,12 @@ def update_job_usage(acct_conn, pdhl=1):
     return 0
 
 
-# Scrub jobs from the flux-accounting "jobs" table by removing any
-# record that is older than num_weeks old. If no number of weeks is
-# specified, remove any record that is older than 6 months old.
 def scrub_old_jobs(conn, num_weeks=26):
+    """
+    Scrub jobs from the jobs table by removing any record that is older than
+    num_weeks old. If no number of weeks is specified, remove any record that
+    is older than 6 months old.
+    """
     cur = conn.cursor()
     # calculate total amount of time to go back (in terms of seconds)
     # (there are 604,800 seconds in a week)

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -19,9 +19,10 @@ import sqlite3
 ###############################################################
 
 
-# check if project already exists and is active in project_table;
-# if so, return True
 def project_is_active(cur, project):
+    """
+    Check if the project already exists and is active in the projects table.
+    """
     cur.execute(
         "SELECT * FROM project_table WHERE project=?",
         (project,),

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -160,9 +160,11 @@ def get_user_rows(conn, user, headers, rows, parseable, json_fmt):
     return user_str
 
 
-# check for a default bank of the user being added; if the user is new, set
-# the first bank they were added to as their default bank
 def set_default_bank(cur, username, bank):
+    """
+    Check the default bank of the user being added; if the user is new, set
+    the first bank they were added to as their default bank.
+    """
     select_stmt = "SELECT default_bank FROM association_table WHERE username=?"
     cur.execute(select_stmt, (username,))
     result = cur.fetchone()
@@ -173,9 +175,8 @@ def set_default_bank(cur, username, bank):
     return result[0]
 
 
-# check if association already exists and is active in association_table;
-# if so, raise sqlite3.IntegrityError
 def association_is_active(cur, username, bank):
+    """Check if association already exists and is active."""
     cur.execute(
         "SELECT active FROM association_table WHERE username=? AND bank=?",
         (
@@ -190,9 +191,11 @@ def association_is_active(cur, username, bank):
     return False
 
 
-# check if user/bank entry already exists but was disabled first; if so,
-# just update the 'active' column in already existing row
 def check_if_user_disabled(conn, cur, username, bank):
+    """
+    Check if the association already exists but was disabled; if so, just
+    update the 'active' column in the already-existing row.
+    """
     cur.execute(
         "SELECT * FROM association_table WHERE username=? AND bank=?",
         (
@@ -223,10 +226,12 @@ def get_default_bank(cur, username):
     return result[0][0]
 
 
-# helper function that is called when a user's default_bank row gets disabled from
-# the association_table. It will look for other banks that the user belongs to; if
-# so, the default bank needs to be updated for these rows
 def update_default_bank(conn, cur, username):
+    """
+    Look for other banks that a user belongs to in the event when a user's
+    default bank is disabled. It will look for other banks that the user
+    belongs to; if so, the default bank needs to be updated for these rows.
+    """
     # get first bank from other potential existing rows from user
     select_stmt = """SELECT bank FROM association_table WHERE active=1 AND username=?
                      ORDER BY creation_time"""


### PR DESCRIPTION
#### Problem

The function descriptions for a number of functions in the Python bindings do not follow [PEP 257: Docstring Conventions](https://peps.python.org/pep-0257/).

---

This PR updates the misformatted function description to follow docstring convention.