### PR TITLE
configure: add `jansson` as a dependency check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AM_PROG_CC_C_O
 AX_VALGRIND_H
 AX_CODE_COVERAGE
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
+PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
 
 if test "$GCC" = yes; then
   WARNING_CFLAGS="-Wall -Werror -Werror=missing-field-initializers -Wno-error=deprecated-declarations"


### PR DESCRIPTION
#### Problem

As noted in #364, flux-accounting does not check for `jansson` when running `./configure` even though it uses it in the priority plugin.

---

This PR adds a check for `jansson` in `configure.ac`.

Fixes #364