### PR TITLE
`job.state.priority`: remove raising exception when no aux item found

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -47,6 +47,7 @@ TESTSCRIPTS = \
 	t1045-issue478.t \
 	t1046-issue565.t \
 	t1047-issue564.t \
+	t1048-issue575.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1048-issue575.t
+++ b/t/t1048-issue575.t
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+test_description='test handling pending jobs sent back to PRIORITY after aux items cleared'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user --username=user1 --userid=5001 --bank=A
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'stop scheduler from allocating resources to jobs' '
+	flux queue stop
+'
+
+test_expect_success 'submit job and make sure it is pending' '
+	job=$(flux python ${SUBMIT_AS} 5001 sleep 60) &&
+	flux job wait-event -vt 5 ${job} priority
+'
+
+# unloading the jobtap plugin will clear all of the aux items set on the job
+test_expect_success 'unload and reload mf_priority.so (clears aux items on job)' '
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'job remains to be held in SCHED' '
+	test $(flux jobs -no {state} ${job}) = "SCHED"
+'
+
+test_expect_success 'start queue so that resources can be allocated to job' '
+	flux queue start
+'
+
+test_expect_success 'update the plugin with flux-accounting information' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'job proceeds to RUN' '
+	flux job wait-event -vt 5 ${job} alloc
+'
+
+test_expect_success 'cancel job' '
+	flux cancel ${job}
+'
+
+test_done


### PR DESCRIPTION
#### Scenario

A job held in PRIORITY and waiting to be allocated resources gets reprioritized and sent back to `job.state.priority` or `job.priority.get` _after_ a restart (clearing its aux items) when a plugin is already loaded and seen the job.

#### Problem

The multi-factor priority plugin raises an exception on a job in `job.state.priority` when it cannot find the aux item containing the association information for the job. However, when a system instance is reloaded, the aux items set on a job are cleared. When jobs are reprioritized and are sent back to `job.state.priority` or `job.priority.get`, the plugin will raise an exception on the job because it can't unpack the aux item containing the flux-accounting information associated with that job. See the below eventlog for an example:

```
...
{"timestamp":1737671575.5923743,"name":"priority","context":{"priority":19668}}
{"timestamp":1737736372.7067723,"name":"priority","context":{"priority":19620}}
{"timestamp":1737757970.5174642,"name":"priority","context":{"priority":19743}}
{"timestamp":1737801156.5343764,"name":"priority","context":{"priority":19865}}
{"timestamp":1737822769.2824628,"name":"priority","context":{"priority":19160}}
{"timestamp":1737998525.3946743,"name":"exception","context":{"type":"mf_priority","severity":0,"note":"internal error: bank info is missing","userid":767}}
{"timestamp":1737998525.3947248,"name":"clean"}
```

---

This PR removes raising a job exception in `job.state.priority` in the case where the job does not have an aux item for the accounting information associated with the job. Instead, it attempts to perform another lookup for the flux-accounting information for the association that submitted the job, which is already what it does when a job is submitted before the plugin is loaded with any flux-accounting information.

Fixes #575