### PR TITLE
`edit-user`: make `fairshare` an editable field for an association

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -1,6 +1,6 @@
 DB_DIR = "@X_LOCALSTATEDIR@/lib/flux/"
 DB_PATH = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
-DB_SCHEMA_VERSION = 25
+DB_SCHEMA_VERSION = 26
 
 # flux-accounting DB table column names
 ASSOCIATION_TABLE = [

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -101,7 +101,7 @@ def create_db(
                 default_bank     tinytext                           NOT NULL,
                 shares           int(11)     DEFAULT 1              NOT NULL    ON CONFLICT REPLACE DEFAULT 1,
                 job_usage        real        DEFAULT 0.0            NOT NULL,
-                fairshare        real        DEFAULT 0.5            NOT NULL,
+                fairshare        real        DEFAULT 0.5            NOT NULL    ON CONFLICT REPLACE DEFAULT 0.5,
                 max_running_jobs int(11)     DEFAULT 5              NOT NULL    ON CONFLICT REPLACE DEFAULT 5,
                 max_active_jobs  int(11)     DEFAULT 7              NOT NULL    ON CONFLICT REPLACE DEFAULT 7,
                 max_nodes        int(11)     DEFAULT 2147483647     NOT NULL    ON CONFLICT REPLACE DEFAULT 2147483647,

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -416,6 +416,8 @@ def edit_user(conn, username, bank=None, **kwargs):
         default_bank: The user's default bank.
         shares: The amount of available resources their organization considers the user
             should be entitled to use relative to other competing users.
+        fairshare: The ratio between the amount of resources an association is
+            allocated versus the amount actually consumed.
         max_running_jobs: The max number of running jobs the association can have at any
             given time.
         max_active_jobs: The max number of both pending and running jobs the association
@@ -441,6 +443,7 @@ def edit_user(conn, username, bank=None, **kwargs):
         "userid",
         "default_bank",
         "shares",
+        "fairshare",
         "max_running_jobs",
         "max_active_jobs",
         "max_nodes",

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -222,6 +222,7 @@ class AccountingService:
                 userid=msg.payload["userid"],
                 default_bank=msg.payload["default_bank"],
                 shares=msg.payload["shares"],
+                fairshare=msg.payload["fairshare"],
                 max_running_jobs=msg.payload["max_running_jobs"],
                 max_active_jobs=msg.payload["max_active_jobs"],
                 max_nodes=msg.payload["max_nodes"],

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -187,6 +187,12 @@ def add_edit_user_arg(subparsers):
         metavar="SHARES",
     )
     subparser_edit_user.add_argument(
+        "--fairshare",
+        help="fairshare",
+        default=None,
+        metavar="SHARES",
+    )
+    subparser_edit_user.add_argument(
         "--max-running-jobs",
         help="max number of jobs that can be running at the same time",
         default=None,

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -266,6 +266,22 @@ class TestAccountingCLI(unittest.TestCase):
         with self.assertRaises(ValueError):
             u.add_user(acct_conn, username="test_user4", bank="A", projects="foo")
 
+    # edit a user's fair-share value
+    def test_16_edit_user_fairshare(self):
+        cur = acct_conn.cursor()
+        cur.execute(
+            "SELECT fairshare FROM association_table WHERE username='test_user5'"
+        )
+        fairshare = cur.fetchall()
+        self.assertEqual(fairshare[0][0], 0.5)
+
+        u.edit_user(acct_conn, username="test_user5", fairshare=0.95)
+        cur.execute(
+            "SELECT fairshare FROM association_table WHERE username='test_user5'"
+        )
+        fairshare = cur.fetchall()
+        self.assertEqual(fairshare[0][0], 0.95)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -104,6 +104,18 @@ test_expect_success 'edit a field in a user account' '
 	flux account edit-user user5011 --shares 50
 '
 
+test_expect_success 'edit the fairshare value for a user' '
+	flux account edit-user user5011 --fairshare 0.99 &&
+	flux account view-user user5011 > user.out &&
+	grep "\"fairshare\": 0.99" user.out
+'
+
+test_expect_success 'reset the fairshare value for a user' '
+	flux account edit-user user5011 --fairshare=-1 &&
+	flux account view-user user5011 > user.out &&
+	grep "\"fairshare\": 0.5" user.out
+'
+
 test_expect_success 'remove a user account' '
 	flux account delete-user user5012 A &&
 	flux account view-user user5012 > deleted_user.out &&


### PR DESCRIPTION
#### Problem

Since admins are the only ones who have privileges to run the `edit-user` command, they should be able to edit the `fairshare` column for an association manually if they so choose, but there is currently no way to do so via `edit-user`; they have to connect to a SQLite shell and create and execute a SQL statement to update the column manually.

---

This PR makes the `fairshare` column an optional argument in the `edit-user` command. I've updated the `fairshare` column in the `association_table` to match the other editable fields, as well as added a unit and sharness test. 