### PR TITLE
bank_table: add `max-preempt-after` column

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -1,6 +1,6 @@
 DB_DIR = "@X_LOCALSTATEDIR@/lib/flux/"
 DB_PATH = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
-DB_SCHEMA_VERSION = 29
+DB_SCHEMA_VERSION = 30
 
 PRIORITY_FACTORS = ["fairshare", "queue", "bank"]
 FSHARE_WEIGHT_DEFAULT = 100000
@@ -28,7 +28,7 @@ ASSOCIATION_TABLE = [
     "projects",
     "default_project",
 ]
-BANK_TABLE = ["bank_id", "bank", "active", "parent_bank", "shares", "job_usage", "priority"]
+BANK_TABLE = ["bank_id", "bank", "active", "parent_bank", "shares", "job_usage", "priority", "max_preempt_after"]
 QUEUE_TABLE = [
     "queue",
     "min_nodes_per_job",

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -122,13 +122,14 @@ def create_db(
     conn.execute(
         """
             CREATE TABLE IF NOT EXISTS bank_table (
-                bank_id     integer PRIMARY KEY AUTOINCREMENT,
-                bank        text                NOT NULL,
-                active      int(11) DEFAULT 1   NOT NULL,
-                parent_bank text    DEFAULT '',
-                shares      int                 NOT NULL,
-                job_usage   real    DEFAULT 0.0 NOT NULL,
-                priority    real    DEFAULT 0.0 NOT NULL    ON CONFLICT REPLACE DEFAULT 0.0
+                bank_id           integer PRIMARY KEY AUTOINCREMENT,
+                bank              text                NOT NULL,
+                active            int(11) DEFAULT 1   NOT NULL,
+                parent_bank       text    DEFAULT '',
+                shares            int                 NOT NULL,
+                job_usage         real    DEFAULT 0.0 NOT NULL,
+                priority          real    DEFAULT 0.0 NOT NULL    ON CONFLICT REPLACE DEFAULT 0.0,
+                max_preempt_after real
         );"""
     )
     LOGGER.info("Created bank_table successfully")

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -309,6 +309,7 @@ class AccountingService:
                 msg.payload["shares"],
                 msg.payload.get("parent_bank"),
                 msg.payload.get("priority"),
+                msg.payload.get("max_preempt_after"),
             )
 
             payload = {"add_bank": val}
@@ -341,6 +342,7 @@ class AccountingService:
                 msg.payload.get("shares"),
                 msg.payload.get("parent_bank"),
                 msg.payload.get("priority"),
+                msg.payload.get("max_preempt_after"),
             )
 
             payload = {"edit_bank": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -442,6 +442,15 @@ def add_add_bank_arg(subparsers):
         help="an associated priority for jobs submitted under this bank",
         metavar="PRIORITY",
     )
+    subparser_add_bank.add_argument(
+        "--max-preempt-after",
+        help=(
+            "max amount of time until a job running under this bank can become "
+            "preemptible; duration must be in Flux Standard Duration"
+        ),
+        type=str,
+        metavar="MAX_PREEMPT_AFTER",
+    )
 
 
 def add_view_bank_arg(subparsers):
@@ -546,6 +555,15 @@ def add_edit_bank_arg(subparsers):
         "--priority",
         help="an associated priority for jobs submitted under this bank",
         metavar="PRIORITY",
+    )
+    subparser_edit_bank.add_argument(
+        "--max-preempt-after",
+        help=(
+            "max amount of time until a job running under this bank can become "
+            "preemptible; duration must be in Flux Standard Duration"
+        ),
+        type=str,
+        metavar="MAX_PREEMPT_AFTER",
     )
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -61,6 +61,7 @@ TESTSCRIPTS = \
 	t1056-mf-priority-urgency-factor.t \
 	t1057-flux-account-jobs.t \
 	t1058-flux-account-visuals.t \
+	t1059-issue553.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -1,6 +1,6 @@
-bank_id | bank | active | parent_bank | shares | job_usage | priority
---------+------+--------+-------------+--------+-----------+---------
-2       | A    | 1      | root        | 1      | 0.0       | 0.0     
+bank_id | bank | active | parent_bank | shares | job_usage | priority | max_preempt_after
+--------+------+--------+-------------+--------+-----------+----------+------------------
+2       | A    | 1      | root        | 1      | 0.0       | 0.0      | None             
 
 username | default_bank | shares | job_usage | fairshare
 ---------+--------------+--------+-----------+----------

--- a/t/expected/flux_account/F_bank_users.expected
+++ b/t/expected/flux_account/F_bank_users.expected
@@ -1,5 +1,5 @@
-bank_id | bank | active | parent_bank | shares | job_usage | priority
---------+------+--------+-------------+--------+-----------+---------
-7       | F    | 1      | D           | 1      | 0.0       | 0.0     
+bank_id | bank | active | parent_bank | shares | job_usage | priority | max_preempt_after
+--------+------+--------+-------------+--------+-----------+----------+------------------
+7       | F    | 1      | D           | 1      | 0.0       | 0.0      | None             
 
 no users under F

--- a/t/expected/flux_account/deleted_bank.expected
+++ b/t/expected/flux_account/deleted_bank.expected
@@ -1,3 +1,3 @@
-bank_id        bank           active         parent_bank    shares         
-4              C              0              root           50             
+bank_id        bank           active         parent_bank    shares         job_usage      max_preempt_after
+4              C              0              root           50             0.0            None           
 

--- a/t/expected/flux_account/root_bank.expected
+++ b/t/expected/flux_account/root_bank.expected
@@ -6,6 +6,7 @@
     "parent_bank": "",
     "shares": 1,
     "job_usage": 0.0,
-    "priority": 0.0
+    "priority": 0.0,
+    "max_preempt_after": null
   }
 ]

--- a/t/python/t1008_banks_output.py
+++ b/t/python/t1008_banks_output.py
@@ -61,7 +61,8 @@ class TestAccountingCLI(unittest.TestCase):
             "parent_bank": "",
             "shares": 1,
             "job_usage": 0.0,
-            "priority": 0.0
+            "priority": 0.0,
+            "max_preempt_after": null
           },
           {
             "bank_id": 2,
@@ -70,7 +71,8 @@ class TestAccountingCLI(unittest.TestCase):
             "parent_bank": "root",
             "shares": 1,
             "job_usage": 0.0,
-            "priority": 0.0
+            "priority": 0.0,
+            "max_preempt_after": null
           }
         ]
         """
@@ -218,10 +220,10 @@ class TestAccountingCLI(unittest.TestCase):
     def test_list_banks_table_default(self):
         expected = textwrap.dedent(
             """\
-        bank_id | bank | active | parent_bank | shares | job_usage | priority
-        --------+------+--------+-------------+--------+-----------+---------
-        1       | root | 1      |             | 1      | 0.0       | 0.0     
-        2       | A    | 1      | root        | 1      | 0.0       | 0.0       
+        bank_id | bank | active | parent_bank | shares | job_usage | priority | max_preempt_after
+        --------+------+--------+-------------+--------+-----------+----------+------------------
+        1       | root | 1      |             | 1      | 0.0       | 0.0      | None             
+        2       | A    | 1      | root        | 1      | 0.0       | 0.0      | None
         """
         )
         test = b.list_banks(conn)

--- a/t/t1059-issue553.t
+++ b/t/t1059-issue553.t
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+test_description='test max-preempt-after values when adding/editing banks'
+
+. `dirname $0`/sharness.sh
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add root bank to the DB' '
+	flux account add-bank root 1
+'
+
+test_expect_success 'add a sub bank with max-preempt in seconds' '
+	flux account add-bank --parent-bank=root --max-preempt-after=60s A 1 &&
+	flux account view-bank A > A.test &&
+	grep "\"max_preempt_after\": 60.0" A.test
+'
+
+test_expect_success 'add a sub bank with max-preempt in hours' '
+	flux account add-bank --parent-bank=root --max-preempt-after=1h B 1 &&
+	flux account view-bank B > B.test &&
+	grep "\"max_preempt_after\": 3600.0" B.test
+'
+
+test_expect_success 'add a sub bank with max-preempt in days' '
+	flux account add-bank --parent-bank=root --max-preempt-after=1d C 1 &&
+	flux account view-bank C > C.test &&
+	grep "\"max_preempt_after\": 86400.0" C.test
+'
+
+test_expect_success 'add a sub bank with no max-preempt specified' '
+	flux account add-bank --parent-bank=root D 1 &&
+	flux account view-bank D > D.test &&
+	grep "\"max_preempt_after\": null" D.test
+'
+
+test_expect_success 'trying to add a sub bank with a bad FSD will raise an error' '
+	test_must_fail flux account add-bank \
+		--parent-bank=root \
+		--max-preempt-after=foo E 1 > error.out 2>&1 &&
+	grep "add-bank: ValueError: invalid Flux standard duration" error.out
+'
+
+test_expect_success 'edit max-preempt-after for a bank' '
+	flux account edit-bank A --max-preempt-after=200s &&
+	flux account view-bank A > A_edited.test &&
+	grep "\"max_preempt_after\": 200.0" A_edited.test
+'
+
+test_expect_success 'clear max-preempt-after for a bank' '
+	flux account edit-bank A --max-preempt-after=-1 &&
+	flux account view-bank A > A_cleared.test &&
+	grep "\"max_preempt_after\": null" A_cleared.test
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The `bank_table` does not have a way to track a max `preemptible-after` value for a certain bank. This kind of information is needed to enforce a limit on association-set `preemptible-after` values on their jobs as well as set a default on their job in the case where the association does not set one on their own.

---

This PR begins to add support for enforcing `preemptible-after` limits on a per-bank basis by adding a new column to the `bank_table` called `max_preempt_after`, which is a floating point number representing the max number of seconds in which a job submitted under this bank can run before being preempted. It does not require a value and does not have a default value.

`--max-preempt-after` optional arguments are also added to the `add-bank` and `edit-bank` commands to allow an admin to both define and change the `max-preempt-after` attribute for a bank. The expected format for this attribute in both the `add-bank` and `edit-bank` commands is [Flux Standard Duration (FSD)](https://github.com/flux-framework/rfc/blob/master/spec_23.rst). A bank's `max-preempt-after` can also be cleared by passing `-1` as a value if the admin no longer wants to have a max `preemptible-after` attribute defined for a particular bank.

I've added some basic tests to a new test file that adds multiple banks with different FSD values as well as resets its value after setting a value initially.

Fixes #553 
