### PR TITLE
`view-user`: create new `AssociationFormatter` subclass for viewing associations

### DIFF
--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -286,3 +286,23 @@ class BankFormatter(AccountingFormatter):
             return info
         except ValueError:
             return info + f"\n\nno users under {bank}"
+
+
+class AssociationFormatter(AccountingFormatter):
+    """
+    Subclass of AccountingFormatter, specific to associations in the flux-accounting
+    database.
+    """
+
+    def __init__(self, cursor, username):
+        """
+        Initialize an AssociationFormatter object with a SQLite cursor.
+
+        Args:
+            cursor: a SQLite Cursor object that has the results of a SQL query.
+            username: the username of the association.
+        """
+        self.username = username
+        super().__init__(
+            cursor, error_msg=f"user {self.username} not found in association_table"
+        )

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -149,7 +149,7 @@ class AccountingService:
                 self.conn,
                 msg.payload["username"],
                 msg.payload["parsable"],
-                msg.payload["json"],
+                msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
             )
 
             payload = {"view_user": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -47,11 +47,15 @@ def add_view_user_arg(subparsers):
         metavar="PARSABLE",
     )
     subparser_view_user.add_argument(
-        "--json",
-        action="store_const",
-        const=True,
-        help="print all information of an association in JSON format",
-        metavar="JSON",
+        "--fields",
+        type=str,
+        help="list of fields to include in JSON output",
+        default=None,
+        metavar=(
+            "CREATION_TIME,MOD_TIME,ACTIVE,USERNAME,USERID,BANK,DEFAULT_BANK,"
+            "SHARES,JOB_USAGE,FAIRSHARE,MAX_RUNNING_JOBS,MAX_ACTIVE_JOBS,MAX_NODES,"
+            "QUEUES,PROJECTS,DEFAULT_PROJECT"
+        ),
     )
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -53,6 +53,7 @@ TESTSCRIPTS = \
 	python/t1006_job_archive.py \
 	python/t1007_formatter.py \
 	python/t1008_banks_output.py
+	python/t1009_users_output.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/python/t1009_users_output.py
+++ b/t/python/t1009_users_output.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import textwrap
+
+import fluxacct.accounting
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import formatter as fmt
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        c.create_db("test_view_associations.db")
+        global conn
+        global cur
+
+        conn = sqlite3.connect("test_view_associations.db")
+        cur = conn.cursor()
+
+    # add some associations, initialize formatter
+    def test_AccountingFormatter_with_associations(self):
+        b.add_bank(conn, bank="root", shares=1)
+        b.add_bank(conn, bank="A", shares=1, parent_bank="root")
+        u.add_user(conn, username="user1", bank="A")
+
+        cur.execute("SELECT * FROM association_table")
+        formatter = fmt.AssociationFormatter(cur, "user1")
+
+        self.assertIsInstance(formatter, fmt.AssociationFormatter)
+
+    def test_default_columns_association_table(self):
+        cur.execute("PRAGMA table_info (association_table)")
+        columns = cur.fetchall()
+        association_table = [column[1] for column in columns]
+
+        self.assertEqual(fluxacct.accounting.ASSOCIATION_TABLE, association_table)
+
+    def test_view_association_noexist(self):
+        with self.assertRaises(ValueError):
+            u.view_user(conn, user="foo")
+
+    # test JSON output for viewing an association
+    def test_view_association(self):
+        expected = textwrap.dedent(
+            """\
+        [
+          {
+            "active": 1,
+            "username": "user1",
+            "bank": "A",
+            "shares": 1
+          }
+        ]
+        """
+        )
+        test = u.view_user(
+            conn, user="user1", cols=["active", "username", "bank", "shares"]
+        )
+        self.assertEqual(expected.strip(), test.strip())
+
+    def test_view_association_table(self):
+        expected = textwrap.dedent(
+            """\
+        active | username | bank | shares
+        -------+----------+------+-------
+        1      | user1    | A    | 1  
+        """
+        )
+        test = u.view_user(
+            conn,
+            user="user1",
+            parsable=True,
+            cols=["active", "username", "bank", "shares"],
+        )
+        self.assertEqual(expected.strip(), test.strip())
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove("test_view_associations.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -77,11 +77,6 @@ test_expect_success 'view some user information with --parsable' '
 	grep -w "user5011\|5011\|A" user_info_parsable.out
 '
 
-test_expect_success 'view some user information with --json' '
-	flux account view-user --json user5014 > user_info_json.out &&
-	grep -w "\"username\": \"user5014\"\|\"userid\": 5014\|\"bank\": \"C\"" user_info_json.out
-'
-
 test_expect_success 'edit a userid for a user' '
 	flux account edit-user user5011 --userid=12345 &&
 	flux account view-user user5011 > edit_userid.out &&

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -67,7 +67,9 @@ test_expect_success 'trying to add an association that already exists should rai
 
 test_expect_success 'view some user information' '
 	flux account view-user user5011 > user_info.out &&
-	grep -w "username: user5011\|userid: 5011\|bank: A" user_info.out
+	grep "\"username\": \"user5011\"" user_info.out &&
+	grep "\"userid\": 5011" user_info.out &&
+	grep "\"bank\": \"A\"" user_info.out
 '
 
 test_expect_success 'view some user information with --parsable' '
@@ -95,7 +97,7 @@ test_expect_success 'edit the max_active_jobs of an existing user' '
 
 test_expect_success 'trying to view a user who does not exist in the DB should raise a ValueError' '
 	test_must_fail flux account view-user user9999 > user_nonexistent.out 2>&1 &&
-	grep "User user9999 not found in association_table" user_nonexistent.out
+	grep "view-user: user user9999 not found in association_table" user_nonexistent.out
 '
 
 test_expect_success 'trying to view a user that does exist in the DB should return some information' '

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -60,9 +60,9 @@ test_expect_success 'run scripts to update job usage and fair-share' '
 '
 
 test_expect_success 'check that usage does not get affected by canceled jobs' '
-	flux account view-user --json $username > user.json &&
+	flux account view-user $username > user.json &&
 	test_debug "jq -S . <user.json" &&
-	jq -e ".banks[0].job_usage == 0.0" <user.json
+	jq -e ".[0].job_usage == 0.0" <user.json
 '
 
 test_expect_success 'check that no jobs show up under user' '
@@ -133,9 +133,9 @@ test_expect_success 'run update-usage and update-fshare commands' '
 '
 
 test_expect_success 'check that job usage and fairshare values get updated' '
-	flux account -p ${DB_PATH} view-user $username --json > query1.json &&
+	flux account -p ${DB_PATH} view-user $username > query1.json &&
 	test_debug "jq -S . <query1.json" &&
-	jq -e ".banks[1].job_usage >= 4" <query1.json
+	jq -e ".[1].job_usage >= 4" <query1.json
 '
 
 # if update-usage is called in the same half-life period when no jobs are found
@@ -144,9 +144,9 @@ test_expect_success 'check that job usage and fairshare values get updated' '
 test_expect_success 'call update-usage in the same half-life period where no jobs are run' '
 	flux account -p ${DB_PATH} update-usage &&
 	flux account-update-fshare -p ${DB_PATH} &&
-	flux account -p ${DB_PATH} view-user $username --json > query2.json &&
+	flux account -p ${DB_PATH} view-user $username > query2.json &&
 	test_debug "jq -S . <query2.json" &&
-	jq -e ".banks[1].job_usage >= 4" <query2.json
+	jq -e ".[1].job_usage >= 4" <query2.json
 '
 
 test_expect_success 'remove flux-accounting DB' '

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -115,9 +115,9 @@ test_expect_success 'delete user default bank row' '
 
 test_expect_success 'check that user default bank gets updated to other bank' '
 	flux account view-user user5015 > new_default_bank.out &&
-	grep "username: user5015" new_default_bank.out &&
-	grep "bank: F" new_default_bank.out &&
-	grep "default_bank: F" new_default_bank.out
+	grep "\"username\": \"user5015\"" new_default_bank.out
+	grep "\"bank\": \"F\"" new_default_bank.out &&
+	grep "\"default_bank\": \"F\"" new_default_bank.out
 '
 
 test_expect_success 'trying to add a user to a nonexistent bank should raise a ValueError' '

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -139,7 +139,7 @@ test_expect_success 'edit the default project of a user' '
 
 test_expect_success 'reset the projects list for an association' '
 	flux account edit-user user5018 --projects=-1 &&
-	flux account view-user user5018 --json > user5018.json &&
+	flux account view-user user5018 > user5018.json &&
 	grep "\"projects\": \"*\"" user5018.json
 '
 

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -68,7 +68,8 @@ test_expect_success 'view project information from the project_table' '
 test_expect_success 'add a user with some specified projects to the association_table' '
 	flux account add-user --username=user5015 --bank=A --projects="project_1,project_3" &&
 	flux account view-user user5015 > user5015_info.out &&
-	grep -w "username: user5015\|projects: project_1,project_3,*" user5015_info.out
+	grep "\"username\": \"user5015\"" user5015_info.out &&
+	grep ""project_1,project_3,*"" user5015_info.out
 '
 
 test_expect_success 'adding a user with a non-existing project should fail' '
@@ -79,7 +80,8 @@ test_expect_success 'adding a user with a non-existing project should fail' '
 test_expect_success 'successfully edit a projects list for a user' '
 	flux account edit-user user5015 --bank=A --projects="project_1,project_2,project_3" &&
 	flux account view-user user5015 > user5015_edited_info.out &&
-	grep -w "username: user5015\|projects: project_1,project_2,project_3,*" user5015_edited_info.out
+	grep "\"username\": \"user5015\"" user5015_edited_info.out &&
+	grep "project_1,project_2,project_3,*" user5015_edited_info.out
 '
 
 test_expect_success 'editing a user project list with a non-existing project should fail' '


### PR DESCRIPTION
#### Problem

The `view_user()` function manually defines its own print functionality for viewing information about an association in the
flux-accounting database, but the Python bindings have its own formatting class that does this. It's also tedious to add new formatting features to the `view_user()` function.

---

This PR creates a new subclass of `AccountingFormatter` called `AssociationFormatter`. It has a unique error message when the user cannot be found in the `association_table`, but otherwise inherits the default JSON and table outputs that the `AccountingFormatter` class already provides. Thus, the various helper functions used to create output for the `view_user()` functions could be removed.

I've edited a number of tests in the testsuite that check for specific output from the `view-user` command, as well as added unit tests for the `view_user()` function.