### PR TITLE
`delete-user`: add `--force` option to actually remove a row from the `association_table`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -151,7 +151,9 @@ def get_default_bank(cur, username):
     cur.execute(select_stmt, (username,))
     result = cur.fetchall()
 
-    return result[0][0]
+    if result:
+        return result[0][0]
+    return None
 
 
 def update_default_bank(conn, cur, username):

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -201,7 +201,12 @@ class AccountingService:
 
     def delete_user(self, handle, watcher, msg, arg):
         try:
-            val = u.delete_user(self.conn, msg.payload["username"], msg.payload["bank"])
+            val = u.delete_user(
+                self.conn,
+                msg.payload["username"],
+                msg.payload["bank"],
+                msg.payload["force"],
+            )
 
             payload = {"delete_user": val}
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -146,6 +146,17 @@ def add_delete_user_arg(subparsers):
         "username", help="username", metavar=("USERNAME")
     )
     subparser_delete_user.add_argument("bank", help="bank", metavar=("BANK"))
+    subparser_delete_user.add_argument(
+        "--force",
+        action="store_const",
+        const=True,
+        default=False,
+        help=(
+            "actually remove user from association_table (WARNING: removing a row from "
+            "the association_table can affect a bank and its users' fair-share value; "
+            "proceed with caution)"
+        ),
+    )
 
 
 def add_edit_user_arg(subparsers):

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -122,6 +122,21 @@ test_expect_success 'remove a user account' '
 	grep -f ${EXPECTED_FILES}/deleted_user.expected deleted_user.out
 '
 
+test_expect_success 'remove a user with --force' '
+	flux account delete-user user5011 A --force &&
+	test_must_fail flux account view-user user5011 > user5011_nonexistent.out 2>&1 &&
+	grep "view-user: user user5011 not found in association_table" user5011_nonexistent.out
+'
+
+test_expect_success 'remove a user with --force/make sure default bank gets updated' '
+	flux account add-user --username=user5201 --bank=A &&
+	flux account add-user --username=user5201 --bank=B &&
+	flux account add-user --username=user5201 --bank=C &&
+	flux account delete-user --force user5201 A &&
+	flux account view-user user5201 > user5201.out &&
+	test $(grep -c "\"default_bank\": \"B\"" user5201.out) -eq 2 
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

The `delete-user` command does not actually delete a row from the `association_table` but instead sets the 'active' column for a row to 0. There might be a use case where an admin would actually want to remove a row from the table.

---

This PR adds a new `--force` optional argument to the `delete-user` command which will actually remove the row from the `association_table`. I've also added a function description to `delete_user()` to describe more fully what the function does (i.e. explaining disabling vs. actually deleting a user).

I've also added a couple of unit tests and sharness tests for calling `delete-user --force`.