### PR TITLE
`view-*`/`list-*` commands: add `-o/--format` optional argument

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -282,6 +282,7 @@ def list_banks(
     inactive=False,
     cols=None,
     table=False,
+    format_string="",
 ):
     """
     List all banks in bank_table.
@@ -293,6 +294,8 @@ def list_banks(
             columns are included.
         table: output data in bank_table in table format. By default, the format of any
             returned data is in JSON.
+        format_string: a format string defining how each row should be formatted. Column
+            names should be used as placeholders.
     """
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.BANK_TABLE
@@ -309,6 +312,8 @@ def list_banks(
 
         # initialize AccountingFormatter object
         formatter = fmt.AccountingFormatter(cur)
+        if format_string != "":
+            return formatter.as_format_string(format_string)
         if table:
             return formatter.as_table()
         return formatter.as_json()

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -136,7 +136,9 @@ def add_bank(conn, bank, shares, parent_bank=""):
         raise sqlite3.IntegrityError(f"bank {bank} already exists in bank_table")
 
 
-def view_bank(conn, bank, tree=False, users=False, parsable=False, cols=None):
+def view_bank(
+    conn, bank, tree=False, users=False, parsable=False, cols=None, format_string=""
+):
     if tree and cols is not None:
         # tree format cannot be combined with custom formatting, so raise an Exception
         raise ValueError(f"--tree option does not support custom formatting")
@@ -158,6 +160,8 @@ def view_bank(conn, bank, tree=False, users=False, parsable=False, cols=None):
         # initialize BankFormatter object
         formatter = fmt.BankFormatter(cur, bank)
 
+        if format_string != "":
+            return formatter.as_format_string(format_string)
         if tree:
             if parsable:
                 return formatter.as_parsable_tree(bank)

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -98,6 +98,34 @@ class AccountingFormatter:
 
         return json_string
 
+    def as_format_string(self, format_string):
+        """
+        Return the output as a formatted string with the results of the query.
+
+        Args:
+            format_string (str): A format string defining how each row should be
+                formatted. Column names should be used as placeholders.
+
+        Returns:
+            str: A formatted string containing the query results, including column headers.
+        """
+        try:
+            header = format_string.format(
+                **dict(zip(self.column_names, self.column_names))
+            )
+            formatted_rows = [
+                format_string.format(**dict(zip(self.column_names, row)))
+                for row in self.rows
+            ]
+
+            return "\n".join([header] + formatted_rows)
+        except KeyError as exc:
+            # one of the column names in the format string is invalid; raise ValueError
+            raise ValueError(
+                f"Invalid column name in format string: {exc.args[0]}."
+                + f"\nAvailable columns: {','.join(self.column_names)}"
+            )
+
 
 class BankFormatter(AccountingFormatter):
     """

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -124,7 +124,7 @@ def edit_queue(
     return 0
 
 
-def list_queues(conn, cols=None, table=False):
+def list_queues(conn, cols=None, table=False, format_string=""):
     """
     List all queues in queue_table.
 
@@ -133,6 +133,8 @@ def list_queues(conn, cols=None, table=False):
             columns are included.
         table: output data in bank_table in table format. By default, the format of any
             returned data is in JSON.
+        format_string: a format string defining how each row should be formatted. Column
+            names should be used as placeholders.
     """
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.QUEUE_TABLE
@@ -147,6 +149,8 @@ def list_queues(conn, cols=None, table=False):
 
         # initialize AccountingFormatter object
         formatter = fmt.AccountingFormatter(cur)
+        if format_string != "":
+            return formatter.as_format_string(format_string)
         if table:
             return formatter.as_table()
         return formatter.as_json()

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -16,7 +16,7 @@ from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import sql_util as sql
 
 
-def view_queue(conn, queue, parsable=False):
+def view_queue(conn, queue, parsable=False, format_string=""):
     try:
         cur = conn.cursor()
         # get the information pertaining to a queue in the DB
@@ -24,11 +24,15 @@ def view_queue(conn, queue, parsable=False):
 
         formatter = fmt.QueueFormatter(cur, queue)
 
+        if format_string != "":
+            return formatter.as_format_string(format_string)
         if parsable:
             return formatter.as_table()
         return formatter.as_json()
     except sqlite3.OperationalError as exc:
         raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
+    except ValueError as exc:
+        raise ValueError(f"view-queue: {exc}")
 
 
 def add_queue(

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -273,7 +273,7 @@ def view_user(
         raise ValueError(f"view-user: {exc}")
 
 
-def list_users(conn, cols=None, json_fmt=False, **kwargs):
+def list_users(conn, cols=None, json_fmt=False, format_string="", **kwargs):
     """
     List all associations in the association_table in the flux-accounting DB. If
     filters are passed in, limit the associations returned to the ones which fit
@@ -285,6 +285,8 @@ def list_users(conn, cols=None, json_fmt=False, **kwargs):
             columns are included.
         filters: a list of optional constraints passed-in to filter the
             association_table by.
+        format_string: a format string defining how each row should be formatted. Column
+            names should be used as placeholders.
     """
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.ASSOCIATION_TABLE
@@ -319,6 +321,8 @@ def list_users(conn, cols=None, json_fmt=False, **kwargs):
 
         # initialize AccountingFormatter object
         formatter = fmt.AccountingFormatter(cur)
+        if format_string != "":
+            return formatter.as_format_string(format_string)
         if json_fmt:
             return formatter.as_json()
         return formatter.as_table()

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -235,7 +235,9 @@ def clear_projects(conn, username, bank=None):
 #                   Subcommand Functions                      #
 #                                                             #
 ###############################################################
-def view_user(conn, user, parsable=False, cols=None, list_banks=False):
+def view_user(
+    conn, user, parsable=False, cols=None, list_banks=False, format_string=""
+):
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.ASSOCIATION_TABLE
 
@@ -252,6 +254,8 @@ def view_user(conn, user, parsable=False, cols=None, list_banks=False):
         # initialize AssociationFormatter object
         formatter = fmt.AssociationFormatter(cur, user)
 
+        if format_string != "":
+            return formatter.as_format_string(format_string)
         if list_banks:
             return formatter.list_banks()
         if parsable:

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -182,6 +182,7 @@ class AccountingService:
                 if msg.payload.get("fields")
                 else None,
                 json_fmt=msg.payload.get("json"),
+                format_string=msg.payload.get("format"),
                 active=msg.payload.get("active"),
                 bank=msg.payload.get("bank"),
                 shares=msg.payload.get("shares"),
@@ -376,6 +377,7 @@ class AccountingService:
                 msg.payload["inactive"],
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
                 msg.payload["table"],
+                msg.payload["format"],
             )
 
             payload = {"list_banks": val}
@@ -637,6 +639,7 @@ class AccountingService:
                 self.conn,
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
                 msg.payload["table"],
+                msg.payload["format"],
             )
 
             payload = {"list_queues": val}

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -154,6 +154,7 @@ class AccountingService:
                 msg.payload["parsable"],
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
                 msg.payload["list_banks"],
+                msg.payload["format"],
             )
 
             payload = {"view_user": val}
@@ -289,6 +290,7 @@ class AccountingService:
                 msg.payload["users"],
                 msg.payload["parsable"],
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
+                msg.payload["format"],
             )
 
             payload = {"view_bank": val}
@@ -459,7 +461,10 @@ class AccountingService:
     def view_queue(self, handle, watcher, msg, arg):
         try:
             val = qu.view_queue(
-                self.conn, msg.payload["queue"], msg.payload["parsable"]
+                self.conn,
+                msg.payload["queue"],
+                msg.payload["parsable"],
+                msg.payload["format"],
             )
 
             payload = {"view_queue": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -95,6 +95,14 @@ def add_list_users_arg(subparsers):
         help="print output in JSON format",
     )
     subparser_list_users.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
+    )
+    subparser_list_users.add_argument(
         "--active",
         metavar="ACTIVE_STATUS",
     )
@@ -535,6 +543,14 @@ def add_list_banks_arg(subparsers):
         const=True,
         help="list all banks in table format",
     )
+    subparser_list_banks.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
+    )
 
 
 def add_update_usage_arg(subparsers):
@@ -830,6 +846,14 @@ def add_list_queues_arg(subparsers):
         action="store_const",
         const=True,
         help="list all queues in table format",
+    )
+    subparser_list_queues.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
     )
 
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -64,6 +64,14 @@ def add_view_user_arg(subparsers):
         help="list all of the banks a user belongs to",
         metavar="LIST_BANKS",
     )
+    subparser_view_user.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
+    )
 
 
 def add_list_users_arg(subparsers):
@@ -444,6 +452,14 @@ def add_view_bank_arg(subparsers):
         default=None,
         metavar="BANK_ID,BANK,ACTIVE,PARENT_BANK,SHARES,JOB_USAGE",
     )
+    subparser_view_bank.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
+    )
 
 
 def add_delete_bank_arg(subparsers):
@@ -591,6 +607,14 @@ def add_view_queue_arg(subparsers):
         const=True,
         help="print all information about a queue on one line",
         metavar="PARSABLE",
+    )
+    subparser_view_queue.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
     )
 
 

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -77,6 +77,18 @@ test_expect_success 'view some user information with --parsable' '
 	grep -w "user5011\|5011\|A" user_info_parsable.out
 '
 
+test_expect_success 'call view-user with a format string (userid, bank)' '
+	flux account view-user -o "{userid:<8} | {bank:<12}" user5011 > user5011_format_string.out &&
+	grep "userid   | bank" user5011_format_string.out &&
+	grep "5011     | A" user5011_format_string.out
+'
+
+test_expect_success 'call view-user with an invalid format string' '
+	test_must_fail flux account \
+		view-user -o "{foo:<8}" user5011 > bad_format_string.out 2>&1 &&
+	grep "Invalid column name in format string: foo" bad_format_string.out
+'
+
 test_expect_success 'edit a userid for a user' '
 	flux account edit-user user5011 --userid=12345 &&
 	flux account view-user user5011 > edit_userid.out &&

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -53,6 +53,12 @@ test_expect_success 'viewing the root bank with no optional args should show bas
 	test_cmp ${EXPECTED_FILES}/root_bank.expected root_bank.test
 '
 
+test_expect_success 'call view-bank with a format string (bank_id, bank, shares)' '
+	flux account view-bank -o "{bank_id:<8} || {bank:<12} || {shares:<5}" A > A_format_string.out &&
+	grep "bank_id  || bank         || shares" A_format_string.out &&
+	grep "2        || A            || 1" A_format_string.out
+'
+
 test_expect_success 'viewing the root bank with -t should show the entire hierarchy' '
 	flux account -p ${DB_PATH} view-bank root -t > full_hierarchy.test &&
 	test_cmp ${EXPECTED_FILES}/full_hierarchy.expected full_hierarchy.test
@@ -149,6 +155,12 @@ test_expect_success 'call list-banks with a bad field' '
 test_expect_success 'combining --tree with --fields does not work' '
     test_must_fail flux account view-bank root --tree --fields=bank_id > error.out 2>&1 &&
     grep "tree option does not support custom formatting" error.out
+'
+
+test_expect_success 'call list-banks with a format string' '
+	flux account list-banks -o "{bank_id:<7}||{bank:<7}||{shares:>2}" > format_string.out &&
+	grep "bank_id||bank   ||shares" format_string.out &&
+	grep "1      ||root   || 1" format_string.out
 '
 
 test_expect_success 'delete a bank with --force; ensure users also get deleted' '

--- a/t/t1024-flux-account-queues.t
+++ b/t/t1024-flux-account-queues.t
@@ -54,6 +54,12 @@ test_expect_success 'view some queue information with --parsable' '
 	grep "standby | 1                 | 1                 | 60               | 0" standby_parsable.out
 '
 
+test_expect_success 'call view-queue with a format string' '
+	flux account view-queue standby -o "{queue:<8} || {priority:<12}" > standby_format_string.out &&
+	grep "queue    || priority" standby_format_string.out &&
+	grep "standby  || 0" standby_format_string.out
+'
+
 test_expect_success 'add a queue to an existing user account' '
 	flux account edit-user user5011 --queue="expedite"
 '
@@ -135,6 +141,13 @@ test_expect_success 'call list-queues and customize output' '
 	grep "expedite | 20000" list_queues_table.out &&
 	grep "queue_1  | 0" list_queues_table.out &&
 	grep "queue_2  | 0" list_queues_table.out
+'
+
+test_expect_success 'call list-queues with a format string' '
+	flux account list-queues \
+		-o "{queue:<8}||{max_time_per_job:<12}" > format_string.out &&
+	grep "queue   ||max_time_per_job" format_string.out &&
+	grep "standby ||60" format_string.out
 '
 
 test_expect_success 'remove flux-accounting DB' '

--- a/t/t1051-list-users.t
+++ b/t/t1051-list-users.t
@@ -143,6 +143,13 @@ test_expect_success 'customize table output of list-users' '
 	grep "user2" bankA_custom_table.out
 '
 
+# In the following test, we customize the output with a format string.
+test_expect_success 'customize output using a format string' '
+	flux account list-users -o "{username:<8}||{userid:<6}|{bank:<7}|" > format_string.out &&
+	grep "username||userid|bank   |" format_string.out &&
+	grep "user1   ||5011  |A      |" format_string.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm ${FLUX_ACCOUNTING_DB}
 '


### PR DESCRIPTION
#### Problem

There is no way to customize the output of a query to the flux-accounting DB using a Python format string. It would be nice if
flux-accounting offered a way to customize the output with a format string, similar to a lot of the commands offered by flux-core.

---

This PR adds a new method to the `AccountingFormatter` class called `as_format_string()`, which will return the results of a query to the flux-accounting DB as a formatted string. As a result, the `view-*` and `list-*` commands now offer an `-o/--format` optional argument, which allows the user to pass in a formatted string to customize their output:

```console
$ flux account view-user -o "{userid:<8} | {bank:<12}" user5011
userid   | bank        
5011     | A
```

I've also added some basic tests for the commands that now have this format string option.

Fixes #598