### PR TITLE
doc: add ReadTheDocs support for flux-accounting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: doc/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,6 +54,10 @@ source_suffix = ".rst"
 extensions = ["sphinx.ext.intersphinx", "sphinx.ext.napoleon", "domainrefs"]
 
 domainrefs = {
+    "core:man1": {
+        "text": "%s(1)",
+        "url": "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man1/%s.html",
+    },
     "core:man5": {
         "text": "%s(5)",
         "url": "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man5/%s.html",
@@ -118,7 +122,7 @@ def man_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 # launch setup
 def setup(app):
     app.connect("builder-inited", run_apidoc)
-    for section in [5]:
+    for section in [1, 5]:
         app.add_role(f"man{section}", man_role)
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,13 @@
 Documentation for flux-accounting
 =================================
 
+This site contains documentation for flux-accounting configuration and
+management.
+
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+
+   guide/accounting-guide
 
 
 .. _man-pages:


### PR DESCRIPTION
#### Problem

flux-accounting currently has "official" documentation over in flux-framework/flux-docs, but for the flux-accounting guide (and other related documentation that could come in the future), it should follow flux-core's documentation configuration, which has guides hosted in its own repository and ReadTheDocs project that can then be linked to by flux-docs.

---

This PR looks to do add ReadTheDocs support for the flux-accounting repository. I've added a `.readthedocs.yaml` config file as well as added a link to `index.rst` to the flux-accounting guide hosted in this repository.

Once landed, I think all I need to do is go on the ReadTheDocs site and add this repository as a new project (at least, that was all I had to do in my local fork). Then I think I'd need to open a PR in flux-docs to remove the flux-accounting guide that's hosted there (and is slightly out-of-date) and point to the the flux-accounting guide that is hosted here. 