### PR TITLE
cmd: add `list-queues` command

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -94,6 +94,7 @@ class AccountingService:
             "view_queue",
             "view_project",
             "list_projects",
+            "list_queues",
         ]
 
         privileged_endpoints = [
@@ -589,6 +590,28 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(
+                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+            )
+
+    def list_queues(self, handle, watcher, msg, arg):
+        try:
+            val = qu.list_queues(
+                self.conn,
+                msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
+                msg.payload["table"],
+            )
+
+            payload = {"list_queues": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except ValueError as exc:
+            handle.respond_error(msg, 0, f"{exc}")
+        except sqlite3.Error as exc:
+            handle.respond_error(msg, 0, f"a SQLite error occurred: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -716,6 +716,28 @@ def add_pop_db_arg(subparsers):
     )
 
 
+def add_list_queues_arg(subparsers):
+    subparser_list_queues = subparsers.add_parser(
+        "list-queues",
+        help="list all queues in the flux-accounting DB",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_list_queues.set_defaults(func="list_queues")
+    subparser_list_queues.add_argument(
+        "--fields",
+        type=str,
+        help="list of fields to include in JSON output",
+        default=None,
+        metavar="QUEUE,MIN_NODES_PER_JOB,MAX_NODES_PER_JOB,MAX_TIME_PER_JOB,PRIORITY",
+    )
+    subparser_list_queues.add_argument(
+        "--table",
+        action="store_const",
+        const=True,
+        help="list all queues in table format",
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -742,6 +764,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_scrub_job_records_arg(subparsers)
     add_export_db_arg(subparsers)
     add_pop_db_arg(subparsers)
+    add_list_queues_arg(subparsers)
 
 
 def set_db_location(args):
@@ -784,6 +807,7 @@ def select_accounting_function(args, output_file, parser):
         "scrub_old_jobs": "accounting.scrub_old_jobs",
         "export_db": "accounting.export_db",
         "pop_db": "accounting.pop_db",
+        "list_queues": "accounting.list_queues",
     }
 
     if args.func in func_map:

--- a/t/t1024-flux-account-queues.t
+++ b/t/t1024-flux-account-queues.t
@@ -121,6 +121,22 @@ test_expect_success 'trying to view a queue that does not exist should raise a V
 	grep "queue foo not found in queue_table" queue_nonexistent.out
 '
 
+test_expect_success 'call list-queues' '
+	flux account list-queues > list_queues.out &&
+	grep "\"queue\": \"standby\"" list_queues.out &&
+	grep "\"queue\": \"expedite\"" list_queues.out &&
+	grep "\"queue\": \"queue_1\"" list_queues.out &&
+	grep "\"queue\": \"queue_2\"" list_queues.out
+'
+
+test_expect_success 'call list-queues and customize output' '
+	flux account list-queues --fields=queue,priority --table > list_queues_table.out &&
+	grep "standby  | 0" list_queues_table.out &&
+	grep "expedite | 20000" list_queues_table.out &&
+	grep "queue_1  | 0" list_queues_table.out &&
+	grep "queue_2  | 0" list_queues_table.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

There is no way to concisely list a set of defined queues in the flux-accounting database, similar to the `list-banks` and `list-projects` commands.

---

This PR adds a new command to the command suite called `list-queues`, which will list all of the queues defined in the `queue_table`. It offers the same options as `list-banks` to customize the output.

I've also added a couple of basic tests that call `list-queues` both in JSON and in a table format with customization.
