### PR TITLE
`export-db/pop-db`: extend functionality to return more data, allow import of any table in database

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -551,11 +551,7 @@ class AccountingService:
 
     def export_db(self, handle, watcher, msg, arg):
         try:
-            val = d.export_db_info(
-                self.conn,
-                msg.payload.get("users"),
-                msg.payload.get("banks"),
-            )
+            val = d.export_db_info(self.conn)
 
             payload = {"export_db": val}
 
@@ -569,8 +565,8 @@ class AccountingService:
         try:
             val = d.populate_db(
                 self.conn,
-                msg.payload.get("users"),
-                msg.payload.get("banks"),
+                msg.payload.get("csv_file"),
+                msg.payload.get("fields"),
             )
 
             payload = {"pop_db": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -1029,69 +1029,24 @@ def add_scrub_job_records_arg(subparsers):
 def add_export_db_arg(subparsers):
     subparser = subparsers.add_parser(
         "export-db",
-        help="""
-        Extract flux-accounting database information into two .csv files.
-
-        Order of columns extracted from association_table:
-
-        Username,UserID,Bank,Shares,MaxRunningJobs,MaxActiveJobs,MaxNodes,Queues
-
-        If no custom path is specified, this will create a file in the
-        current working directory called users.csv.
-
-        ----------------
-
-        Order of columns extracted from bank_table:
-
-        Bank,ParentBank,Shares
-
-        If no custom path is specified, this will create a file in the
-        current working directory called banks.csv.
-
-        Use these two files to populate a new flux-accounting DB with:
-
-        flux account pop-db -b banks.csv -u users.csv
-        """,
+        help="extract flux-accounting DB information into separate .csv files",
         formatter_class=flux.util.help_formatter(),
     )
     subparser.set_defaults(func="export_db")
-    subparser.add_argument(
-        "-u", "--users", help="path to a .csv file containing user information"
-    )
-    subparser.add_argument(
-        "-b", "--banks", help="path to a .csv file containing bank information"
-    )
 
 
 def add_pop_db_arg(subparsers):
     subparser = subparsers.add_parser(
         "pop-db",
-        help="""
-        Description: Populate a flux-accounting database with a .csv file.
-
-        Order of elements required for populating association_table:
-
-        Username,UserID,Bank,Shares,MaxRunningJobs,MaxActiveJobs,MaxNodes,Queues
-
-        [Shares], [MaxRunningJobs], [MaxActiveJobs], and [MaxNodes] can be left
-        blank ('') in the .csv file for a given row.
-
-        ----------------
-
-        Order of elements required for populating bank_table:
-
-        Bank,ParentBank,Shares
-
-        [ParentBank] can be left blank ('') in .csv file for a given row.
-        """,
+        help="populate a table in the flux-accounting DB with a .csv file",
         formatter_class=flux.util.help_formatter(),
     )
     subparser.set_defaults(func="pop_db")
     subparser.add_argument(
-        "-u", "--users", help="path to a .csv file containing user information"
+        "-c", "--csv-file", help="path to a .csv file containing table information"
     )
     subparser.add_argument(
-        "-b", "--banks", help="path to a .csv file containing bank information"
+        "-f", "--fields", help="which fields to insert into the table"
     )
 
 

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -18,8 +18,15 @@ test_expect_success 'start flux-accounting service' '
 	flux account-service -p ${DB_PATH} -t
 '
 
-test_expect_success 'create a banks.csv file containing bank information' '
-	cat <<-EOF >banks.csv
+test_expect_success 'try to populate flux-accounting DB with a bad filename' '
+	touch foo.csv &&
+	test_must_fail flux account pop-db -c foo.csv > error.out 2>&1 &&
+	grep "table \"foo\" does not exist in the database" error.out
+'
+
+test_expect_success 'create bank_table.csv' '
+	cat <<-EOF >bank_table.csv
+	bank,parent_bank,shares
 	root,,1
 	A,root,1
 	B,root,1
@@ -28,22 +35,23 @@ test_expect_success 'create a banks.csv file containing bank information' '
 	EOF
 '
 
-test_expect_success 'populate flux-accounting DB with banks.csv' '
-	flux account pop-db -b banks.csv
+test_expect_success 'populate flux-accounting DB with bank_table.csv' '
+	flux account pop-db -c bank_table.csv
 '
 
-test_expect_success 'create a users.csv file containing user information' '
-	cat <<-EOF >users.csv
-	user1000,1000,A,1,10,15,5,""
-	user1001,1001,A,1,10,15,5,""
-	user1002,1002,A,1,10,15,5,""
-	user1003,1003,A,1,10,15,5,""
-	user1004,1004,A,1,10,15,5,""
+test_expect_success 'create association_table.csv' '
+	cat <<-EOF >association_table.csv
+	creation_time,username,userid,bank,default_bank,shares,max_running_jobs,max_active_jobs,max_nodes,queues
+	0,user1000,1000,A,A,1,10,15,5,""
+	0,user1001,1001,A,A,1,10,15,5,""
+	0,user1002,1002,A,A,1,10,15,5,""
+	0,user1003,1003,A,A,1,10,15,5,""
+	0,user1004,1004,A,A,1,10,15,5,""
 	EOF
 '
 
-test_expect_success 'populate flux-accounting DB with users.csv' '
-	flux account pop-db -u users.csv
+test_expect_success 'populate association_table with association_table.csv' '
+	flux account pop-db -c association_table.csv
 '
 
 test_expect_success 'check database hierarchy to make sure all banks & users were added' '
@@ -51,18 +59,19 @@ test_expect_success 'check database hierarchy to make sure all banks & users wer
 	test_cmp ${EXPECTED_FILES}/db_hierarchy_base.expected db_hierarchy_base.test
 '
 
-test_expect_success 'create a users.csv file with some missing optional user information' '
-	cat <<-EOF >users_optional_vals.csv
-	user1005,1005,B,1,5,,5,""
-	user1006,1006,B,,,,5,""
-	user1007,1007,B,1,7,,,""
-	user1008,1008,B,,,,5,""
-	user1009,1009,B,1,9,,,""
+test_expect_success 'create association_table.csv with some missing user information' '
+	cat <<-EOF >association_table.csv
+	creation_time,username,userid,bank,default_bank,shares,max_running_jobs,max_active_jobs,max_nodes,queues
+	0,user1005,1005,B,B,1,5,,5,""
+	0,user1006,1006,B,B,,,,5,""
+	0,user1007,1007,B,B,1,7,,,""
+	0,user1008,1008,B,B,,,,5,""
+	0,user1009,1009,B,B,1,9,,,""
 	EOF
 '
 
-test_expect_success 'populate flux-accounting DB with users_optional_vals.csv' '
-	flux account pop-db -u users_optional_vals.csv
+test_expect_success 'populate association_table' '
+	flux account pop-db -c association_table.csv
 '
 
 test_expect_success 'check database hierarchy to make sure new users were added' '

--- a/t/t1016-export-db.t
+++ b/t/t1016-export-db.t
@@ -41,61 +41,28 @@ test_expect_success 'export DB information into .csv files' '
 '
 
 test_expect_success 'compare banks.csv' '
-	cat <<-EOF >banks_expected.csv
-	root,,1
-	A,root,1
-	B,root,1
-	C,root,1
-	D,root,1
-	E,D,1
-	F,D,1
+	cat <<-EOF >bank_table_expected.csv
+	bank_id,bank,active,parent_bank,shares,job_usage,priority,ignore_older_than
+	1,root,1,,1,0.0,0.0,0
+	2,A,1,root,1,0.0,0.0,0
+	3,B,1,root,1,0.0,0.0,0
+	4,C,1,root,1,0.0,0.0,0
+	5,D,1,root,1,0.0,0.0,0
+	6,E,1,D,1,0.0,0.0,0
+	7,F,1,D,1,0.0,0.0,0
 	EOF
-	test_cmp -b banks_expected.csv banks.csv
+	test_cmp -b bank_table_expected.csv bank_table.csv
 '
 
-test_expect_success 'compare users.csv' '
-	cat <<-EOF >users_expected.csv
-	user5011,5011,A,1,5,7,2147483647,
-	user5012,5012,A,1,5,7,2147483647,
-	user5013,5013,B,1,5,7,2147483647,
-	user5014,5014,C,1,5,7,2147483647,
-	EOF
-	test_cmp -b users_expected.csv users.csv
-'
-
-test_expect_success 'create hierarchy output of the flux-accounting DB and store it in a file' '
-	flux account view-bank root -t > db1.test
-'
-
-test_expect_success 'shut down flux-accounting service' '
-	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
-'
-
-test_expect_success 'create a new flux-accounting DB' '
-	flux account -p $(pwd)/FluxAccountingTestv2.db create-db
-'
-
-test_expect_success 'restart service against new DB' '
-	flux account-service -p ${DB_PATHv2} -t
-'
-
-test_expect_success 'import information into new DB' '
-	flux account pop-db -b banks.csv &&
-	flux account pop-db -u users.csv
-'
-
-test_expect_success 'create hierarchy output of the new DB and store it in a file' '
-	flux account view-bank root -t > db2.test
-'
-
-test_expect_success 'compare DB hierarchies to make sure they are the same' '
-	test_cmp db1.test db2.test
-'
-
-test_expect_success 'specify a different filename for exported users and banks .csv files' '
-	flux account export-db --users foo.csv --banks bar.csv &&
-	test_cmp -b users_expected.csv foo.csv &&
-	test_cmp -b banks_expected.csv bar.csv
+# use 'grep' checks here because the contents of association_table also
+# store timestamps of when the user was added to the DB, and thus will be
+# slightly different every time these tests are run
+test_expect_success 'make association_table.csv is populated' '
+	grep "creation_time,mod_time,active,username" association_table.csv &&
+	grep "user5011,5011,A,A" association_table.csv &&
+	grep "user5012,5012,A,A" association_table.csv &&
+	grep "user5013,5013,B,B" association_table.csv &&
+	grep "user5014,5014,C,C" association_table.csv
 '
 
 test_expect_success 'shut down flux-accounting service' '

--- a/t/t1026-flux-account-perms.t
+++ b/t/t1026-flux-account-perms.t
@@ -140,8 +140,7 @@ test_expect_success 'pop-db should not be accessible by all users' '
 	( export FLUX_HANDLE_ROLEMASK=0x2 &&
 	  export FLUX_HANDLE_USERID=$newid &&
 		touch users.csv &&
-		touch banks.csv &&
-		test_must_fail flux account pop-db -u users.csv -b banks.csv > no_access_pop_db.out 2>&1 &&
+		test_must_fail flux account pop-db -c association_table.csv > no_access_pop_db.out 2>&1 &&
 		grep "Request requires owner credentials" no_access_pop_db.out
 	)
 '


### PR DESCRIPTION
#### Problem

The `export-db` and `pop-db` commands only handle a couple of columns from just the `association_table` and `bank_table`. These commands would be more robust if they included export and import support from all of the tables.

---

This PR restructures the `export_db_info()` function to return data from *all* of the tables in the flux-accounting DB into separate `.csv` files, labeled with their table names in the database. It also restructures the `populate_db()` function to handle populating any of the tables in the flux-accounting DB with a corresponding `.csv` file. It adds an optional argument to the command which allows the user to specify which columns to include from the file when populating the table.

As a result of the improvements made to both functions, I've also restructured the tests for both of these commands slightly, mostly just:

- updated the filenames to match the table names in the flux-accounting DB
- include the column names in the first line of the `.csv` files
- drop the use of the `--banks` and `--users` optional arguments