### PR TITLE
`list-banks`: use `AccountingFormatter` class

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -331,7 +331,8 @@ class AccountingService:
             val = b.list_banks(
                 self.conn,
                 msg.payload["inactive"],
-                msg.payload["fields"].split(","),
+                msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
+                msg.payload["table"],
             )
 
             payload = {"list_banks": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -370,8 +370,14 @@ def add_list_banks_arg(subparsers):
         "--fields",
         type=str,
         help="list of fields to include in JSON output",
-        default="bank_id,bank,parent_bank,shares,job_usage",
+        default=None,
         metavar="BANK_ID,BANK,ACTIVE,PARENT_BANK,SHARES,JOB_USAGE",
+    )
+    subparser_list_banks.add_argument(
+        "--table",
+        action="store_const",
+        const=True,
+        help="list all banks in table format",
     )
 
 


### PR DESCRIPTION
#### Problem

The `list-banks` command defines its own formatting for the output of the command, but the Python bindings now has its own common formatter and SQL utilities.

---

This PR edits the `list-banks` command to make use of the new formatter and external SQLite utilities. It also changes the default for the `--fields` optional argument to be `None` if it is not specified.