### PR TITLE
python: create new `QueueFormatter` class, refactor `view_queue()` to use new class

### DIFF
--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -400,3 +400,22 @@ class JobsFormatter(flux.util.OutputFormat):
                 )
 
         return output_str
+
+
+class QueueFormatter(AccountingFormatter):
+    """
+    Subclass of AccountingFormatter that includes a custom error message in the
+    case where a queue does not exist in the queue_table.
+    """
+
+    def __init__(self, cursor, queue_name):
+        """
+        Initialize a QueueFormatter object with a SQLite cursor.
+        Args:
+            cursor: a SQLite Cursor object that has the results of a SQL query.
+            queue_name: the name of the queue.
+        """
+        self.queue_name = queue_name
+        super().__init__(
+            cursor, error_msg=f"queue {self.queue_name} not found in queue_table"
+        )

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -11,28 +11,20 @@
 ###############################################################
 import sqlite3
 
+from fluxacct.accounting import formatter as fmt
 
-def view_queue(conn, queue):
-    cur = conn.cursor()
+
+def view_queue(conn, queue, parsable=False):
     try:
+        cur = conn.cursor()
         # get the information pertaining to a queue in the DB
         cur.execute("SELECT * FROM queue_table where queue=?", (queue,))
-        result = cur.fetchall()
-        headers = [description[0] for description in cur.description]
-        queue_str = ""
-        if not result:
-            raise ValueError(f"queue {queue} not found in queue_table")
 
-        # print column names of queue_table
-        for header in headers:
-            queue_str += header.ljust(18)
-        queue_str += "\n"
-        for row in result:
-            for col in list(row):
-                queue_str += str(col).ljust(18)
-            queue_str += "\n"
+        formatter = fmt.QueueFormatter(cur, queue)
 
-        return queue_str
+        if parsable:
+            return formatter.as_table()
+        return formatter.as_json()
     except sqlite3.OperationalError as exc:
         raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -427,7 +427,9 @@ class AccountingService:
 
     def view_queue(self, handle, watcher, msg, arg):
         try:
-            val = qu.view_queue(self.conn, msg.payload["queue"])
+            val = qu.view_queue(
+                self.conn, msg.payload["queue"], msg.payload["parsable"]
+            )
 
             payload = {"view_queue": val}
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -521,6 +521,13 @@ def add_view_queue_arg(subparsers):
 
     subparser_view_queue.set_defaults(func="view_queue")
     subparser_view_queue.add_argument("queue", help="queue name", metavar="QUEUE")
+    subparser_view_queue.add_argument(
+        "--parsable",
+        action="store_const",
+        const=True,
+        help="print all information about a queue on one line",
+        metavar="PARSABLE",
+    )
 
 
 def add_edit_queue_arg(subparsers):

--- a/t/t1024-flux-account-queues.t
+++ b/t/t1024-flux-account-queues.t
@@ -43,6 +43,17 @@ test_expect_success 'add some queues to the DB' '
 	flux account add-queue special --priority=99999
 '
 
+test_expect_success 'view some queue information' '
+	flux account view-queue standby > standby.out &&
+	grep "\"queue\": \"standby\"" standby.out &&
+	grep "\"priority\": 0" standby.out
+'
+
+test_expect_success 'view some queue information with --parsable' '
+	flux account view-queue standby --parsable > standby_parsable.out &&
+	grep "standby | 1                 | 1                 | 60               | 0" standby_parsable.out
+'
+
 test_expect_success 'add a queue to an existing user account' '
 	flux account edit-user user5011 --queue="expedite"
 '


### PR DESCRIPTION
#### Problem

The `view-queue` command defines its own formatting for the output, but flux-accounting now has a common `AccountingFormatter` class that is uniform across all of the `view-*` commands.

---

This PR creates a new `QueueFormatter` subclass to use for printing out queue information from the flux-accounting database. I've also added some basic sharness tests for testing the output of calling `view-queue`. 