### PR TITLE
`update-fshare`: change job usage variable from 32-bit `int` to `double`

### DIFF
--- a/src/fairness/reader/data_reader_db.cpp
+++ b/src/fairness/reader/data_reader_db.cpp
@@ -230,7 +230,7 @@ std::shared_ptr<weighted_tree_node_t> data_reader_db_t::get_sub_banks (
 
     // we've reached a bank with no sub banks, so add associations to the tree
     if (rc != SQLITE_ROW) {
-        int bank_usg = 0;
+        double bank_usg = 0.0;
 
         rc = sqlite3_bind_text (c_assoc, 1, bank_name.c_str (), -1, NULL);
         if (rc != SQLITE_OK) {
@@ -262,7 +262,7 @@ std::shared_ptr<weighted_tree_node_t> data_reader_db_t::get_sub_banks (
                         return nullptr;
                     }
 
-                    bank_usg += std::stoi (usage);
+                    bank_usg += std::stod (usage);
                 }
                 catch (const std::invalid_argument &ia) {
                     m_err_msg += "Invalid argument: "

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -48,6 +48,7 @@ TESTSCRIPTS = \
 	t1046-issue565.t \
 	t1047-issue564.t \
 	t1048-issue575.t \
+	t1049-issue580.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1049-issue580.t
+++ b/t/t1049-issue580.t
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+test_description='test updating fair-share for a DB with huge job usage values'
+
+. `dirname $0`/sharness.sh
+TEST_DB=$(pwd)/FluxAccountingTest.db
+
+UPDATE_USAGE=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create small_no_tie flux-accounting DB' '
+	flux account -p ${TEST_DB} create-db
+'
+
+test_expect_success 'start flux-accounting service on small_no_tie DB' '
+	flux account-service -p ${TEST_DB} -t
+'
+
+test_expect_success 'add users/banks to DB' '
+	flux account add-bank root 1000 &&
+	flux account add-bank --parent-bank root bankA 1 &&
+	flux account add-user --username leaf.1.1 --bank bankA
+'
+
+test_expect_success 'update usage and fair-share for the users/banks' '
+	flux python ${UPDATE_USAGE} ${TEST_DB} leaf.1.1 19115069644.16
+	flux account update-usage
+'
+
+test_expect_success 'ensure update-fshare works with a huge job usage value' '
+	flux account-update-fshare -p ${TEST_DB}
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm ${TEST_DB}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The variable that stores job usage values for banks in the update-fshare script is a 32-bit `int`, and it cannot keep up with larger job usage values that are generated on big machines.

---

This PR changes the variable type of the job usage value from a 32-bit `int` to a 64-bit `double`. This variable probably should have been a `double` this whole time because the job usage value for an association or bank is not always guaranteed to be a whole number. 

I've also added a test that updates the fair-share value for an association and bank where the job usage value is gigantic.