### PR TITLE
`view-user --parsable`: improve output formatting

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -130,21 +130,26 @@ def create_json_object(conn, user):
 
 
 def get_user_rows(conn, user, headers, rows, parsable, json_fmt):
-    user_str = ""
-
     if parsable is True:
-        # find length of longest column name
-        col_width = len(sorted(headers, key=len)[-1])
+        # fetch column names and determine width of each column
+        col_widths = [
+            max(len(str(value)) for value in [col] + [row[i] for row in rows])
+            for i, col in enumerate(headers)
+        ]
 
-        for header in headers:
-            user_str += header.ljust(col_width)
-        user_str += "\n"
-        for row in rows:
-            for col in list(row):
-                user_str += str(col).ljust(col_width)
+        def format_row(row):
+            return " | ".join(
+                [f"{str(value).ljust(col_widths[i])}" for i, value in enumerate(row)]
+            )
 
-        return user_str
+        header = format_row(headers)
+        separator = "-+-".join(["-" * width for width in col_widths])
+        data_rows = "\n".join([format_row(row) for row in rows])
+        table = f"{header}\n{separator}\n{data_rows}"
 
+        return table
+
+    user_str = ""
     if json_fmt is True:
         user_str += create_json_object(conn, user)
 


### PR DESCRIPTION
#### Problem

Since the formatting of the columns in the output of `view-user --parsable` is dependent on the length of the longest column name, the width of every column is forced to match, which can result in some ugly screen wrapping even in a relatively small font.

```console
$ flux account view-user moussa1 --parsable
creation_time   mod_time        active          username        userid          bank            default_bank    shares          job_usage       fairshare       max_running_jobsmax_active_jobs max_nodes       queues          projects        default_project 
1661527404      1661527404      1               moussa1         58985           lc              lc              1               0.0             0.457547        100             1000            2147483647                      *               *   
```

---

This PR improves the formatting of `view-user --parsable` by making the width of each column dynamic based on the length of each column name instead of based on the length of the longest column name. Below is an example:

```console
$ flux account view-user user1 --parsable
creation_time | mod_time   | active | username | userid | bank | default_bank | shares | job_usage | fairshare | max_running_jobs | max_active_jobs | max_nodes  | queues | projects | default_project
--------------+------------+--------+----------+--------+------+--------------+--------+-----------+-----------+------------------+-----------------+------------+--------+----------+----------------
1729113599    | 1729113599 | 1      | user1    | 65534  | A    | A            | 1      | 0.0       | 0.5       | 5                | 7               | 2147483647 |        | *        | *   
```