### PR TITLE
t: skip t1011 if job-archive module not detected, add new tests for `fetch-job-records`

### DIFF
--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -5,8 +5,6 @@ test_description='test fetching jobs and updating the fair share values for a gr
 . $(dirname $0)/sharness.sh
 
 DB_PATH=$(pwd)/FluxAccountingTest.db
-ARCHIVEDIR=`pwd`
-ARCHIVEDB="${ARCHIVEDIR}/jobarchive.db"
 QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
 NO_JOBS=${SHARNESS_TEST_SRCDIR}/expected/job_usage/no_jobs.expected
 
@@ -14,27 +12,6 @@ export FLUX_CONF_DIR=$(pwd)
 test_under_flux 4 job
 
 flux setattr log-stderr-level 1
-
-# wait for job to be stored in job archive
-# arg1 - jobid
-# arg2 - database path
-wait_db() {
-		local jobid=$(flux job id $1)
-		local dbpath=$2
-		local i=0
-		query="select id from jobs;"
-		while ! ${QUERYCMD} -t 100 ${dbpath} "${query}" | grep $jobid > /dev/null \
-			   && [ $i -lt 50 ]
-		do
-				sleep 0.1
-				i=$((i + 1))
-		done
-		if [ "$i" -eq "100" ]
-		then
-			return 1
-		fi
-		return 0
-}
 
 # select job records from flux-accounting DB
 select_job_records() {
@@ -70,29 +47,14 @@ test_expect_success 'add some users to the DB' '
 	flux account add-user --username=user5012 --userid=5012 --bank=account1 --shares=1
 '
 
-test_expect_success 'job-archive: set up config file' '
-		cat >archive.toml <<EOF &&
-[archive]
-dbpath = "${ARCHIVEDB}"
-period = "0.5s"
-busytimeout = "0.1s"
-EOF
-	flux config reload
-'
-
-test_expect_success 'load job-archive module' '
-	flux module load job-archive
-'
-
 test_expect_success 'submit a job that does not run' '
 	job=$(flux submit --urgency=0 sleep 60) &&
 	flux job wait-event -vt 10 ${job} priority &&
-	flux cancel ${job} &&
-	wait_db ${job} ${ARCHIVEDB}
+	flux cancel ${job}
 '
 
 test_expect_success 'run scripts to update job usage and fair-share' '
-	flux account-fetch-job-records --copy ${ARCHIVEDB} -p ${DB_PATH} &&
+	flux account-fetch-job-records -p ${DB_PATH} &&
 	flux account -p ${DB_PATH} update-usage &&
 	flux account-update-fshare -p ${DB_PATH}
 '
@@ -108,19 +70,19 @@ test_expect_success 'check that no jobs show up under user' '
 	test_cmp ${NO_JOBS} no_jobs.test
 '
 
-test_expect_success 'submit some jobs so they populate flux-core job-archive' '
+test_expect_success 'submit some jobs and wait for them to finish running' '
 	jobid1=$(flux submit -N 1 hostname) &&
 	jobid2=$(flux submit -N 1 hostname) &&
 	jobid3=$(flux submit -N 2 hostname) &&
 	jobid4=$(flux submit -N 1 hostname) &&
-	wait_db ${jobid1} ${ARCHIVEDB} &&
-	wait_db ${jobid2} ${ARCHIVEDB} &&
-	wait_db ${jobid3} ${ARCHIVEDB} &&
-	wait_db ${jobid4} ${ARCHIVEDB}
+	flux job wait-event -vt 3 ${jobid1} clean &&
+	flux job wait-event -vt 3 ${jobid2} clean &&
+	flux job wait-event -vt 3 ${jobid3} clean &&
+	flux job wait-event -vt 3 ${jobid4} clean
 '
 
-test_expect_success 'call --copy argument to populate jobs table from job-archive DB' '
-	flux account-fetch-job-records --copy ${ARCHIVEDB} -p ${DB_PATH} &&
+test_expect_success 'run fetch-job-records; ensure jobs show up in jobs table' '
+	flux account-fetch-job-records -p ${DB_PATH} &&
 	select_job_records ${DB_PATH} > records.out &&
 	grep "hostname" records.out
 '
@@ -129,17 +91,13 @@ test_expect_success 'submit some sleep 1 jobs under one user' '
 	jobid1=$(flux submit -N 1 sleep 1) &&
 	jobid2=$(flux submit -N 1 sleep 1) &&
 	jobid3=$(flux submit -n 2 -N 2 sleep 1) &&
-	wait_db ${jobid1} ${ARCHIVEDB} &&
-	wait_db ${jobid2} ${ARCHIVEDB} &&
-	wait_db ${jobid3} ${ARCHIVEDB}
+	flux job wait-event -vt 3 ${jobid1} clean &&
+	flux job wait-event -vt 3 ${jobid2} clean &&
+	flux job wait-event -vt 3 ${jobid3} clean
 '
 
 test_expect_success 'run fetch-job-records script' '
 	flux account-fetch-job-records -p ${DB_PATH}
-'
-
-test_expect_success 'view job records for a user' '
-	flux account -p ${DB_PATH} view-job-records --user $username
 '
 
 test_expect_success 'view job records for a user and direct it to a file' '
@@ -160,9 +118,9 @@ test_expect_success 'submit some sleep 1 jobs under the secondary bank of the sa
 	jobid1=$(flux submit --setattr=system.bank=account2 -N 1 sleep 1) &&
 	jobid2=$(flux submit --setattr=system.bank=account2 -N 1 sleep 1) &&
 	jobid3=$(flux submit --setattr=system.bank=account2 -n 2 -N 2 sleep 1) &&
-	wait_db ${jobid1} ${ARCHIVEDB} &&
-	wait_db ${jobid2} ${ARCHIVEDB} &&
-	wait_db ${jobid3} ${ARCHIVEDB}
+	flux job wait-event -vt 3 ${jobid1} clean &&
+	flux job wait-event -vt 3 ${jobid2} clean &&
+	flux job wait-event -vt 3 ${jobid3} clean
 '
 
 test_expect_success 'run custom job-list script' '
@@ -193,10 +151,6 @@ test_expect_success 'call update-usage in the same half-life period where no job
 
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
-'
-
-test_expect_success 'job-archive: unload module' '
-	flux module unload job-archive
 '
 
 test_expect_success 'shut down flux-accounting service' '


### PR DESCRIPTION
#### Problem

Mentioned in #517, `t1011-job-archive-interface.t` relies on the job-archive module
 in flux-core which is being considered for removal in
 https://github.com/flux-framework/flux-core/pull/6378 since flux-accounting now has that
 capability on its own.

---

This PR adds a check in `t1011-job-archive-interface.t` that will skip the test file in the event that the job-archive module does not exist.

I've also added a new file to the test suite that very similarly runs through the same tests in `t1011` but does not rely at all on the detection of the job-archive module. 