### PR TITLE
`edit-user`: unify reset behavior, `**kwargs` for editable fields

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -214,18 +214,18 @@ class AccountingService:
     def edit_user(self, handle, watcher, msg, arg):
         try:
             val = u.edit_user(
-                self.conn,
-                msg.payload["username"],
-                msg.payload["bank"],
-                msg.payload["userid"],
-                msg.payload["default_bank"],
-                msg.payload["shares"],
-                msg.payload["max_running_jobs"],
-                msg.payload["max_active_jobs"],
-                msg.payload["max_nodes"],
-                msg.payload["queues"],
-                msg.payload["projects"],
-                msg.payload["default_project"],
+                conn=self.conn,
+                username=msg.payload["username"],
+                bank=msg.payload["bank"],
+                userid=msg.payload["userid"],
+                default_bank=msg.payload["default_bank"],
+                shares=msg.payload["shares"],
+                max_running_jobs=msg.payload["max_running_jobs"],
+                max_active_jobs=msg.payload["max_active_jobs"],
+                max_nodes=msg.payload["max_nodes"],
+                queues=msg.payload["queues"],
+                projects=msg.payload["projects"],
+                default_project=msg.payload["default_project"],
             )
 
             payload = {"edit_user": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -145,7 +145,10 @@ def add_edit_user_arg(subparsers):
     )
     subparser_edit_user.add_argument(
         "--bank",
-        help="bank to charge jobs against",
+        help=(
+            "specify under which bank to make this change; if not specified,"
+            " the edit will be applied across all of the user's accounts"
+        ),
         default=None,
         metavar="BANK",
     )

--- a/t/t1021-mf-priority-issue332.t
+++ b/t/t1021-mf-priority-issue332.t
@@ -76,7 +76,7 @@ test_expect_success 'submit a job while specifying a queue' '
 '
 
 test_expect_success 'edit a user to no longer have access to any of the added queues' '
-	flux account edit-user user5001 --bank=A --queues=
+	flux account edit-user user5001 --bank=A --queues=-1
 '
 
 test_expect_success 're-send flux-accounting DB information to the plugin' '
@@ -104,7 +104,7 @@ test_expect_success 'delete the queues from the flux-accounting database and fro
 	flux account delete-queue bronze &&
 	flux account delete-queue silver &&
 	flux account delete-queue gold &&
-	flux account edit-user user5001 --bank=A --queues=
+	flux account edit-user user5001 --bank=A --queues=-1
 '
 
 test_expect_success 're-send flux-accounting DB information to the plugin' '


### PR DESCRIPTION
#### Problem

The `edit_user()` function is clunky and could stand to undergo some improvements. Namely:

- the reset behavior for editable fields is inconsistent. For example, an association's `projects` list can be reset with `-1`, but their `queues` list is reset with an empty string.
- the function parameters define every editable field in the signature when it really could just use `**kwargs`.
- The function allows `bank` to be edited for an association, which should not be allowed since associations, once created, are not deleted because they can continue to contribute to a bank's fair-share (up to the job usage reset period).

---

This PR changes the function's signature to use `**kwargs` for the editable fields and removes "bank" as an editable field for an association. It also unifies the reset behavior for any of the editable fields by making `-1` the keyword to reset the field to its default value.

Finally, I've added a function docstring description.