### PR TITLE
`apply_decay_factor ()`: fix iteration through usage periods, actually `commit` SQL statements

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -117,10 +117,11 @@ def apply_decay_factor(decay, acct_conn, user=None, bank=None):
     for power, usage_factor in enumerate(usg_past, start=1):
         usg_past_decay.append(usage_factor * math.pow(decay, power))
 
-    # update job_usage_factor_table with new values, starting with period-2;
-    # the last usage factor in the table will get discarded after the update
+    # update job_usage_factor_table with new values, starting with the second usage
+    # period and working back to the oldest usage period since the most recent usage
+    # period is updated separately
     period = 1
-    for usage_factor in usg_past_decay[1 : len(usg_past_decay) - 1]:
+    for usage_factor in usg_past_decay[0:-1]:
         update_stmt = (
             "UPDATE job_usage_factor_table SET usage_factor_period_"
             + str(period)

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -137,6 +137,7 @@ def apply_decay_factor(decay, acct_conn, user=None, bank=None):
         )
         period += 1
 
+    acct_conn.commit()
     # only return the usage factors up to but not including the oldest one
     # since it no longer affects a user's historical usage factor
     return sum(usg_past_decay[:-1])

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -363,7 +363,7 @@ class TestAccountingCLI(unittest.TestCase):
             default_bank=bank,
         )
 
-        self.assertEqual(usage_factor, 2199.5)
+        self.assertEqual(usage_factor, 3215.5)
 
     # simulate a half-life period further; assure the new end of the
     # current half-life period gets updated


### PR DESCRIPTION
#### Problem

As noted in #593, the past usage factors for an association are not actually getting calculated and applied to associations and in the flux-accounting database because the `UPDATE` statements are not being `commit`ted in the `apply_decay_factor ()` function. The iteration through usage periods is also incorrect because the `for`-loop is starting at the wrong index; it *should* be starting at the first index and going to the second-to-last index instead of starting at the *second* index.

---

This PR changes the starting index for the `for`-loop in `apply_decay_factor()` to start at the *first* index instead of the second. It also adds a `commit()` statement near the end of the function to actually apply the `UPDATE` statements that are executed in the flux-accounting database. Finally, a unit test is adjusted to account for the change to how past usage factors are calculated and applied to the database.

Fixes #593 