### PR TITLE
`bank_table`: add a new `list-banks` command

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -66,7 +66,7 @@ def check_db_version(conn):
         sys.exit(1)
 
 
-# pylint: disable=broad-except
+# pylint: disable=broad-except, too-many-public-methods
 class AccountingService:
     def __init__(self, flux_handle, conn):
 
@@ -87,6 +87,7 @@ class AccountingService:
         general_endpoints = [
             "view_user",
             "view_bank",
+            "list_banks",
             "view_job_records",
             "view_queue",
             "view_project",
@@ -316,6 +317,28 @@ class AccountingService:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
         except ValueError as val_err:
             handle.respond_error(msg, 0, f"error in edit_bank: {val_err}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def list_banks(self, handle, watcher, msg, arg):
+        try:
+            val = b.list_banks(
+                self.conn,
+                msg.payload["inactive"],
+                msg.payload["fields"],
+            )
+
+            payload = {"list_banks": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as exc:
+            handle.respond_error(msg, 0, f"{exc}")
+        except sqlite3.Error as exc:
+            handle.respond_error(msg, 0, f"a SQLite error occured: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -343,6 +343,28 @@ def add_edit_bank_arg(subparsers):
     )
 
 
+def add_list_banks_arg(subparsers):
+    subparser_list_banks = subparsers.add_parser(
+        "list-banks",
+        help="list all banks in the flux-accounting DB",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_list_banks.set_defaults(func="list_banks")
+    subparser_list_banks.add_argument(
+        "--inactive",
+        action="store_const",
+        const=True,
+        help="include inactive banks in output",
+    )
+    subparser_list_banks.add_argument(
+        "--fields",
+        type=str,
+        help="list of fields to include in JSON output",
+        default="bank_id,bank,parent_bank,shares,job_usage",
+        metavar="BANK_ID,BANK,ACTIVE,PARENT_BANK,SHARES,JOB_USAGE",
+    )
+
+
 def add_update_usage_arg(subparsers):
     subparser_update_usage = subparsers.add_parser(
         "update-usage",
@@ -523,6 +545,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_view_bank_arg(subparsers)
     add_delete_bank_arg(subparsers)
     add_edit_bank_arg(subparsers)
+    add_list_banks_arg(subparsers)
     add_update_usage_arg(subparsers)
     add_add_queue_arg(subparsers)
     add_view_queue_arg(subparsers)
@@ -642,6 +665,13 @@ def select_accounting_function(args, output_file, parser):
             "parent_bank": args.parent_bank,
         }
         return_val = flux.Flux().rpc("accounting.edit_bank", data).get()
+    elif args.func == "list_banks":
+        data = {
+            "path": args.path,
+            "inactive": args.inactive,
+            "fields": args.fields.split(","),
+        }
+        return_val = flux.Flux().rpc("accounting.list_banks", data).get()
     elif args.func == "update_usage":
         data = {
             "path": args.path,

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -124,6 +124,27 @@ test_expect_success 'trying to add a user to a nonexistent bank should raise a V
 	grep "Bank foo does not exist in bank_table" nonexistent_bank.out
 '
 
+test_expect_success 'call list-banks --help' '
+	flux account list-banks --help
+'
+
+test_expect_success 'call list-banks' '
+	flux account list-banks
+'
+
+test_expect_success 'call list-banks and include inactive banks' '
+	flux account list-banks --inactive
+'
+
+test_expect_success 'call list-banks and customize output' '
+	flux account list-banks --fields=bank_id,bank
+'
+
+test_expect_success 'call list-banks with a bad field' '
+	test_must_fail flux account list-banks --fields=bank_id,foo > error.out 2>&1 &&
+	grep "invalid fields: foo" error.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

There is currently no way to list the current banks defined in the `bank_table` in the flux-accounting database, especially in a
convenient format like JSON.

---

This PR adds a new command to the flux-accounting command suite called `list-banks`. When called, this command will create a JSON object containing all of the active banks in the `bank_table`. Below is example output of `flux account list-banks`:

```json
[
  {
    "bank_id": 1,
    "bank": "root",
    "parent_bank": "",
    "shares": 1,
    "job_usage": 0.0
  },
  {
    "bank_id": 2,
    "bank": "A",
    "parent_bank": "root",
    "shares": 1,
    "job_usage": 0.0
  },
  {
    "bank_id": 3,
    "bank": "B",
    "parent_bank": "root",
    "shares": 1,
    "job_usage": 0.0
  }
]
```

Passing `--inactive` will include *all* banks, even those which have been disabled. The fields output in the JSON object can be customized with a list of fields to be included with `--fields`. Below is example output of `flux account list-banks --fields=bank_id,bank`:

```json
[
  {
    "bank_id": 1,
    "bank": "root"
  },
  {
    "bank_id": 2,
    "bank": "A"
  },
  {
    "bank_id": 3,
    "bank": "B"
  }
]
```

A couple of basic tests calling these different optional arguments are also added to the test suite. I've included them with the other sharness tests for various bank commands.

Fixes #472 

---

@wihobbs, does Steph have a GitHub account? Perhaps she should take a high-level look at this PR to see if it matches her needs. :-)