### PR TITLE
doc: add example error message when creating DB after starting systemd service

### DIFF
--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -77,7 +77,9 @@ the following prerequisites must be met:
 
 1. A flux-accounting database has been created with ``flux account create-db``.
 The service establishes a connection with the database in order to read from
-and write to it.
+and write to it. If the service has been started before the creation of the
+database, you may encounter unexpected behavior from running ``flux account``
+commands, such as ``sqlite3.OperationalError: attempt to write a readonly database``.
 
 2. An active Flux system instance is running. The flux-accounting service will
 only run after the system instance is started.


### PR DESCRIPTION
#### Problem

The flux-accounting service depends on the creation of the flux-accounting DB before starting since it needs to establish a connection to the DB in order to run `flux account` commands. If this is done out of order, confusing behavior can result from running the commands, such as an `attempt to write to a readonly database` error.

---

This PR just adds a note to the flux-accounting guide about making sure the flux-accounting DB has been created before starting the flux-accounting service and gives an example of the error message that can potentially occur.