### PR TITLE
fair-share calculation: change `shares`, `usage` types to more appropriate types

### DIFF
--- a/src/fairness/account/account.cpp
+++ b/src/fairness/account/account.cpp
@@ -19,7 +19,7 @@ extern "C" {
 using namespace Flux::accounting;
 
 account_t::account_t (const std::string &name,
-                      bool is_user,  uint64_t shares, uint64_t usage)
+                      bool is_user,  uint64_t shares, double usage)
 {
     m_name = name;
     m_is_user = is_user;
@@ -37,7 +37,7 @@ void account_t::set_shares (uint64_t shares)
     m_shares = shares;
 }
 
-void account_t::set_usage (uint64_t usage)
+void account_t::set_usage (double usage)
 {
     m_usage = usage;
 }
@@ -62,7 +62,7 @@ uint64_t account_t::get_shares () const
     return m_shares;
 }
 
-uint64_t account_t::get_usage () const
+double account_t::get_usage () const
 {
     return m_usage;
 }

--- a/src/fairness/account/account.hpp
+++ b/src/fairness/account/account.hpp
@@ -24,17 +24,17 @@ namespace accounting {
 class account_t {
 public:
     account_t (const std::string &name,
-               bool is_user, uint64_t shares, uint64_t usage);
+               bool is_user, uint64_t shares, double usage);
 
     void set_name (const std::string &name);
     void set_shares (uint64_t shares);
-    void set_usage (uint64_t usage);
+    void set_usage (double usage);
     void set_fshare (double fshare);
 
     const std::string &get_name () const;
     bool is_user () const;
     uint64_t get_shares () const;
-    uint64_t get_usage () const;
+    double get_usage () const;
     double get_fshare () const;
 
     int dprint (std::ostringstream &out) const;
@@ -43,7 +43,7 @@ private:
     std::string m_name = "";
     bool m_is_user = false;
     uint64_t m_shares = 0;
-    uint64_t m_usage = std::numeric_limits<uint64_t>::max ();
+    double m_usage = std::numeric_limits<double>::max ();
     double m_fshare = 0.0f;
 };
 

--- a/src/fairness/reader/data_reader_db.cpp
+++ b/src/fairness/reader/data_reader_db.cpp
@@ -66,7 +66,7 @@ association's data and adds it to the weighted tree.
 */
 int data_reader_db_t::add_assoc (const std::string &username,
                                  uint64_t shrs,
-                                 const std::string &usg,
+                                 double usg,
                                  double fshare,
                                  std::shared_ptr<weighted_tree_node_t> &node)
 {
@@ -75,7 +75,7 @@ int data_reader_db_t::add_assoc (const std::string &username,
                                                              username,
                                                              true,
                                                              shrs,
-                                                             std::stoll (usg));
+                                                             usg);
     user_node->set_fshare (fshare);
     return node->add_child (user_node);
 }
@@ -246,8 +246,7 @@ std::shared_ptr<weighted_tree_node_t> data_reader_db_t::get_sub_banks (
             std::string username = reinterpret_cast<char const *> (
                 sqlite3_column_text (c_assoc, 0));
             uint64_t shrs = sqlite3_column_int64 (c_assoc, 1);
-            std::string usage = reinterpret_cast<char const *> (
-                sqlite3_column_text (c_assoc, 3));
+            double usage = sqlite3_column_double (c_assoc, 3);
             double fshare = sqlite3_column_double (c_assoc, 4);
             int active = sqlite3_column_int (c_assoc, 5);
 
@@ -261,7 +260,7 @@ std::shared_ptr<weighted_tree_node_t> data_reader_db_t::get_sub_banks (
                         return nullptr;
                     }
 
-                    bank_usg += std::stod (usage);
+                    bank_usg += usage;
                 }
                 catch (const std::invalid_argument &ia) {
                     m_err_msg += "Invalid argument: "

--- a/src/fairness/reader/data_reader_db.hpp
+++ b/src/fairness/reader/data_reader_db.hpp
@@ -40,7 +40,7 @@ private:
 
     int add_assoc (const std::string &username,
                    uint64_t shrs,
-                   const std::string &usg,
+                   double usg,
                    double fshare,
                    std::shared_ptr<weighted_tree_node_t> &node);
 

--- a/src/fairness/weighted_tree/weighted_tree.hpp
+++ b/src/fairness/weighted_tree/weighted_tree.hpp
@@ -25,7 +25,7 @@ class weighted_tree_node_t : public account_t {
 public:
     weighted_tree_node_t (std::shared_ptr<weighted_tree_node_t> parent,
                           const std::string &name, bool is_user,
-                          uint64_t shares, uint64_t usage);
+                          uint64_t shares, double usage);
 
     uint64_t get_rank () const;
     uint64_t get_subtree_size () const;
@@ -55,7 +55,7 @@ private:
 
     bool is_equal (double a, double b) const;
     void calc_set_weight (uint64_t sibling_shares_sum,
-                          uint64_t sibling_usage_sum);
+                          double sibling_usage_sum);
     void calc_set_children_weight ();
     void propagate_subtree_size ();
     void propagate_subtree_leaf_size ();


### PR DESCRIPTION
#### Problem

The `shares` attribute for the `Account` class is of type `uint64_t`, but `data_reader_db` is extracting the shares value for an
association as a string and then casting it back to a `long long`. It would make more sense to just set this variable type as a `uint64_t` from the start.

The `usage` attribute used throughout the fair-share code is of type `uint64_t`, but it is of type `real` (i.e a floating-point value) in
the SQLite database. This means that the job usage values are getting truncated when they are being passed through to the actual weight --> fair-share calculation. It would be more precise to keep this `usage` value as type `double` throughout the fair-share calculation code.

---

This PR changes the variable type of the `shares` value to `uint64_t` to match its declared type in the **Account** class. It also changes the type of `usage` throughout the fair-share calculation code to be of type `double`.

You'll also notice that I've changed the comparison of `usage` to be a comparison to an epsilon value instead of a direct comparison to `0` since its type has changed to `double`.