### PR TITLE
cmd: add new `list-users` command

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -95,6 +95,7 @@ class AccountingService:
             "view_project",
             "list_projects",
             "list_queues",
+            "list_users",
         ]
 
         privileged_endpoints = [
@@ -170,6 +171,34 @@ class AccountingService:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
             )
+
+    # pylint: disable=no-self-use
+    def list_users(self, handle, watcher, msg, arg):
+        try:
+            val = u.list_users(
+                self.conn,
+                cols=msg.payload.get("fields").split(",")
+                if msg.payload.get("fields")
+                else None,
+                json_fmt=msg.payload.get("json"),
+                active=msg.payload.get("active"),
+                bank=msg.payload.get("bank"),
+                shares=msg.payload.get("shares"),
+                max_running_jobs=msg.payload.get("max_running_jobs"),
+                max_active_jobs=msg.payload.get("max_active_jobs"),
+                max_nodes=msg.payload.get("max_nodes"),
+                max_cores=msg.payload.get("max_cores"),
+                queues=msg.payload.get("queues"),
+                projects=msg.payload.get("projects"),
+            )
+
+            payload = {"list_users": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, str(exc))
 
     def add_user(self, handle, watcher, msg, arg):
         try:

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -66,6 +66,64 @@ def add_view_user_arg(subparsers):
     )
 
 
+def add_list_users_arg(subparsers):
+    subparser_list_users = subparsers.add_parser(
+        "list-users",
+        help="list all associations in association_table",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_list_users.set_defaults(func="list_users")
+    subparser_list_users.add_argument(
+        "--fields",
+        type=str,
+        help="list of fields to include in output",
+        default=None,
+        metavar=f"{','.join(fluxacct.accounting.ASSOCIATION_TABLE)}",
+    )
+    subparser_list_users.add_argument(
+        "--json",
+        action="store_const",
+        const=True,
+        help="print output in JSON format",
+    )
+    subparser_list_users.add_argument(
+        "--active",
+        metavar="ACTIVE_STATUS",
+    )
+    subparser_list_users.add_argument(
+        "--bank",
+        metavar="BANK",
+    )
+    subparser_list_users.add_argument(
+        "--shares",
+        metavar="SHARES",
+    )
+    subparser_list_users.add_argument(
+        "--max-running-jobs",
+        metavar="MAX_RUNNING_JOBS",
+    )
+    subparser_list_users.add_argument(
+        "--max-active-jobs",
+        metavar="MAX_ACTIVE_JOBS",
+    )
+    subparser_list_users.add_argument(
+        "--max-nodes",
+        metavar="MAX_NODES",
+    )
+    subparser_list_users.add_argument(
+        "--max-cores",
+        metavar="MAX_CORES",
+    )
+    subparser_list_users.add_argument(
+        "--queues",
+        metavar="QUEUES",
+    )
+    subparser_list_users.add_argument(
+        "--projects",
+        metavar="PROJECTS",
+    )
+
+
 def add_add_user_arg(subparsers):
     subparser_add_user = subparsers.add_parser(
         "add-user",
@@ -742,6 +800,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
     add_view_user_arg(subparsers)
+    add_list_users_arg(subparsers)
     add_add_user_arg(subparsers)
     add_delete_user_arg(subparsers)
     add_edit_user_arg(subparsers)
@@ -786,6 +845,7 @@ def select_accounting_function(args, output_file, parser):
     # map each command to the corresponding accounting RPC call
     func_map = {
         "view_user": "accounting.view_user",
+        "list_users": "accounting.list_users",
         "add_user": "accounting.add_user",
         "delete_user": "accounting.delete_user",
         "edit_user": "accounting.edit_user",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -50,6 +50,7 @@ TESTSCRIPTS = \
 	t1048-issue575.t \
 	t1049-issue580.t \
 	t1050-mf-priority-update-on-reload.t \
+	t1051-list-users.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1051-list-users.t
+++ b/t/t1051-list-users.t
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+test_description='test list-users command'
+
+. `dirname $0`/sharness.sh
+FLUX_ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${FLUX_ACCOUNTING_DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${FLUX_ACCOUNTING_DB} -t
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze &&
+	flux account add-queue silver &&
+	flux account add-queue gold
+'
+
+test_expect_success 'add some projects to the DB' '
+	flux account add-project leviathan_wakes &&
+	flux account add-project babylons_gate
+'
+
+test_expect_success 'add some users to the DB' '
+	flux account add-user --username=user1 --userid=5011 --bank=A &&
+	flux account add-user --username=user2 --userid=5012 --bank=A &&
+	flux account add-user --username=user2 --userid=5012 --bank=B &&
+	flux account add-user --username=user3 --userid=5013 --bank=B &&
+	flux account add-user --username=user4 --userid=5014 --bank=C
+'
+
+test_expect_success 'edit two associations to have different shares values than the rest' '
+	flux account edit-user user3 --shares=100 &&
+	flux account edit-user user4 --shares=100
+'
+
+test_expect_success 'edit associations to belong to different queues' '
+	flux account edit-user user1 --queues="bronze" &&
+	flux account edit-user user2 --queues="bronze,silver" &&
+	flux account edit-user user3 --queues="bronze,silver,gold" &&
+	flux account edit-user user4 --queues="bronze,silver"
+'
+
+test_expect_success 'edit associations to belong to different projects' '
+	flux account edit-user user1 --projects="leviathan_wakes" &&
+	flux account edit-user user2 --bank=B --projects="leviathan_wakes,babylons_gate"
+'
+
+test_expect_success 'call list-users --help' '
+	flux account list-users --help
+'
+
+test_expect_success 'pass in an invalid argument to list-users' '
+	test_must_fail flux account list-users --foo=bar > invalid_arg.out 2>&1 &&
+	grep "error: unrecognized arguments: --foo=bar" invalid_arg.out
+'
+
+# If no filters are passed, every association in the association_table will be
+# returned in the output.
+test_expect_success 'call list-users with no optional args to get all associations' '
+	flux account list-users --json >all_users.json &&
+	test_debug "jq -S . <all_users.json" &&
+	jq -e "length == 5" all_users.json 
+'
+
+# In the following set of tests, we pass certain filters to only get
+# the associations which fit the criteria of the filters passed in.
+test_expect_success 'filter associations by bank' '
+	flux account list-users --json --bank=A >bankA_users.json &&
+	test_debug "jq -S . <bankA_users.json" &&
+	jq -e "length == 2" bankA_users.json 
+'
+
+test_expect_success 'filter associations by shares' '
+	flux account list-users --json --shares=100 >100shares_users.json &&
+	test_debug "jq -S . <100shares_users.json" &&
+	jq -e "length == 2" 100shares_users.json 
+'
+
+test_expect_success 'filter associations by queues' '
+	flux account list-users --json --queues="bronze" >bronze_users.json &&
+	test_debug "jq -S . <bronze_users.json" &&
+	jq -e "length == 5" bronze_users.json
+'
+
+test_expect_success 'filter associations by more queues' '
+	flux account list-users --json --queues="gold" >gold_users.json &&
+	test_debug "jq -S . <gold_users.json" &&
+	jq -e "length == 1" gold_users.json
+'
+
+test_expect_success 'filter associations by project' '
+	flux account list-users --json --project="leviathan_wakes" >leviathan_wakes_users.json &&
+	test_debug "jq -S . <leviathan_wakes_users.json" &&
+	jq -e "length == 2" leviathan_wakes_users.json
+'
+
+test_expect_success 'delete an association and ensure we can filter by active status' '
+	flux account delete-user user4 C &&
+	flux account list-users --json --active=0 >inactive_users.json &&
+	test_debug "jq -S . <inactive_users.json" &&
+	jq -e "length == 1" inactive_users.json
+'
+
+# In the following test, we pass more than one field when listing the
+# associations to further filter the values returned.
+test_expect_success 'filter by more than one field' '
+	flux account list-users --json --bank=A --projects="leviathan_wakes" >multiple_filters_users.json &&
+	cat multiple_filters_users.json &&
+	test_debug "jq -S . <multiple_filters_users.json" &&
+	jq -e "length == 1" multiple_filters_users.json
+'
+
+# In the following set of tests, we customize the output to only include
+# certain columns in the output.
+test_expect_success 'customize JSON output of list-users' '
+	flux account list-users --json \
+		--bank=A --fields=username,bank,default_bank,shares > bankA_custom_output.json &&
+	grep "\"username\": \"user1\"" bankA_custom_output.json &&
+	grep "\"username\": \"user2\"" bankA_custom_output.json
+'
+
+test_expect_success 'customize table output of list-users' '
+	flux account list-users \
+		--bank=A --fields=username,bank,default_bank,shares > bankA_custom_table.out &&
+	grep "user1" bankA_custom_table.out &&
+	grep "user2" bankA_custom_table.out
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm ${FLUX_ACCOUNTING_DB}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As noted in #596, there is no way to list any of the rows in the `association_table`, similar to the `list-banks` command. It would also be nice if the table could be filtered by certain columns in the table, such as by queue, project, or limit.

---

This PR adds a new command to the flux-accounting command suite called `list-users`, which by default will list all of the rows in the `association_table` in a human-readable table format. An optional `--json` argument is also added to output the results in a JSON format:

```console
$ flux account list-users
username | bank | default_bank | shares
---------+------+--------------+-------
user1    | A    | A            | 1     
user2    | A    | A            | 1     
user2    | B    | A            | 1     
user3    | B    | B            | 100   
user4    | C    | C            | 100  
```

It accepts multiple optional arguments to filter the table by certain columns in the `association_table`.

```console
$ flux account list-users --shares=100
username | bank | default_bank | shares
---------+------+--------------+-------
user3    | B    | B            | 100   
user4    | C    | C            | 100
```

Its output can also be customized by column, e.g the person calling this command only wants to see the username of the association.

```console
$ flux account list-users --shares=100 --fields=username,bank
username | bank
---------+-----
user3    | B   
user4    | C   
```

Fixes #596 