### PR TITLE
NEWS: add release notes for `v0.36.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+flux-accounting version 0.36.0 - 2024-08-06
+-------------------------------------------
+
+#### Fixes
+
+* python: change function descriptions to follow docstring convention (#468)
+
+* python: convert more function descriptions to docstring format (#470)
+
+* src: remove `flux_account_shares.cpp` in favor of just using `-t` option with
+`view-bank` (#471)
+
+* `fetch-job-records`: add integrity check for records (#475)
+
+#### Features
+
+* `bank_table`: add a new `list-banks` command (#473)
+
 flux-accounting version 0.35.0 - 2024-07-10
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.36.0`.

---

This PR adds some release notes. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.36.0 -m "Tag v0.36.0" && git push upstream v0.36.0
```