### PR TITLE
[WIP] `export-db`: allow formatting customization of `association_table` and `bank_table`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -76,6 +76,7 @@ def populate_db(conn, users=None, banks=None):
         try:
             with open(banks) as csv_file:
                 csv_reader = csv.reader(csv_file, delimiter=",")
+                headers = next(csv_reader)
 
                 for row in csv_reader:
                     b.add_bank(
@@ -91,6 +92,7 @@ def populate_db(conn, users=None, banks=None):
         try:
             with open(users) as csv_file:
                 csv_reader = csv.reader(csv_file, delimiter=",")
+                headers = next(csv_reader)
 
                 # assign default values to fields if
                 # their slot is empty in the csv file

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -548,6 +548,12 @@ class AccountingService:
                 self.conn,
                 msg.payload["users"],
                 msg.payload["banks"],
+                msg.payload["bank_fields"].split(",")
+                if msg.payload.get("bank_fields")
+                else None,
+                msg.payload["user_fields"].split(",")
+                if msg.payload.get("user_fields")
+                else None,
             )
 
             payload = {"export_db": val}
@@ -555,6 +561,12 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except IOError as exc:
+            handle.respond_error(msg, 0, f"an IOError occurred: {exc}")
+        except ValueError as exc:
+            handle.respond_error(msg, 0, f"{exc}")
+        except sqlite3.OperationalError as exc:
+            handle.respond_error(msg, 0, f"{exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -582,6 +582,20 @@ def add_export_db_arg(subparsers):
     subparser.add_argument(
         "-b", "--banks", help="path to a .csv file containing bank information"
     )
+    subparser.add_argument(
+        "--bank-fields",
+        help="list of fields from bank_table to include",
+        metavar="BANK_ID,BANK,ACTIVE,PARENT_BANK,SHARES,JOB_USAGE",
+    )
+    subparser.add_argument(
+        "--user-fields",
+        help="list of fields from association_table to include",
+        metavar=(
+            "CREATION_TIME,MOD_TIME,ACTIVE,USERNAME,USERID,BANK,DEFAULT_BANK,"
+            "SHARES,JOB_USAGE,FAIRSHARE,MAX_RUNNING_JOBS,MAX_ACTIVE_JOBS,MAX_NODES,"
+            "QUEUES,PROJECTS,DEFAULT_PROJECT"
+        ),
+    )
 
 
 def add_pop_db_arg(subparsers):

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -22,6 +22,7 @@ test_expect_success 'start flux-accounting service' '
 
 test_expect_success 'create a banks.csv file containing bank information' '
 	cat <<-EOF >banks.csv
+	bank,parent_bank,shares
 	root,,1
 	A,root,1
 	B,root,1
@@ -36,6 +37,7 @@ test_expect_success 'populate flux-accounting DB with banks.csv' '
 
 test_expect_success 'create a users.csv file containing user information' '
 	cat <<-EOF >users.csv
+	username,uid,bank,shares,max_running_jobs,max_active_jobs,max_nodes,queues
 	user1000,1000,A,1,10,15,5,""
 	user1001,1001,A,1,10,15,5,""
 	user1002,1002,A,1,10,15,5,""
@@ -55,6 +57,7 @@ test_expect_success 'check database hierarchy to make sure all banks & users wer
 
 test_expect_success 'create a users.csv file with some missing optional user information' '
 	cat <<-EOF >users_optional_vals.csv
+	username,uid,bank,shares,max_running_jobs,max_active_jobs,max_nodes,queues
 	user1005,1005,B,1,5,,5,""
 	user1006,1006,B,,,,5,""
 	user1007,1007,B,1,7,,,""


### PR DESCRIPTION
#### Problem

The `export_db_info()` function statically defines the columns extracted from both the `bank_table` and the `association_table`, but there could definitely be a case where the user extracting DB information wants to customize the format of the data they are retrieving.

---

This PR refactors the `export_db_info()` function to allow customization of which fields to extract from both `association_table` and `bank_table` through optional arguments. It dynamically builds each SQLite query using these
custom fields and includes which columns are being used in the header of the `.csv` files.

I've adjusted the `populate_db()` function as well as the tests for both the `pop-db` and `export-db` commands to account for the adjustments to `export_db_info()` - namely, skipping the headers of the `.csv` files and including custom formatting in the `export-db` calls.
