### PR TITLE
fetch-job-records: set `max_entries=0`

### DIFF
--- a/src/cmd/flux-account-fetch-job-records.py
+++ b/src/cmd/flux-account-fetch-job-records.py
@@ -65,7 +65,10 @@ def fetch_new_jobs(last_timestamp=0.0):
 
     # construct and send RPC
     rpc_handle = flux.job.job_list_inactive(
-        handle, attrs=custom_attrs, since=last_timestamp
+        handle,
+        attrs=custom_attrs,
+        since=last_timestamp,
+        max_entries=0,
     )
     jobs = get_jobs(rpc_handle)
 


### PR DESCRIPTION
#### Problem

`flux account-fetch-job-records` uses `flux.job.job_list_inactive()` to fetch all jobs that have finished since a certain time. However, it does not set a value for `max_entries`, which defaults to 1000. This would mean that it could miss fetching certain jobs if more than 1000 completed since a certain time.

---

This PR sets `max_entries` to 0 to get all jobs that have finished since a certain timestamp.

Fixes #515