### PR TITLE
github: fix ubuntu version for `"python-format"` action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
   python-format:
     name: python format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
#### Problem

The `"python-format"` GitHub action fails with:

> Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.

because Python 3.7 has reached its EOL: https://github.com/actions/setup-python/issues/962.

---

This PR fixes the version of Ubuntu for the `"python-format"` action to `20.04` instead of using `ubuntu-latest`.