### PR TITLE
testsuite: pull in valgrind suppression from core

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -133,3 +133,12 @@
    fun:ev_run
    ...
 }
+{
+   <libuuid_tls_leak>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:uuid_generate*
+   ...
+}


### PR DESCRIPTION
Problem: changes proposed to flux-core introduce a new "false positive" valgrind error.

Bring over the suppression proposed in core.