### PR TITLE
`__init__.py`: fix formatting of constants

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -1,5 +1,5 @@
-db_dir = "@X_LOCALSTATEDIR@/lib/flux/"
-db_path = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
-db_schema_version = 23
+DB_DIR = "@X_LOCALSTATEDIR@/lib/flux/"
+DB_PATH = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
+DB_SCHEMA_VERSION = 23
 
-__all__ = ["db_dir", "db_path", "db_schema_version"]
+__all__ = ["DB_DIR", "DB_PATH", "DB_SCHEMA_VERSION"]

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -85,7 +85,7 @@ def create_db(
         sys.exit(1)
 
     # set version number of database
-    conn.execute("PRAGMA user_version = %d" % (fluxacct.accounting.db_schema_version))
+    conn.execute("PRAGMA user_version = %d" % (fluxacct.accounting.DB_SCHEMA_VERSION))
 
     # Association Table
     logging.info("Creating association_table in DB...")

--- a/src/cmd/flux-account-fetch-job-records.py
+++ b/src/cmd/flux-account-fetch-job-records.py
@@ -22,7 +22,7 @@ import fluxacct.accounting
 
 
 def set_db_loc(args):
-    path = args.path if args.path else fluxacct.accounting.db_path
+    path = args.path if args.path else fluxacct.accounting.DB_PATH
 
     return path
 

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -23,7 +23,7 @@ import fluxacct.accounting
 
 
 def set_db_loc(args):
-    path = args.path if args.path else fluxacct.accounting.db_path
+    path = args.path if args.path else fluxacct.accounting.DB_PATH
 
     return path
 
@@ -49,7 +49,7 @@ def est_sqlite_conn(path):
     cur = conn.cursor()
     cur.execute("PRAGMA user_version")
     db_version = cur.fetchone()[0]
-    if db_version < fluxacct.accounting.db_schema_version:
+    if db_version < fluxacct.accounting.DB_SCHEMA_VERSION:
         print(
             """flux-accounting database out of date; updating DB with """
             """'flux account-update-db' before sending information to plugin"""

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -599,7 +599,7 @@ def main():
 
     # try to connect to flux-accounting database; if connection fails, exit
     # flux-accounting service
-    db_path = args.path if args.path else fluxacct.accounting.db_path
+    db_path = args.path if args.path else fluxacct.accounting.DB_PATH
     conn = establish_sqlite_connection(db_path)
 
     # check version of database; if not up to date, output message

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -23,7 +23,7 @@ from fluxacct.accounting import create_db as c
 
 
 def set_db_loc(args):
-    path = args.old_db if args.old_db else fluxacct.accounting.db_path
+    path = args.old_db if args.old_db else fluxacct.accounting.DB_PATH
 
     return path
 
@@ -238,7 +238,7 @@ def update_db(path, new_db):
 
             # update user_version for DB
             old_cur.execute(
-                "PRAGMA user_version = %d" % (fluxacct.accounting.db_schema_version)
+                "PRAGMA user_version = %d" % (fluxacct.accounting.DB_SCHEMA_VERSION)
             )
 
             # commit changes

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -645,7 +645,7 @@ def add_arguments_to_parser(parser, subparsers):
 
 
 def set_db_location(args):
-    path = args.path if args.path else fluxacct.accounting.db_path
+    path = args.path if args.path else fluxacct.accounting.DB_PATH
 
     return path
 


### PR DESCRIPTION
#### Problem

The constants defined in `__init__.py` for the flux-accounting Python package are formatted incorrectly and are flagged by `pylint`. They should be in all caps:

```
__init__.py:1:0: C0103: Constant name "db_dir" doesn't conform to '(([A-Z_][A-Z0-9_]*)|(__.*__))$' pattern (invalid-name)
__init__.py:2:0: C0103: Constant name "db_path" doesn't conform to '(([A-Z_][A-Z0-9_]*)|(__.*__))$' pattern (invalid-name)
__init__.py:3:0: C0103: Constant name "db_schema_version" doesn't conform to '(([A-Z_][A-Z0-9_]*)|(__.*__))$' pattern (invalid-name)
```

---

This PR fixes the format of the constants defined in `__init__.py` and changes the references to these constants throughout the Python package to account for the change.