### PR TITLE
[WIP] t: automatically generate test UIDs

### DIFF
--- a/t/sharness.d/flux-accounting.sh
+++ b/t/sharness.d/flux-accounting.sh
@@ -16,4 +16,10 @@ prepend_colon_separated FLUX_PYTHONPATH_PREPEND ${SRC_DIR}/src/bindings/python
 
 export FLUX_EXEC_PATH_PREPEND FLUX_PYTHONPATH_PREPEND
 
+TEST_UID1=$(($(id -u)+1))
+TEST_UID2=$(($(id -u)+2))
+TEST_UID3=$(($(id -u)+3))
+TEST_UID4=$(($(id -u)+4))
+TEST_UID5=$(($(id -u)+5))
+
 # vi: ts=4 sw=4 expandtab

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -61,8 +61,8 @@ test_expect_success 'add some projects to the DB' '
 '
 
 test_expect_success 'add a user with two different banks to the DB' '
-	flux account add-user --username=user5001 --userid=5001 --bank=account1 --max-running-jobs=2 &&
-	flux account add-user --username=user5001 --userid=5001 --bank=account2
+	flux account add-user --username=user1 --userid=${TEST_UID1} --bank=account1 --max-running-jobs=2 &&
+	flux account add-user --username=user1 --userid=${TEST_UID1} --bank=account2
 '
 
 test_expect_success 'send flux-accounting DB information to the plugin' '
@@ -72,22 +72,22 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 test_expect_success HAVE_JQ 'fetch plugin state' '
 	flux jobtap query mf_priority.so > query_1.json &&
 	test_debug "jq -S . <query_1.json" &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[0].bank_name == \"account1\"" <query_1.json &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[1].bank_name == \"account2\"" <query_1.json
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[0].bank_name == \"account1\"" <query_1.json &&
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[1].bank_name == \"account2\"" <query_1.json
 '
 
 test_expect_success 'submit max number of jobs under default bank (1 held job due to max_run_jobs limit)' '
-	jobid1=$(flux python ${SUBMIT_AS} 5001 sleep 60) &&
-	jobid2=$(flux python ${SUBMIT_AS} 5001 sleep 60) &&
-	jobid3=$(flux python ${SUBMIT_AS} 5001 sleep 60)
+	jobid1=$(flux python ${SUBMIT_AS} ${TEST_UID1} sleep 60) &&
+	jobid2=$(flux python ${SUBMIT_AS} ${TEST_UID1} sleep 60) &&
+	jobid3=$(flux python ${SUBMIT_AS} ${TEST_UID1} sleep 60)
 '
 
 test_expect_success HAVE_JQ 'fetch plugin state and make sure that jobs are reflected in JSON object' '
 	flux jobtap query mf_priority.so > query_2.json &&
 	test_debug "jq -S . <query_2.json" &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[0].held_jobs | length == 1" <query_2.json &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[0].cur_run_jobs == 2" <query_2.json &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[0].cur_active_jobs == 3" <query_2.json
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[0].held_jobs | length == 1" <query_2.json &&
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[0].cur_run_jobs == 2" <query_2.json &&
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[0].cur_active_jobs == 3" <query_2.json
 '
 
 test_expect_success 'cancel jobs in reverse order so last job does not get alloc event' '
@@ -98,8 +98,8 @@ test_expect_success 'cancel jobs in reverse order so last job does not get alloc
 
 test_expect_success 'add another user to flux-accounting DB and send it to plugin' '
 	flux account add-user \
-		--username=user5002 \
-		--userid=5002 \
+		--username=user2 \
+		--userid=${TEST_UID2} \
 		--bank=account3 \
 		--queues="bronze" \
 		--projects="A,B" \
@@ -110,9 +110,9 @@ test_expect_success 'add another user to flux-accounting DB and send it to plugi
 test_expect_success HAVE_JQ 'fetch plugin state again with multiple users' '
 	flux jobtap query mf_priority.so > query_3.json &&
 	test_debug "jq -S . <query_3.json" &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[0].bank_name == \"account1\"" <query_3.json &&
-	jq -e ".mf_priority_map[] | select(.userid == 5001) | .banks[1].bank_name == \"account2\"" <query_3.json &&
-	jq -e ".mf_priority_map[] | select(.userid == 5002) | .banks[0].bank_name == \"account3\"" <query_3.json
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[0].bank_name == \"account1\"" <query_3.json &&
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID1}) | .banks[1].bank_name == \"account2\"" <query_3.json &&
+	jq -e ".mf_priority_map[] | select(.userid == ${TEST_UID2}) | .banks[0].bank_name == \"account3\"" <query_3.json
 '
 
 test_expect_success 'shut down flux-accounting service' '


### PR DESCRIPTION
#### Problem

As mentioned in #480, there are a number of tests throughout the test suite that explicitly define UIDs for users created and used for various tests in flux-accounting, but these have a potential of conflicting with system-defined UIDs.

---

This PR adds definitions for test UIDs in `sharness.d/flux-accounting.sh`. I basically followed the same formula for testing permissions for certain flux-accounting commands in `t1026-flux-account-perms.t`, where a UID is created by just incrementing the current UID by 1.

I've included an example of replace the use of explicitly defined UIDs in `t1019-mf-priority-info-fetch.t` with the UIDs defined in `flux-accounting.sh`. If this looks good, then I can update this PR and take it out of [WIP] by including the rest of the test files in the test suite.