### PR TITLE
`Makefile`: remove left over compile instructions for `flux_account_shares`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,19 +120,6 @@ cmd_flux_account_update_fshare_CXXFLAGS = \
 
 cmd_flux_account_update_fshare_LDFLAGS = $(SQLITE_LIBS)
 
-cmd_flux_account_shares_SOURCES = cmd/flux_account_shares.cpp
-
-cmd_flux_account_shares_LDADD = \
-	fairness/libweighted_tree.la
-
-cmd_flux_account_shares_CXXFLAGS = \
-	$(WARNING_CXXFLAGS) \
-	$(CODE_COVERAGE_CFLAGS) \
-	$(AM_CXXFLAGS) \
-	$(SQLITE_CFLAGS)
-
-cmd_flux_account_shares_LDFLAGS = $(SQLITE_LIBS)
-
 dist_fluxcmd_SCRIPTS = \
 	cmd/flux-account.py \
 	cmd/flux-account-update-fshare \


### PR DESCRIPTION
#### Problem

`flux_account_shares.cpp` was removed in #471, but there is still a compile definition for it in the top-level `Makefile.am` that is left over.

---

This PR just removes the left over compilation instructions.

Fixes #481 