### PR TITLE
`delete-bank`: add `--force` option to actually remove a row from the `bank_table`

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -301,7 +301,7 @@ class AccountingService:
 
     def delete_bank(self, handle, watcher, msg, arg):
         try:
-            val = b.delete_bank(self.conn, msg.payload["bank"])
+            val = b.delete_bank(self.conn, msg.payload["bank"], msg.payload["force"])
 
             payload = {"delete_bank": val}
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -387,6 +387,17 @@ def add_delete_bank_arg(subparsers):
         help="bank name",
         metavar="BANK",
     )
+    subparser_delete_bank.add_argument(
+        "--force",
+        action="store_const",
+        const=True,
+        default=False,
+        help=(
+            "actually remove bank from bank_table (WARNING: removing a row from "
+            "the bank_table can affect a bank and its users' fair-share value; "
+            "proceed with caution)"
+        ),
+    )
 
 
 def add_edit_bank_arg(subparsers):

--- a/t/python/t1003_bank_cmds.py
+++ b/t/python/t1003_bank_cmds.py
@@ -153,6 +153,23 @@ class TestAccountingCLI(unittest.TestCase):
         rows = cur.fetchall()
         self.assertEqual(rows[0][0], 1)
 
+    # actually remove a bank row from the bank_table
+    def test_13_delete_bank_force(self):
+        b.delete_bank(acct_conn, bank="G", force=True)
+        cur.execute("SELECT * FROM bank_table WHERE bank='G'")
+        rows = cur.fetchall()
+        self.assertEqual(len(rows), 0)
+
+    # actually delete multiple banks from bank_table by deleting a parent bank
+    def test_14_delete_parent_bank_force(self):
+        b.delete_bank(acct_conn, bank="C", force=True)
+        cur.execute("SELECT * FROM bank_table WHERE bank='C'")
+        rows = cur.fetchall()
+        self.assertEqual(len(rows), 0)
+        cur.execute("SELECT * FROM bank_table WHERE parent_bank='C'")
+        rows = cur.fetchall()
+        self.assertEqual(len(rows), 0)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -151,6 +151,24 @@ test_expect_success 'combining --tree with --fields does not work' '
     grep "tree option does not support custom formatting" error.out
 '
 
+test_expect_success 'delete a bank with --force; ensure users also get deleted' '
+	flux account delete-bank C --force &&
+	test_must_fail flux account view-bank C > nonexistent_bank.out 2>&1 &&
+	grep "view-bank: bank C not found in bank_table" nonexistent_bank.out &&
+	test_must_fail flux account view-user user5014 > nonexistent_user.out 2>&1 &&
+	grep "view-user: user user5014 not found in association_table" nonexistent_user.out
+'
+
+test_expect_success 'delete a bank with multiple sub-banks and users with --force' '
+	flux account delete-bank D --force &&
+	test_must_fail flux account view-bank E > bankE_noexist.out 2>&1 &&
+	grep "view-bank: bank E not found in bank_table" bankE_noexist.out &&
+	test_must_fail flux account view-bank F > bankF_noexist.out 2>&1 &&
+	grep "view-bank: bank F not found in bank_table" bankF_noexist.out &&
+	test_must_fail flux account view-user user5030 > nonexistent_user.out 2>&1 &&
+	grep "view-user: user user5030 not found in association_table" nonexistent_user.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

Similar to #572, the `delete-bank` command does not actually delete a row from the `bank_table` but instead sets the 'active' column for a row to 0. There might be a use case where an admin would actually want to remove a row from the table.

---

This PR adds a new `--force` optional argument to the `delete-bank` command which will actually remove the row from the `bank_table`. I've also added a function description to `delete_bank()` to describe more fully what the function does (i.e. explaining disabling vs. actually deleting a bank).

I've also added a couple of unit tests and sharness tests for calling `delete-bank --force`, both with and without sub-banks and users in those banks.