### PR TITLE
doc: add note about manually loading plugin

### DIFF
--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -130,6 +130,14 @@ configure the ``job-manager`` to load this plugin.
 
 See also: :core:man5:`flux-config-job-manager`.
 
+The plugin can also be manually loaded with ``flux jobtap load``. Be sure to
+send all flux-accounting data to the plugin after it is loaded:
+
+.. code-block:: console
+
+ $ flux jobtap load mf_priority.so
+ $ flux account-priority-update
+
 Automatic Accounting Database Updates
 =====================================
 


### PR DESCRIPTION
#### Problem

The flux-accounting guide does not detail how to manually load the priority plugin if the path to the plugin is not configured in the job-manager config file.

---

This PR just adds a note that the plugin can be loaded manually with `flux jobtap load`. It includes the `flux account-priority-update` command so admins know to send flux-accounting information to the plugin once it is loaded.

Fixes #497 