### PR TITLE
plugin: add callback prefixes to exception messages

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -567,8 +567,8 @@ static int priority_cb (flux_plugin_t *p,
             if (update_jobspec_bank (p, userid) < 0) {
                 flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                              "mf_priority", 0,
-                                             "failed to update jobspec "
-                                             "with bank name");
+                                             "job.state.priority: failed to "
+                                             "update jobspec with bank name");
                 return -1;
             }
 
@@ -578,8 +578,9 @@ static int priority_cb (flux_plugin_t *p,
                 if (update_jobspec_project (p, userid, bank) < 0) {
                     flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                                 "mf_priority", 0,
-                                                "failed to update jobspec "
-                                                "with project name");
+                                                "job.state.priority: failed "
+                                                "to update jobspec with "
+                                                "project name");
                     return -1;
                 }
             }
@@ -761,8 +762,8 @@ static int new_cb (flux_plugin_t *p,
             if (update_jobspec_bank (p, userid) < 0) {
                 flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                              "mf_priority", 0,
-                                             "failed to update jobspec "
-                                             "with bank name");
+                                             "job.new: failed to update "
+                                             "jobspec with bank name");
                 return -1;
             }
         }
@@ -799,8 +800,8 @@ static int new_cb (flux_plugin_t *p,
         if (update_jobspec_project (p, userid, bank) < 0) {
             flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                          "mf_priority", 0,
-                                         "failed to update jobspec with "
-                                         "project name");
+                                         "job.new: failed to update jobspec "
+                                         "with project name");
             return -1;
         }
     }


### PR DESCRIPTION
#### Problem

The priority plugin uses the same exception message for jobspec updates in more than one callback because there is more than one instance where that message would be appropriate. However, these exception messages are not prefixed with the callback the exception is being raised from, which can make it hard to debug when looking at a job's eventlog.

---

This PR just adds a prefix of the name of the callback the exception message is coming from.