### PR TITLE
`t/Makefile.am`: add missing line continuation (`\`) character

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -56,7 +56,7 @@ TESTSCRIPTS = \
 	python/t1005_project_cmds.py \
 	python/t1006_job_archive.py \
 	python/t1007_formatter.py \
-	python/t1008_banks_output.py
+	python/t1008_banks_output.py \
 	python/t1009_users_output.py
 
 dist_check_SCRIPTS = \


### PR DESCRIPTION
#### Problem

The test files in `t/Makefile.am` is missing a line continuation character between `t1008_banks_output.py` and `t1009_users_output.py`.

---

This PR adds the missing line continuation character.