### PR TITLE
`formatter`: add new `JobsFormatter` class, restructure `view-job-records` to use new class

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -365,6 +365,7 @@ class AccountingService:
             val = j.view_jobs(
                 self.conn,
                 msg.payload["output_file"],
+                msg.payload["format"],
                 jobid=msg.payload["jobid"],
                 user=msg.payload["user"],
                 before_end_time=msg.payload["before_end_time"],

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -293,6 +293,17 @@ def add_view_job_records_arg(subparsers):
         help="bank",
         metavar="BANK",
     )
+    subparser_view_job_records.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        help=(
+            "Specify output format using Python's string format syntax. "
+            "Available fields: jobid,username,userid,t_submit,t_run,t_inactive,nnodes,"
+            "project,bank"
+        ),
+        metavar="FORMAT",
+    )
 
 
 def add_create_db_arg(subparsers):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -120,7 +120,6 @@ EXTRA_DIST= \
 	expected/flux_account/F_bank_users.expected \
 	expected/pop_db/db_hierarchy_base.expected \
 	expected/pop_db/db_hierarchy_new_users.expected \
-	expected/job_usage/no_jobs.expected \
 	expected/sample_payloads/same_fairshare.json \
 	expected/sample_payloads/small_no_tie.json \
 	expected/sample_payloads/small_tie_all.json \

--- a/t/expected/job_usage/no_jobs.expected
+++ b/t/expected/job_usage/no_jobs.expected
@@ -1,1 +1,0 @@
-UserID     Username   JobID                T_Submit             T_Run                T_Inactive           Nodes      Project              Bank                

--- a/t/t1041-view-jobs-by-project.t
+++ b/t/t1041-view-jobs-by-project.t
@@ -75,7 +75,8 @@ test_expect_success 'run fetch-job-records script' '
 
 test_expect_success 'look at all jobs (will show 4 records)' '
 	flux account view-job-records > all_jobs.out &&
-	test $(grep -c "project" all_jobs.out) -eq 4
+	test $(grep -c "projectA" all_jobs.out) -eq 2 &&
+	test $(grep -c "projectB" all_jobs.out) -eq 2
 '
 
 test_expect_success 'filter jobs by projectA (will show 2 records)' '


### PR DESCRIPTION
#### Problem

The `formatter` module in flux-accounting does not have a class for formatting the output of job records which would be useful because the flux-accounting Python bindings manually define the formatting of these job records within its bindings.

---

This PR creates a new class called `JobsFormatter`, a subclass of `flux.util.OutputFormat`, which can take a Python format string to allow a user to customize their output, similar to flux-jobs:

```console
flux account view-job-records -o "{userid:<8} | {nnodes:<6} | {bank:<8}" 
userid   | nnodes | bank    
5001     | 1      | bankB   
5002     | 1      | bankB   
5002     | 1      | bankB   
5001     | 1      | bankA   
5001     | 1      | bankA 
```

`view-job-records` is restructured to use the new `JobsFormatter` class instead of defining its own print function as well as modified to include a `-o, --format` optional argument to the command to allow the user to specify a format string to customize their output.

Finally, a couple of the `view-job-records` tests are cleaned up to account for the use of the new formatter class.