### PR TITLE
python: use column names when accessing results of a query instead of row indices

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -207,13 +207,16 @@ def delete_bank(conn, bank, force=False):
                     """
                 for assoc_row in cursor.execute(select_assoc_stmt, (bank,)):
                     u.delete_user(
-                        conn, username=assoc_row[0], bank=assoc_row[1], force=force
+                        conn,
+                        username=assoc_row["username"],
+                        bank=assoc_row["bank"],
+                        force=force,
                     )
             # else, disable all of its sub banks and continue traversing
             else:
                 for row in result:
-                    cursor.execute(sql_stmt, (row[0],))
-                    get_sub_banks(row[0])
+                    cursor.execute(sql_stmt, (row["bank"],))
+                    get_sub_banks(row["bank"])
 
         get_sub_banks(bank)
     # if an exception occurs while recursively deleting

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -246,21 +246,26 @@ class BankFormatter(AccountingFormatter):
                 if users:
                     for user in users:
                         hierarchy += (
-                            f"{indent} {bank}|{user[0]}|{user[1]}|{user[2]}|{user[3]}\n"
+                            f"{indent} {bank}|{user['username']}|{user['shares']}|"
+                            f"{user['job_usage']}|{user['fairshare']}\n"
                         )
+
             else:
                 # continue traversing the hierarchy
                 for sub_bank in sub_banks:
-                    hierarchy += f"{indent} {str(sub_bank[0])}||{str(sub_bank[1])}|{str(sub_bank[2])}\n"
+                    hierarchy += (
+                        f"{indent} {str(sub_bank['bank'])}||{str(sub_bank['shares'])}|"
+                        f"{str(sub_bank['job_usage'])}\n"
+                    )
                     hierarchy = construct_parsable_hierarchy(
-                        cur, sub_bank[0], hierarchy, indent + " "
+                        cur, sub_bank["bank"], hierarchy, indent + " "
                     )
 
             return hierarchy
 
         # construct a hierarchy string starting with the bank passed in
         hierarchy = "Bank|Username|RawShares|RawUsage|Fairshare\n"
-        hierarchy += f"{self.rows[0][1]}||{str(self.rows[0][4])}|{str(round(self.rows[0][5], 2))}\n"
+        hierarchy += f"{self.rows[0]['bank']}||{str(self.rows[0]['shares'])}|{str(round(self.rows[0]['job_usage'], 2))}\n"
         hierarchy = construct_parsable_hierarchy(self.cursor, bank, hierarchy, "")
         return hierarchy
 
@@ -321,7 +326,7 @@ class AssociationFormatter(AccountingFormatter):
         result = self.cursor.fetchall()
         banks = ""
         for bank in result:
-            banks += f"{str(bank[0])}\n"
+            banks += f"{str(bank['bank'])}\n"
 
         return banks
 

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -67,6 +67,7 @@ def est_sqlite_conn(path):
 
 def bulk_update(path):
     conn = est_sqlite_conn(path)
+    conn.row_factory = sqlite3.Row
     cur = conn.cursor()
 
     data = {}
@@ -83,18 +84,18 @@ def bulk_update(path):
     ):
         # create a JSON payload with the results of the query
         single_user_data = {
-            "userid": int(row[0]),
-            "bank": str(row[1]),
-            "def_bank": str(row[2]),
-            "fairshare": float(row[3]),
-            "max_running_jobs": int(row[4]),
-            "max_active_jobs": int(row[5]),
-            "queues": str(row[6]),
-            "active": int(row[7]),
-            "projects": str(row[8]),
-            "def_project": str(row[9]),
-            "max_nodes": int(row[10]),
-            "max_cores": int(row[11]),
+            "userid": int(row["userid"]),
+            "bank": str(row["bank"]),
+            "def_bank": str(row["default_bank"]),
+            "fairshare": float(row["fairshare"]),
+            "max_running_jobs": int(row["max_running_jobs"]),
+            "max_active_jobs": int(row["max_active_jobs"]),
+            "queues": str(row["queues"]),
+            "active": int(row["active"]),
+            "projects": str(row["projects"]),
+            "def_project": str(row["default_project"]),
+            "max_nodes": int(row["max_nodes"]),
+            "max_cores": int(row["max_cores"]),
         }
         bulk_user_data.append(single_user_data)
 
@@ -106,11 +107,11 @@ def bulk_update(path):
     for row in cur.execute("SELECT * FROM queue_table"):
         # create a JSON payload with the results of the query
         single_q_data = {
-            "queue": str(row[0]),
-            "min_nodes_per_job": int(row[1]),
-            "max_nodes_per_job": int(row[2]),
-            "max_time_per_job": int(row[3]),
-            "priority": int(row[4]),
+            "queue": str(row["queue"]),
+            "min_nodes_per_job": int(row["min_nodes_per_job"]),
+            "max_nodes_per_job": int(row["max_nodes_per_job"]),
+            "max_time_per_job": int(row["max_time_per_job"]),
+            "priority": int(row["priority"]),
         }
         bulk_q_data.append(single_q_data)
 
@@ -122,7 +123,7 @@ def bulk_update(path):
     for row in cur.execute("SELECT project FROM project_table"):
         # create a JSON payload with the results of the query
         single_project = {
-            "project": str(row[0]),
+            "project": str(row["project"]),
         }
         bulk_proj_data.append(single_project)
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -39,6 +39,7 @@ def establish_sqlite_connection(path):
         conn = sqlite3.connect(db_uri, uri=True)
         # set foreign keys constraint
         conn.execute("PRAGMA foreign_keys = 1")
+        conn.row_factory = sqlite3.Row
     except sqlite3.OperationalError as exc:
         print(f"Unable to open database file: {db_uri}", file=sys.stderr)
         print(f"Exception: {exc}")

--- a/t/python/t1001_db.py
+++ b/t/python/t1001_db.py
@@ -26,6 +26,7 @@ class TestDB(unittest.TestCase):
         global cur
         try:
             conn = sqlite3.connect("file:FluxAccounting.db?mode=rw", uri=True)
+            conn.row_factory = sqlite3.Row
             cur = conn.cursor()
         except sqlite3.OperationalError:
             print(f"Unable to open test database file", file=sys.stderr)

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -31,6 +31,7 @@ class TestAccountingCLI(unittest.TestCase):
         global acct_conn
         try:
             acct_conn = sqlite3.connect("file:TestUserSubcommands.db?mode=rw", uri=True)
+            acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:
             print(f"Unable to open test database file", file=sys.stderr)

--- a/t/python/t1003_bank_cmds.py
+++ b/t/python/t1003_bank_cmds.py
@@ -27,6 +27,7 @@ class TestAccountingCLI(unittest.TestCase):
         global cur
         try:
             acct_conn = sqlite3.connect("file:TestBankSubcommands.db?mode=rw", uri=True)
+            acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:
             print(f"Unable to open test database file", file=sys.stderr)

--- a/t/python/t1004_queue_cmds.py
+++ b/t/python/t1004_queue_cmds.py
@@ -26,6 +26,7 @@ class TestAccountingCLI(unittest.TestCase):
         global cur
 
         acct_conn = sqlite3.connect("TestQueueSubcommands.db")
+        acct_conn.row_factory = sqlite3.Row
         cur = acct_conn.cursor()
 
     # add a valid queue to queue_table

--- a/t/python/t1005_project_cmds.py
+++ b/t/python/t1005_project_cmds.py
@@ -28,6 +28,7 @@ class TestAccountingCLI(unittest.TestCase):
         global cur
 
         acct_conn = sqlite3.connect("TestProjectSubcommands.db")
+        acct_conn.row_factory = sqlite3.Row
         cur = acct_conn.cursor()
 
     # add a valid project to project_table

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -35,6 +35,7 @@ class TestAccountingCLI(unittest.TestCase):
         c.create_db("FluxAccountingUsers.db")
         try:
             acct_conn = sqlite3.connect("file:FluxAccountingUsers.db?mode=rw", uri=True)
+            acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:
             print(f"Unable to open test database file", file=sys.stderr)

--- a/t/python/t1007_formatter.py
+++ b/t/python/t1007_formatter.py
@@ -29,6 +29,7 @@ class TestAccountingCLI(unittest.TestCase):
         global cur
 
         conn = sqlite3.connect("TestFormatter.db")
+        conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
     # initialize Formatter object with no data in Cursor object

--- a/t/python/t1008_banks_output.py
+++ b/t/python/t1008_banks_output.py
@@ -29,6 +29,7 @@ class TestAccountingCLI(unittest.TestCase):
         global cur
 
         conn = sqlite3.connect("test_view_banks.db")
+        conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
     # add some banks, initialize formatter

--- a/t/python/t1009_users_output.py
+++ b/t/python/t1009_users_output.py
@@ -30,6 +30,7 @@ class TestAccountingCLI(unittest.TestCase):
         global cur
 
         conn = sqlite3.connect("test_view_associations.db")
+        conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
     # add some associations, initialize formatter


### PR DESCRIPTION
#### Problem

Currently, a lot of the functions that retrieve data from the SQLite database use a raw SQL query. The results of this query are accessed using positional indexing (e.g., `row[0]`, `row[1]`, etc.), which requires prior knowledge of the column order. This approach is problematic because it makes the code harder to read and maintain, and if the database schema changes (e.g., column order is modified), the function could break or return incorrect values.

---

This PR sets the `row_factory` property for the SQLite `Connection` object created in the flux-accounting service, the bulk-update script, the `formatter` module, and the Python unit tests. As a result, a number of functions are edited to access the results of a SQL query by column name instead of by row index.

I've broken this PR into multiple commits for clarity, but since they all do basically the same thing, I wouldn't mind squashing these into just one commit. I'm open either way.

Fixes #578