### PR TITLE
ci: add spellchecker to flux-accounting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,13 @@ jobs:
     - run: git fetch origin master
     - uses: flux-framework/pr-validator@master
 
+  spelling:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check Spelling
+      uses: crate-ci/typos@bcafd462cb07ef7ba57e34abf458fe20767e808b # v1.19.0
+
   python-format:
     name: python format
     runs-on: ubuntu-latest

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,29 @@
+# do not check code copied into the project
+# do not check sha code, lots of hashing false positives
+# do not check testing data
+[files]
+extend-exclude = [
+  "config/*",
+  "src/common/libtap/*",
+  "t/sharness.sh",
+  "doc/test/spell.en.pws",
+  "t/sharness",
+  "t/t0000-sharness.t",
+]
+
+[default.extend-words]
+# in hwloc output
+hsi = "hsi"
+# commonly used names/variables that aren't typos
+fo = "fo"
+ba = "ba"
+inout = "inout"
+trun = "trun"
+fullset = "fullset"
+mone = "mone"
+requestor = "requestor"
+requestors = "requestors"
+clen = "clen"
+WRONLY = "WRONLY"
+dne = "dne"
+DNE = "DNE"

--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -71,7 +71,7 @@ AC_DEFUN([AX_FLUX_CORE], [
       AC_SUBST(FLUX_PREFIX)
       AC_SUBST(LIBFLUX_VERSION)
       #  Ensure we find the same flux executable as corresponds to
-      #  to libflux-core found by pkg-config by puting FLUX_PREFIX/bin
+      #  to libflux-core found by pkg-config by putting FLUX_PREFIX/bin
       #  first in AC_PATH_PROG's path
       #
       AC_PATH_PROG(FLUX,[flux],

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -533,5 +533,6 @@ afternotok
 parsedatetime
 cancelall
 raiseall
-IPv4
-IPv6
+fairshare
+dne
+DNE

--- a/doc/test/spellcheck
+++ b/doc/test/spellcheck
@@ -22,7 +22,7 @@ if test  -z "$ASPELL"; then
    echo "1..0 # skip because aspell is not installed"
    exit 0
 fi
-if ! $ASPELL -n list </dev/null >/dev/null; then
+if ! $ASPELL -p $dict -n list </dev/null >/dev/null; then
    echo "1..$# # skip because aspell dry run failed"
    exit 0
 fi

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -107,7 +107,7 @@ def bank_is_active(cur, bank, parent_bank):
 def check_if_bank_disabled(cur, bank, parent_bank):
     """
     Check if the bank already exists but was disabled first. If so, just
-    update the 'active' column in the alread existing row.
+    update the 'active' column in the already existing row.
     """
     cur.execute(
         "SELECT * FROM bank_table WHERE bank=? AND parent_bank=?",
@@ -359,7 +359,7 @@ def delete_bank(conn, bank):
                     get_sub_banks(row[0])
 
         get_sub_banks(bank)
-    # if an exception occcurs while recursively deleting
+    # if an exception occurs while recursively deleting
     # the parent banks, then throw the exception and roll
     # back the changes made to the DB
     except sqlite3.OperationalError as exc:

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -17,7 +17,7 @@ from fluxacct.accounting import jobs_table_subcommands as j
 
 def update_t_inactive(acct_conn, last_t_inactive, user, bank):
     """
-    Save the timestamp of the most recent inactive job for the assocation.
+    Save the timestamp of the most recent inactive job for the association.
     """
     u_ts = """
         UPDATE job_usage_factor_table SET last_job_timestamp=? WHERE username=? AND bank=?

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -98,7 +98,7 @@ def delete_project(conn, project):
     cursor.execute(select_stmt, ("%" + project + "%",))
     result = cursor.fetchall()
     warning_stmt = (
-        "WARNING: user(s) in the assocation_table still "
+        "WARNING: user(s) in the association_table still "
         "reference this project. Make sure to edit user rows to "
         "account for this deleted project."
     )

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -52,7 +52,7 @@ def est_sqlite_conn(path):
     if db_version < fluxacct.accounting.db_schema_version:
         print(
             """flux-accounting database out of date; updating DB with """
-            """'flux account-update-db' before sending infomation to plugin"""
+            """'flux account-update-db' before sending information to plugin"""
         )
         # if flux account-update-db fails, we should not attempt to send data from
         # the DB to the priority plugin, and instead we should abort

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -342,7 +342,7 @@ class AccountingService:
         except ValueError as exc:
             handle.respond_error(msg, 0, f"{exc}")
         except sqlite3.Error as exc:
-            handle.respond_error(msg, 0, f"a SQLite error occured: {exc}")
+            handle.respond_error(msg, 0, f"a SQLite error occurred: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -50,7 +50,7 @@ public:
     json_t* to_json () const;    // convert object to JSON string
 };
 
-// - UKNOWN_QUEUE: a queue is specified for a submitted job that flux-accounting
+// - UNKNOWN_QUEUE: a queue is specified for a submitted job that flux-accounting
 // does not know about
 // - NO_QUEUE_SPECIFIED: no queue was specified for this job
 // - INVALID_QUEUE: the association does not have permission to run jobs under

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -655,7 +655,7 @@ static int validate_cb (flux_plugin_t *p,
     a = get_association (userid, bank, users, users_def_bank);
 
     if (a == nullptr) {
-        // the assocation could not be found in the plugin's internal map,
+        // the association could not be found in the plugin's internal map,
         // so perform a check to see if the map has any loaded
         // flux-accounting data before rejecting the job
         bool only_dne_data = check_map_for_dne_only (users, users_def_bank);

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -109,7 +109,7 @@ static void test_direct_map_access (
 }
 
 
-// ensure an Assocation* is returned on success
+// ensure an Association* is returned on success
 static void test_get_association_success ()
 {
     // retrieve user_bank_info object
@@ -180,7 +180,7 @@ static void test_get_queue_info_no_queue_specified ()
 }
 
 
-// ensure UNKOWN_QUEUE is returned when an unrecognized queue is passed in
+// ensure UNKNOWN_QUEUE is returned when an unrecognized queue is passed in
 static void test_get_queue_info_unknown_queue ()
 {
     Association a = users[1001]["bank_A"];

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -65,7 +65,7 @@ export PATH=/usr/lib/ccache:$PATH
 # Ensure ccache dir exists
 mkdir -p $HOME/.ccache
 
-# clang+ccache requries second cpp pass:
+# clang+ccache requires second cpp pass:
 if echo "$CC" | grep -q "clang"; then
     CCACHE_CPP=1
 fi

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -117,7 +117,7 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	flux cancel ${jobid2}
 '
 
-test_expect_success 'submit max number of jobs with a mix of default bank and explicity set bank' '
+test_expect_success 'submit max number of jobs with a mix of default bank and explicitly set bank' '
 	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
 	jobid2=$(flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account3 -n 1 sleep 60)
 '

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -90,7 +90,7 @@ test_expect_success 'editing a user project list with a non-existing project sho
 test_expect_success 'remove a project from the project_table that is still referenced by at least one user' '
 	flux account delete-project project_1 > warning_message.out &&
 	test_must_fail flux account view-project project_1 > deleted_project.out 2>&1 &&
-	grep "WARNING: user(s) in the assocation_table still reference this project." warning_message.out &&
+	grep "WARNING: user(s) in the association_table still reference this project." warning_message.out &&
 	grep "project project_1 not found in project_table" deleted_project.out
 '
 

--- a/t/t1033-mf-priority-update-job.t
+++ b/t/t1033-mf-priority-update-job.t
@@ -104,7 +104,7 @@ test_expect_success 'check that job is still in original queue' '
 	grep "\"queue\": \"bronze\"" jobspec.out
 '
 
-test_expect_success 'update job with invalud combination (invalid queue)' '
+test_expect_success 'update job with invalid combination (invalid queue)' '
 	test_must_fail flux update ${jobid} bank=B queue=gold > unavail_queue.out 2>&1 &&
 	test_debug "cat unavail_queue.out" &&
 	grep "ERROR: mf_priority: queue not valid for user: gold" unavail_queue.out


### PR DESCRIPTION
#### Problem

flux-accounting does not have a spellchecker that runs on pull requests.

---

This PR adds a spellchecker as another builder during CI. As a result of the spellchecker running (and my horrendous spelling), I've also fixed all of the spelling mistakes flagged by the spellchecker throughout flux-accounting. Like flux-core, I've removed `IPv4` and `IPv6` from the dictionary. Finally, I've added `"dne"`, `"DNE"`, and `"fairshare"` as acceptable words.