### PR TITLE
`view-user`: add a new `--list-banks` optional argument

### DIFF
--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -306,3 +306,18 @@ class AssociationFormatter(AccountingFormatter):
         super().__init__(
             cursor, error_msg=f"user {self.username} not found in association_table"
         )
+
+    def list_banks(self):
+        """
+        Return all of the banks that the user belongs to with each bank
+        on its own line.
+        """
+        self.cursor.execute(
+            "SELECT bank FROM association_table WHERE username=?", (self.username,)
+        )
+        result = self.cursor.fetchall()
+        banks = ""
+        for bank in result:
+            banks += f"{str(bank[0])}\n"
+
+        return banks

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -233,7 +233,7 @@ def clear_projects(conn, username, bank=None):
 #                   Subcommand Functions                      #
 #                                                             #
 ###############################################################
-def view_user(conn, user, parsable=False, cols=None):
+def view_user(conn, user, parsable=False, cols=None, list_banks=False):
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.ASSOCIATION_TABLE
 
@@ -250,6 +250,8 @@ def view_user(conn, user, parsable=False, cols=None):
         # initialize AssociationFormatter object
         formatter = fmt.AssociationFormatter(cur, user)
 
+        if list_banks:
+            return formatter.list_banks()
         if parsable:
             return formatter.as_table()
         return formatter.as_json()

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -150,6 +150,7 @@ class AccountingService:
                 msg.payload["username"],
                 msg.payload["parsable"],
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
+                msg.payload["list_banks"],
             )
 
             payload = {"view_user": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -57,6 +57,13 @@ def add_view_user_arg(subparsers):
             "MAX_CORES,QUEUES,PROJECTS,DEFAULT_PROJECT"
         ),
     )
+    subparser_view_user.add_argument(
+        "--list-banks",
+        action="store_const",
+        const=True,
+        help="list all of the banks a user belongs to",
+        metavar="LIST_BANKS",
+    )
 
 
 def add_add_user_arg(subparsers):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -44,6 +44,7 @@ TESTSCRIPTS = \
 	t1042-issue508.t \
 	t1043-view-jobs-by-bank.t \
 	t1044-mf-priority-resource-limits.t \
+	t1045-issue478.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1045-issue478.t
+++ b/t/t1045-issue478.t
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+test_description='test calling view-user with the --list-banks optional argument'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB, start flux-accounting service' '
+	flux account -p ${ACCOUNTING_DB} create-db &&
+	flux account-service -p ${ACCOUNTING_DB} -t
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root bankA 1 &&
+	flux account add-bank --parent-bank=root bankB 1 &&
+	flux account add-bank --parent-bank=root bankC 1
+'
+
+test_expect_success 'add a user' '
+	flux account add-user --username=testuser --bank=bankA &&
+	flux account add-user --username=testuser --bank=bankB &&
+	flux account add-user --username=testuser --bank=bankC
+'
+
+test_expect_success 'call view-user --list-banks' '
+	flux account view-user testuser --list-banks > banks.out &&
+	grep "bankA" banks.out &&
+	grep "bankB" banks.out &&
+	grep "bankC" banks.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm ${ACCOUNTING_DB}
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Mentioned in #478, there is no concise way to just view a list of banks that a user belongs to without having to parse through the rest of the accounting information associated with it.

---

This PR adds a new optional argument to `view-user` called `--list-banks`, which just outputs a newline-delimited list of banks that a user belongs to.

```console
$ flux account view-user testuser --list-banks
bankA
bankB
bankC
```

A basic test file is also added which calls this optional argument. For now, this is just built on top of #477, but I can always make it separate in case this gets reviewed first. :-)

Fixes #478