### PR TITLE
`.gitignore`: add built docs, sharness test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,11 @@ config.h.in
 config.h.in~
 config.h
 config.status
+
+# misc
+*.trs
+*.log
+
+# docs intermediate files
+/doc/man*/*.xml
+/doc/_build


### PR DESCRIPTION
#### Problem

Git does not ignore the built documentation under `doc/_build` or the `.log` or `.trs` files as a result of running sharness tests.

---

This PR just adds the docs intermediate files and sharness test result files to the list of ignored files by Git.