### PR TITLE
`add-bank`: add a check when adding a root bank

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -219,6 +219,12 @@ def print_parsable_hierarchy(cur, bank, hierarchy_str, indent=""):
 def add_bank(conn, bank, shares, parent_bank=""):
     cur = conn.cursor()
 
+    if parent_bank == "":
+        # a root bank is trying to be added; check that one does not already exist
+        cur.execute("SELECT * FROM bank_table WHERE parent_bank=''")
+        if len(cur.fetchall()) > 0:
+            raise ValueError(f"bank_table already has a root bank")
+
     # if the parent bank is not "", that means the bank trying
     # to be added wants to be placed under an existing parent bank
     try:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,6 +41,7 @@ TESTSCRIPTS = \
 	t1039-issue476.t \
 	t1040-mf-priority-projects.t \
 	t1041-view-jobs-by-project.t \
+	t1042-issue508.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -78,7 +78,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # add a user with the same username but a different bank
     def test_03_add_duplicate_user(self):
-        b.add_bank(acct_conn, bank="other_acct", shares=10)
+        b.add_bank(acct_conn, bank="other_acct", parent_bank="acct", shares=10)
         u.add_user(
             acct_conn,
             username="dup_user",
@@ -151,7 +151,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # check for a new user's default bank
     def test_07_check_default_bank_new_user(self):
-        b.add_bank(acct_conn, bank="test_bank", shares=10)
+        b.add_bank(acct_conn, bank="test_bank", parent_bank="acct", shares=10)
         u.add_user(
             acct_conn,
             username="test_user1",
@@ -167,7 +167,7 @@ class TestAccountingCLI(unittest.TestCase):
 
     # check for an existing user's default bank
     def test_08_check_default_bank_existing_user(self):
-        b.add_bank(acct_conn, bank="other_test_bank", shares=10)
+        b.add_bank(acct_conn, bank="other_test_bank", parent_bank="acct", shares=10)
         u.add_user(
             acct_conn,
             username="test_user1",
@@ -202,8 +202,8 @@ class TestAccountingCLI(unittest.TestCase):
     # disable a user who belongs to multiple banks; make sure that the default_bank
     # is updated to the next earliest associated bank
     def test_11_disable_user_default_bank_row(self):
-        b.add_bank(acct_conn, bank="A", shares=1)
-        b.add_bank(acct_conn, bank="B", shares=1)
+        b.add_bank(acct_conn, bank="A", parent_bank="acct", shares=1)
+        b.add_bank(acct_conn, bank="B", parent_bank="acct", shares=1)
         u.add_user(acct_conn, username="test_user2", bank="A")
         u.add_user(acct_conn, username="test_user2", bank="B")
         cur = acct_conn.cursor()

--- a/t/t1042-issue508.t
+++ b/t/t1042-issue508.t
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+test_description='test trying to add more than one root bank to the bank_table'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB, start flux-accounting service' '
+	flux account -p ${ACCOUNTING_DB} create-db &&
+	flux account-service -p ${ACCOUNTING_DB} -t
+'
+
+test_expect_success 'add a root bank' '
+	flux account add-bank root 1
+'
+
+test_expect_success 'adding a second root bank will raise a ValueError' '
+	test_must_fail flux account add-bank second_root 1 > error.out 2>&1 &&
+	grep "bank_table already has a root bank" error.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm ${ACCOUNTING_DB}
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Mentioned in #508, the structure of the flux-accounting database hierarchy of banks and users assumes there is only one root bank (e.g when calculating fair-share), but multiple root banks can be added with the `add-bank` command.

---

This PR adds a check when adding a root bank that one does not already exist. If so, an exception is raised.

A couple of existing tests that did not make this assumption have been edited to account for this new check, and I've also added a simple sharness test that ensures an exception is raised when trying to add more than one root bank.

Fixes #508 