### PR TITLE
`job.state.inactive`: add `return -1` to exception

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1138,8 +1138,11 @@ static int inactive_cb (flux_plugin_t *p,
         if (flux_jobtap_dependency_remove (p,
                                            jobid,
                                            "max-running-jobs-user-limit") < 0)
+        {
             flux_jobtap_raise_exception (p, jobid, "mf_priority",
                                          0, "failed to remove job dependency");
+            return -1;
+        }
 
         b->held_jobs.erase (b->held_jobs.begin ());
     }


### PR DESCRIPTION
#### Problem

The callback for `job.state.inactive` does not `return -1` in the event of an exception being raised due to failing to remove a dependency from a held job for an association.

---

Add a `return -1` call after `flux_jobtap_raise_exception ()` in the callback for `job.state.inactive`.