### PR TITLE
`view-user`: make "parsable" spelling consistent

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -129,10 +129,10 @@ def create_json_object(conn, user):
     return user_info_json
 
 
-def get_user_rows(conn, user, headers, rows, parseable, json_fmt):
+def get_user_rows(conn, user, headers, rows, parsable, json_fmt):
     user_str = ""
 
-    if parseable is True:
+    if parsable is True:
         # find length of longest column name
         col_width = len(sorted(headers, key=len)[-1])
 
@@ -285,7 +285,7 @@ def clear_queues(conn, username, bank=None):
 #                   Subcommand Functions                      #
 #                                                             #
 ###############################################################
-def view_user(conn, user, parseable=False, json_fmt=False):
+def view_user(conn, user, parsable=False, json_fmt=False):
     cur = conn.cursor()
     try:
         # get the information pertaining to a user in the DB
@@ -295,7 +295,7 @@ def view_user(conn, user, parseable=False, json_fmt=False):
         if not result:
             raise ValueError(f"User {user} not found in association_table")
 
-        user_str = get_user_rows(conn, user, headers, result, parseable, json_fmt)
+        user_str = get_user_rows(conn, user, headers, result, parsable, json_fmt)
 
         return user_str
     # this kind of exception is raised for errors related to the DB's operation,

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -147,7 +147,7 @@ class AccountingService:
             val = u.view_user(
                 self.conn,
                 msg.payload["username"],
-                msg.payload["parseable"],
+                msg.payload["parsable"],
                 msg.payload["json"],
             )
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -40,11 +40,11 @@ def add_view_user_arg(subparsers):
     subparser_view_user.set_defaults(func="view_user")
     subparser_view_user.add_argument("username", help="username", metavar=("USERNAME"))
     subparser_view_user.add_argument(
-        "--parseable",
+        "--parsable",
         action="store_const",
         const=True,
         help="print all information of an association on one line",
-        metavar="PARSEABLE",
+        metavar="PARSABLE",
     )
     subparser_view_user.add_argument(
         "--json",
@@ -652,7 +652,7 @@ def select_accounting_function(args, output_file, parser):
         data = {
             "path": args.path,
             "username": args.username,
-            "parseable": args.parseable,
+            "parsable": args.parsable,
             "json": args.json,
         }
         return_val = flux.Flux().rpc("accounting.view_user", data).get()

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -60,9 +60,9 @@ test_expect_success 'view some user information' '
 	grep -w "username: user5011\|userid: 5011\|bank: A" user_info.out
 '
 
-test_expect_success 'view some user information with --parseable' '
-	flux account view-user --parseable user5011 > user_info_parseable.out &&
-	grep -w "user5011\|5011\|A" user_info_parseable.out
+test_expect_success 'view some user information with --parsable' '
+	flux account view-user --parsable user5011 > user_info_parsable.out &&
+	grep -w "user5011\|5011\|A" user_info_parsable.out
 '
 
 test_expect_success 'view some user information with --json' '

--- a/t/t1036-hierarchy-small-no-tie-db.t
+++ b/t/t1036-hierarchy-small-no-tie-db.t
@@ -53,7 +53,7 @@ test_expect_success 'view database hierarchy' '
 	test_cmp ${EXPECTED_FILES}/small_no_tie.txt small_no_tie.test
 '
 
-test_expect_success 'view database hierarchy in a parseable format' '
+test_expect_success 'view database hierarchy in a parsable format' '
 	flux account view-bank -P root > small_no_tie_parsable.test &&
 	test_cmp ${EXPECTED_FILES}/small_no_tie_parsable.txt small_no_tie_parsable.test
 '

--- a/t/t1037-hierarchy-small-tie-db.t
+++ b/t/t1037-hierarchy-small-tie-db.t
@@ -54,7 +54,7 @@ test_expect_success 'view database hierarchy' '
 	test_cmp ${EXPECTED_FILES}/small_tie.txt small_tie.test
 '
 
-test_expect_success 'view database hierarchy in a parseable format' '
+test_expect_success 'view database hierarchy in a parsable format' '
 	flux account view-bank -P root > small_tie_parsable.test &&
 	test_cmp ${EXPECTED_FILES}/small_tie_parsable.txt small_tie_parsable.test
 '

--- a/t/t1038-hierarchy-small-tie-all-db.t
+++ b/t/t1038-hierarchy-small-tie-all-db.t
@@ -57,7 +57,7 @@ test_expect_success 'view database hierarchy' '
 	test_cmp ${EXPECTED_FILES}/small_tie_all.txt small_tie_all.test
 '
 
-test_expect_success 'view database hierarchy in a parseable format' '
+test_expect_success 'view database hierarchy in a parsable format' '
 	flux account view-bank -P root > small_tie_all_parsable.test &&
 	test_cmp ${EXPECTED_FILES}/small_tie_all_parsable.txt small_tie_all_parsable.test
 '


### PR DESCRIPTION
#### Problem

There are multiple `--parsable` optional arguments throughout the flux-accounting command suite, but the spelling for it in the view-user command is not consistent and is spelled `--parseable`. Technically, both spellings are correct, but they should be made consistent throughout the command suite.

---

This PR just changes the spelling of the `--parseable` optional argument for `view-user` to `--parsable`.