### PR TITLE
NEWS: add release notes for `v0.41.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,59 @@
+flux-accounting version 0.41.0 - 2025-02-04
+-------------------------------------------
+
+#### Fixes
+
+* `view-job-records`: accept multiple timestamp formats for `after-start-time`,
+`before-end-time` optional args (#567)
+
+* `view-job-records --jobid`: accept all Flux job ID formats (#566)
+
+* `t/Makefile.am`: add missing line continuation (`\`) character (#570)
+
+* `edit-user`: make `fairshare` an editable field for an association (#569)
+
+* `job.state.priority`: remove raising exception when no aux item found (#568)
+
+#### Features
+
+* doc: add section on configuring queue permissions (#550)
+
+* python: create new `BankFormatter` subclass, restructure view-bank to use new
+class (#525)
+
+* `view-user`: create new `AssociationFormatter` subclass for viewing
+associations (#527)
+
+* `association_table`: add `max_cores` attribute, send information to plugin
+(#560)
+
+* plugin: track the resources used across all of an association's running jobs
+(#561)
+
+* `view-user`: add a new `--list-banks` optional argument (#479)
+
+* doc: add fair-share documentation (#536)
+
+* `delete-user`: add `--force` option to actually remove a row from the
+`association_table` (#572)
+
+* `delete-bank`: add `--force` option to actually remove a row from the
+`bank_table` (#573)
+
+* doc: add note about permanently deleting rows with `--force`, update
+`view-user` examples (#574)
+
+#### Testsuite
+
+* testsuite: pull in valgrind suppression from core (#546)
+
+* testsuite: add longer test descriptions for some of the more complex test
+scenarios (#548)
+
+#### CI
+
+* github: fix ubuntu version for `"python-format"` action (#547)
+
 flux-accounting version 0.40.0 - 2024-12-03
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for v0.41.0.

---

This PR adds some release notes for 02-04-2025. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.41.0 -m "Tag v0.41.0" && git push upstream v0.41.0
```