### PR TITLE
testsuite: add longer test descriptions for some of the more complex test scenarios

### DIFF
--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -97,6 +97,10 @@ test_expect_success 'update plugin with sample test data' '
 	flux python fake_payload.py
 '
 
+# The following set of tests will check the integer priority calculated by the
+# priority plugin for two associations. The fair-share of the first association
+# is 0.45321 and the fair-share of the second is 0.11345. In addition, job
+# priorities get affected if the user sets a custom urgency on their job.
 test_expect_success 'submit a job with default urgency' '
 	jobid=$(flux submit --setattr=system.bank=account3 -n1 hostname) &&
 	flux job wait-event -f json ${jobid} priority | jq '.context.priority' > job1.test &&
@@ -157,6 +161,9 @@ test_expect_success 'submit a job using default bank' '
 	flux cancel ${jobid}
 '
 
+# The following two tests ensure job submissions are rejected when a user
+# tries to submit a job under a bank they do not belong to or when the format
+# of the bank is not valid.
 test_expect_success 'submit a job using a bank the user does not belong to' '
 	test_must_fail flux submit --setattr=system.bank=account1 -n1 hostname > bad_bank.out 2>&1 &&
 	test_debug "cat bad_bank.out" &&
@@ -169,6 +176,10 @@ test_expect_success 'reject job when invalid bank format is passed in' '
 	grep "unable to unpack bank arg" invalid_fmt.out
 '
 
+# This set of tests simulates a special case where a portion of the Association
+# object that is kept with every job is missing, and therefore, an exception on
+# the job is raised with a message explaining that it cannot load the
+# information for the job.
 test_expect_success 'pass special key to user/bank struct to nullify information' '
 	cat <<-EOF >null_struct.json
 	{

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -20,6 +20,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -20,6 +20,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -20,6 +20,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -125,7 +125,7 @@ test_expect_success 'a submitted job while at max-running-jobs limit will have a
 	flux cancel ${jobid2}
 '
 
-test_expect_success 'submit max number of jobs with a mix of default bank and explicitly set bank' '
+test_expect_success 'submit max number of jobs to the same bank (explicitly and by default)' '
 	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
 	jobid2=$(flux python ${SUBMIT_AS} 5011 --setattr=system.bank=account3 -n 1 sleep 60)
 '

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -86,6 +86,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 	flux python fake_payload.py
 '
 
+# The following set of tests will check that the priority plugin enforces
+# accounting limits defined per-association in the flux-accounting database,
+# specifically an association's max running jobs and max active jobs limit.
+# When the association hits their max running jobs limit, subsequently
+# submitted jobs will be held by having an accounting-specific dependency added
+# to it. Once they hit their max active jobs limit, subsequently submitted jobs
+# will be rejected with an accounting-specific rejection message.
 test_expect_success 'submit max number of jobs' '
 	jobid1=$(flux python ${SUBMIT_AS} 5011 sleep 60) &&
 	jobid2=$(flux python ${SUBMIT_AS} 5011 sleep 60)

--- a/t/t1008-mf-priority-update.t
+++ b/t/t1008-mf-priority-update.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -139,7 +139,7 @@ test_expect_success 'check that job usage and fairshare values get updated' '
 '
 
 # if update-usage is called in the same half-life period when no jobs are found
-# for a user, their job usage factor should be affected; this test is taken
+# for a user, their job usage factor should not be affected; this test is taken
 # from the set of job-archive interface Python unit tests
 test_expect_success 'call update-usage in the same half-life period where no jobs are run' '
 	flux account -p ${DB_PATH} update-usage &&

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -22,6 +22,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1015-mf-priority-urgency.t
+++ b/t/t1015-mf-priority-urgency.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1020-mf-priority-issue262.t
+++ b/t/t1020-mf-priority-issue262.t
@@ -20,6 +20,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1021-mf-priority-issue332.t
+++ b/t/t1021-mf-priority-issue332.t
@@ -23,6 +23,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -22,6 +22,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1027-mf-priority-issue376.t
+++ b/t/t1027-mf-priority-issue376.t
@@ -21,6 +21,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -21,6 +21,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB, start flux-accounting service' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db &&
 	flux account-service -p ${DB_PATH} -t

--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
 '

--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -22,6 +22,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1031-mf-priority-issue406.t
+++ b/t/t1031-mf-priority-issue406.t
@@ -19,6 +19,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1032-mf-priority-update-bank.t
+++ b/t/t1032-mf-priority-update-bank.t
@@ -21,6 +21,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '

--- a/t/t1033-mf-priority-update-job.t
+++ b/t/t1033-mf-priority-update-job.t
@@ -22,6 +22,7 @@ test_expect_success 'allow guest access to testexec' '
 	allow-guests = true
 	EOF
 '
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '


### PR DESCRIPTION
#### Problem

Some of the tests in the testsuite can be somewhat complex and simulate a scenario that might take multiple steps; it would be helpful if descriptions were added that went into more detail than what is described in the one-liner for each test.

---

This PR makes a number of minor test description improvements in the flux-accounting testsuite, most notably adding some more thorough test descriptions in a couple of the test files explaining what is being tested, particularly for the scenarios that are broken up over multiple tests.

I've also fixed a couple of mistakes in the test description and in already-existing test comments.

Lastly, I've just added a space between the `"allow guest access..."` tests to match the format of the rest of the testsuite.

Built on top of #547