### PR TITLE
python: add `AccountingFormatter` class, SQLite utility file

### DIFF
--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -7,7 +7,8 @@ acctpy_PYTHON = \
 	job_usage_calculation.py \
 	jobs_table_subcommands.py \
 	db_info_subcommands.py \
-	create_db.py
+	create_db.py \
+	formatter.py
 
 clean-local:
 	-rm -f *.pyc *.pyo

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -8,7 +8,8 @@ acctpy_PYTHON = \
 	jobs_table_subcommands.py \
 	db_info_subcommands.py \
 	create_db.py \
-	formatter.py
+	formatter.py \
+	sql_util.py
 
 clean-local:
 	-rm -f *.pyc *.pyo

--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -2,4 +2,53 @@ DB_DIR = "@X_LOCALSTATEDIR@/lib/flux/"
 DB_PATH = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
 DB_SCHEMA_VERSION = 23
 
-__all__ = ["DB_DIR", "DB_PATH", "DB_SCHEMA_VERSION"]
+# flux-accounting DB table column names
+ASSOCIATION_TABLE = [
+    "creation_time",
+    "mod_time",
+    "active",
+    "username",
+    "userid",
+    "bank",
+    "default_bank",
+    "shares",
+    "job_usage",
+    "fairshare",
+    "max_running_jobs",
+    "max_active_jobs",
+    "max_nodes",
+    "queues",
+    "projects",
+    "default_project",
+]
+BANK_TABLE = ["bank_id", "bank", "active", "parent_bank", "shares", "job_usage"]
+QUEUE_TABLE = [
+    "queue",
+    "min_nodes_per_job",
+    "max_nodes_per_job",
+    "max_time_per_job",
+    "priority",
+]
+PROJECT_TABLE = ["project_id", "project", "usage"]
+JOBS_TABLE = [
+    "id",
+    "userid",
+    "t_submit",
+    "t_run",
+    "t_inactive",
+    "ranks",
+    "R",
+    "jobspec",
+    "project",
+]
+
+__all__ = [
+    "DB_DIR",
+    "DB_PATH",
+    "DB_SCHEMA_VERSION",
+    "ASSOCIATION_TABLE",
+    "BANK_TABLE",
+    "QUEUE_TABLE",
+    "PROJECT_TABLE",
+    "JOBS_TABLE",
+]

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import json
+
+
+class AccountingFormatter:
+    def __init__(self, cursor):
+        """
+        Initialize an AccountingFormatter object with a SQLite cursor.
+
+        Args:
+            cursor: a SQLite Cursor object that has the results of a SQL query.
+        """
+        self.cursor = cursor
+        self.column_names = [description[0] for description in cursor.description]
+        self.rows = self.cursor.fetchall()
+
+        if not self.rows:
+            # the SQL query didn't fetch any results; raise an Exception
+            raise ValueError("no results found in query")
+
+    def get_column_names(self):
+        """
+        Return the column names from the query result.
+
+        Returns:
+            list: list of column names.
+        """
+        return self.column_names
+
+    def get_rows(self):
+        """
+        Return all rows fetched by the cursor.
+
+        Returns:
+            list: list of tuples representing rows of data.
+        """
+        return self.rows
+
+    def as_table(self):
+        """
+        Format a SQL query in table format.
+
+        Returns:
+            table: the data from the query formatted as a table.
+        """
+        # fetch column names and determine the width of each column
+        col_names = [description[0] for description in self.cursor.description]
+        col_widths = [
+            max(len(str(value)) for value in [col] + [row[i] for row in self.rows])
+            for i, col in enumerate(col_names)
+        ]
+
+        # format a row of data
+        def format_row(row):
+            return " | ".join(
+                [f"{str(value).ljust(col_widths[i])}" for i, value in enumerate(row)]
+            )
+
+        # format the header, separator, and data rows
+        header = format_row(col_names)
+        separator = "-+-".join(["-" * width for width in col_widths])
+        data_rows = "\n".join([format_row(row) for row in self.rows])
+
+        table = f"{header}\n{separator}\n{data_rows}"
+
+        return table
+
+    def as_json(self):
+        """
+        Format a SQL query in JSON format.
+
+        Returns:
+            json_string: the data from the query formatted as a JSON string.
+        """
+        # fetch column names
+        col_names = [description[0] for description in self.cursor.description]
+
+        # create a list of dictionaries, one for each row
+        table_data = [
+            {col_names[i]: row[i] for i in range(len(col_names))} for row in self.rows
+        ]
+
+        # convert the list of dictionaries to a JSON string
+        json_string = json.dumps(table_data, indent=2)
+
+        return json_string

--- a/src/bindings/python/fluxacct/accounting/sql_util.py
+++ b/src/bindings/python/fluxacct/accounting/sql_util.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+def validate_columns(columns, valid_columns):
+    """
+    Validate a list of of columns against a list of valid columns of a table
+    in a flux-accounting database.
+
+    Args:
+        columns: a list of column names
+        valid_columns: a list of valid column names
+
+    Raises:
+        ValueError: at least one of the columns passed in is not valid
+    """
+    invalid_columns = [column for column in columns if column not in valid_columns]
+    if invalid_columns:
+        raise ValueError(f"invalid fields: {', '.join(invalid_columns)}")

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -49,7 +49,8 @@ TESTSCRIPTS = \
 	python/t1003_bank_cmds.py \
 	python/t1004_queue_cmds.py \
 	python/t1005_project_cmds.py \
-	python/t1006_job_archive.py
+	python/t1006_job_archive.py \
+	python/t1007_formatter.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/python/t1007_formatter.py
+++ b/t/python/t1007_formatter.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+import fluxacct.accounting
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import formatter as fmt
+from fluxacct.accounting import sql_util as sql
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        c.create_db("TestFormatter.db")
+        global conn
+        global cur
+
+        conn = sqlite3.connect("TestFormatter.db")
+        cur = conn.cursor()
+
+    # initialize Formatter object with no data in Cursor object
+    def test_AccountingFormatter_empty(self):
+        with self.assertRaises(ValueError):
+            cur.execute("SELECT * FROM bank_table")
+            formatter = fmt.AccountingFormatter(cur)
+
+    # add some data to a table and re-initialize formatter
+    def test_AccountingFormatter_with_banks(self):
+        b.add_bank(conn, bank="root", shares=1)
+        b.add_bank(conn, bank="A", shares=1, parent_bank="root")
+        b.add_bank(conn, bank="B", shares=1, parent_bank="root")
+        b.add_bank(conn, bank="C", shares=1, parent_bank="root")
+
+        cur.execute("SELECT * FROM bank_table")
+        formatter = fmt.AccountingFormatter(cur)
+
+        self.assertIsInstance(formatter, fmt.AccountingFormatter)
+
+    # ensure formatter has the correct number of rows
+    def test_formatter_get_rows(self):
+        cur.execute("SELECT * FROM bank_table")
+        formatter = fmt.AccountingFormatter(cur)
+
+        self.assertEqual(len(formatter.get_rows()), 4)
+
+    # ensure formatter retrieves only the column names passed by query
+    def test_formatter_get_column_names_default(self):
+        cur.execute("SELECT * FROM bank_table")
+        formatter = fmt.AccountingFormatter(cur)
+
+        self.assertEqual(formatter.get_column_names(), fluxacct.accounting.BANK_TABLE)
+
+    def test_formatter_get_column_names_custom(self):
+        cur.execute("SELECT bank_id FROM bank_table")
+        formatter = fmt.AccountingFormatter(cur)
+
+        self.assertEqual(formatter.get_column_names(), ["bank_id"])
+
+    # ensure default fields can be accessed for relevant flux-accounting
+    # tables in DB
+    def test_default_columns_association_table(self):
+        cur.execute("PRAGMA table_info (association_table)")
+        columns = cur.fetchall()
+        association_table = [column[1] for column in columns]
+
+        self.assertEqual(fluxacct.accounting.ASSOCIATION_TABLE, association_table)
+
+    def test_default_columns_bank_table(self):
+        cur.execute("PRAGMA table_info (bank_table)")
+        columns = cur.fetchall()
+        bank_table = [column[1] for column in columns]
+
+        self.assertEqual(fluxacct.accounting.BANK_TABLE, bank_table)
+
+    def test_default_columns_queue_table(self):
+        cur.execute("PRAGMA table_info (queue_table)")
+        columns = cur.fetchall()
+        queue_table = [column[1] for column in columns]
+
+        self.assertEqual(fluxacct.accounting.QUEUE_TABLE, queue_table)
+
+    def test_default_columns_project_table(self):
+        cur.execute("PRAGMA table_info (project_table)")
+        columns = cur.fetchall()
+        project_table = [column[1] for column in columns]
+
+        self.assertEqual(fluxacct.accounting.PROJECT_TABLE, project_table)
+
+    def test_default_columns_jobs_table(self):
+        cur.execute("PRAGMA table_info (jobs)")
+        columns = cur.fetchall()
+        jobs_table = [column[1] for column in columns]
+
+        self.assertEqual(fluxacct.accounting.JOBS_TABLE, jobs_table)
+
+    # an exception is raised if the columns passed in are not valid
+    def test_validate_columns_invalid(self):
+        with self.assertRaises(ValueError):
+            sql.validate_columns(["foo"], fluxacct.accounting.ASSOCIATION_TABLE)
+
+    def test_validate_columns_valid(self):
+        cur.execute("SELECT username, bank FROM association_table")
+        column_names = [description[0] for description in cur.description]
+
+        sql.validate_columns(column_names, fluxacct.accounting.ASSOCIATION_TABLE)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove("TestFormatter.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
#### Problem

flux-accounting has lots of different tables that can be viewed with `view-*` and `list-*` commands, but each one has its own function that could probably be cleaned up with some common utility. Better yet, if the formatting options for all of these commands was centralized, it might make for easier changes in the future and/or customization of output by users.

---

This PR begins to centralize the formatting for flux-accounting by adding a new `AccountingFormatter` class to the Python bindings. The class takes a SQLite `Cursor` object that has the results of running a query on the flux-accounting database and offers two methods of formatting its data: data in an adjustable table or data in JSON format. Since this class just takes a `Cursor` object, this means it can support customization of what fields are formatted and returned (because the query itself can just be customized to not fetch every field).

I've also added a SQLite utility file to the Python bindings to also help centralize some of the basic SQL helpers I have throughout the bindings. I've started with just a simple validation function where, given a custom list of columns passed in, that list is then validated against what is actually defined in the flux-accounting database.

I've added some basic unit tests for the `AccountingFormatter` class and the utilization of the `sql_util` helper function.