### PR TITLE
`jj_read_vertex ()`: ignore unknown resources

### DIFF
--- a/src/plugins/jj.cpp
+++ b/src/plugins/jj.cpp
@@ -56,11 +56,7 @@ static int jj_read_vertex (json_t *o, int level, struct jj_counts *jj)
         jj->slot_size = count;
     else if (streq (type, "gpu"))
         jj->slot_gpus = count;
-    else {
-        sprintf (jj->error, "Unsupported resource type '%s'", type);
-        errno = EINVAL;
-        return -1;
-    }
+    // ignore unknown resources
     if (with)
         return jj_read_level (with, level+1, jj);
     return 0;


### PR DESCRIPTION
#### Problem

As mentioned in flux-framework/flux-core#6710, the `jj_read_vertex ()` function returns an error if it encounters a resource type it does not recognize certain types like 'ssd'. Since flux-coral2 can create non-v1 jobspecs, flux-accounting needs to be able to handle these types of resources instead of raising an exception on the job.

---

This PR removes the `else`-condition from `jj_read_vertex ()` to raise an error when it encounters an unknown resource type, and instead just ignore unknown resources.