### PR TITLE
bindings: add `ProjectFormatter` subclass, `-o/--format` options to `view-project`/`list-projects`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -447,3 +447,22 @@ class QueueFormatter(AccountingFormatter):
         super().__init__(
             cursor, error_msg=f"queue {self.queue_name} not found in queue_table"
         )
+
+
+class ProjectFormatter(AccountingFormatter):
+    """
+    Subclass of AccountingFormatter that includes a custom error message in the
+    case where a project does not exist in the project_table.
+    """
+
+    def __init__(self, cursor, project_name):
+        """
+        Initialize a ProjectFormatter object with a SQLite cursor.
+        Args:
+            cursor: a SQLite Cursor object that has the results of a SQL query.
+            project: the name of the project.
+        """
+        self.project_name = project_name
+        super().__init__(
+            cursor, error_msg=f"project {self.project_name} not found in project_table"
+        )

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -44,7 +44,7 @@ def project_is_active(cur, project):
 ###############################################################
 
 
-def view_project(conn, project, parsable=False):
+def view_project(conn, project, parsable=False, format_string=None):
     try:
         cur = conn.cursor()
         # get the information pertaining to a project in the DB
@@ -52,6 +52,8 @@ def view_project(conn, project, parsable=False):
 
         formatter = fmt.ProjectFormatter(cur, project)
 
+        if format_string is not None:
+            return formatter.as_format_string(format_string)
         if parsable:
             return formatter.as_table()
         return formatter.as_json()
@@ -111,7 +113,7 @@ def delete_project(conn, project):
     return 0
 
 
-def list_projects(conn, cols=None, table=False):
+def list_projects(conn, cols=None, table=False, format_string=None):
     """
     List all of the available projects registered in the project_table.
 
@@ -134,6 +136,8 @@ def list_projects(conn, cols=None, table=False):
 
         # initialize AccountingFormatter object
         formatter = fmt.AccountingFormatter(cur)
+        if format_string is not None:
+            return formatter.as_format_string(format_string)
         if table:
             return formatter.as_table()
         return formatter.as_json()

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -11,6 +11,9 @@
 ###############################################################
 import sqlite3
 
+import fluxacct.accounting
+from fluxacct.accounting import formatter as fmt
+from fluxacct.accounting import sql_util as sql
 
 ###############################################################
 #                                                             #
@@ -41,26 +44,17 @@ def project_is_active(cur, project):
 ###############################################################
 
 
-def view_project(conn, project):
-    cur = conn.cursor()
+def view_project(conn, project, parsable=False):
     try:
+        cur = conn.cursor()
         # get the information pertaining to a project in the DB
         cur.execute("SELECT * FROM project_table where project=?", (project,))
-        result = cur.fetchall()
-        headers = [description[0] for description in cur.description]
-        project_str = ""
-        if not result:
-            raise ValueError(f"project {project} not found in project_table")
 
-        for header in headers:
-            project_str += header.ljust(18)
-        project_str += "\n"
-        for row in result:
-            for col in list(row):
-                project_str += str(col).ljust(18)
-            project_str += "\n"
+        formatter = fmt.ProjectFormatter(cur, project)
 
-        return project_str
+        if parsable:
+            return formatter.as_table()
+        return formatter.as_json()
     except sqlite3.OperationalError as exc:
         raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
 
@@ -117,30 +111,33 @@ def delete_project(conn, project):
     return 0
 
 
-def list_projects(conn):
+def list_projects(conn, cols=None, table=False):
     """
     List all of the available projects registered in the project_table.
+
+    Args:
+        cols: a list of columns from the table to include in the output. By default, all
+            columns are included.
+        table: output data in bank_table in table format. By default, the format of any
+            returned data is in JSON.
     """
-    cur = conn.cursor()
+    # use all column names if none are passed in
+    cols = cols or fluxacct.accounting.PROJECT_TABLE
 
-    cur.execute("SELECT * FROM project_table")
-    rows = cur.fetchall()
+    try:
+        cur = conn.cursor()
 
-    # fetch column names and determine width of each column
-    col_names = [description[0] for description in cur.description]
-    col_widths = [
-        max(len(str(value)) for value in [col] + [row[i] for row in rows])
-        for i, col in enumerate(col_names)
-    ]
+        sql.validate_columns(cols, fluxacct.accounting.PROJECT_TABLE)
+        # construct SELECT statement
+        select_stmt = f"SELECT {', '.join(cols)} FROM project_table"
+        cur.execute(select_stmt)
 
-    def format_row(row):
-        return " | ".join(
-            [f"{str(value).ljust(col_widths[i])}" for i, value in enumerate(row)]
-        )
-
-    header = format_row(col_names)
-    separator = "-+-".join(["-" * width for width in col_widths])
-    data_rows = "\n".join([format_row(row) for row in rows])
-    table = f"{header}\n{separator}\n{data_rows}"
-
-    return table
+        # initialize AccountingFormatter object
+        formatter = fmt.AccountingFormatter(cur)
+        if table:
+            return formatter.as_table()
+        return formatter.as_json()
+    except sqlite3.Error as err:
+        raise sqlite3.Error(f"list-projects: an sqlite3.Error occurred: {err}")
+    except ValueError as exc:
+        raise ValueError(f"list-projects: {exc}")

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -540,7 +540,10 @@ class AccountingService:
     def view_project(self, handle, watcher, msg, arg):
         try:
             val = p.view_project(
-                self.conn, msg.payload["project"], msg.payload["parsable"]
+                self.conn,
+                msg.payload["project"],
+                msg.payload["parsable"],
+                msg.payload["format"],
             )
 
             payload = {"view_project": val}
@@ -577,6 +580,7 @@ class AccountingService:
                 self.conn,
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
                 msg.payload["table"],
+                msg.payload["format"],
             )
 
             payload = {"list_projects": val}

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -539,7 +539,9 @@ class AccountingService:
 
     def view_project(self, handle, watcher, msg, arg):
         try:
-            val = p.view_project(self.conn, msg.payload["project"])
+            val = p.view_project(
+                self.conn, msg.payload["project"], msg.payload["parsable"]
+            )
 
             payload = {"view_project": val}
 
@@ -571,7 +573,11 @@ class AccountingService:
 
     def list_projects(self, handle, watcher, msg, arg):
         try:
-            val = p.list_projects(self.conn)
+            val = p.list_projects(
+                self.conn,
+                msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
+                msg.payload["table"],
+            )
 
             payload = {"list_projects": val}
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -722,6 +722,12 @@ def add_view_project_arg(subparsers):
         help="print all information about a project on one line",
         metavar="PARSABLE",
     )
+    subparser_view_project.add_argument(
+        "-o",
+        "--format",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
+    )
 
 
 def add_delete_project_arg(subparsers):
@@ -756,6 +762,12 @@ def add_list_projects_arg(subparsers):
         action="store_const",
         const=True,
         help="list all projects in table format",
+    )
+    subparser_list_projects.add_argument(
+        "-o",
+        "--format",
+        help="Specify output format using Python's string format syntax.",
+        metavar="FORMAT",
     )
 
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -715,6 +715,13 @@ def add_view_project_arg(subparsers):
     subparser_view_project.add_argument(
         "project", help="project name", metavar="PROJECT"
     )
+    subparser_view_project.add_argument(
+        "--parsable",
+        action="store_const",
+        const=True,
+        help="print all information about a project on one line",
+        metavar="PARSABLE",
+    )
 
 
 def add_delete_project_arg(subparsers):
@@ -738,6 +745,18 @@ def add_list_projects_arg(subparsers):
     )
 
     subparser_list_projects.set_defaults(func="list_projects")
+    subparser_list_projects.add_argument(
+        "--fields",
+        help="list of fields to include in output",
+        default=None,
+        metavar="PROJECT_ID,PROJECT,USAGE",
+    )
+    subparser_list_projects.add_argument(
+        "--table",
+        action="store_const",
+        const=True,
+        help="list all projects in table format",
+    )
 
 
 def add_scrub_job_records_arg(subparsers):

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -53,6 +53,12 @@ test_expect_success 'list contents of project_table before adding projects' '
 	grep -f project_table.expected project_table.test
 '
 
+test_expect_success 'call list-projects with a format string' '
+	flux account list-projects -o "{project_id:>12} || {project:<10}" > projects_format_string.out &&
+	grep "project_id || project" projects_format_string.out &&
+	grep "         1 || *" projects_format_string.out
+'
+
 test_expect_success 'add some projects to the project_table' '
 	flux account add-project project_1 &&
 	flux account add-project project_2 &&
@@ -63,6 +69,13 @@ test_expect_success 'add some projects to the project_table' '
 test_expect_success 'view project information from the project_table' '
 	flux account view-project project_1 > project_1.out &&
 	grep -w "1\|project_1" project_1.out
+'
+
+test_expect_success 'view project information with a format string' '
+	flux account view-project -o "{project_id:>12} || {project:<10}" \
+		project_1 > project_1_format_string.out &&
+	grep "project_id || project" project_1_format_string.out &&
+	grep "         2 || project_1" project_1_format_string.out
 '
 
 test_expect_success 'add a user with some specified projects to the association_table' '

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -44,7 +44,7 @@ test_expect_success 'add some queues to the DB' '
 '
 
 test_expect_success 'list contents of project_table before adding projects' '
-	flux account list-projects > project_table.test &&
+	flux account list-projects --table > project_table.test &&
 	cat <<-EOF >project_table.expected
 	project_id | project | usage
 	-----------+---------+------
@@ -144,7 +144,7 @@ test_expect_success 'reset the projects list for an association' '
 '
 
 test_expect_success 'list all of the projects currently registered in project_table' '
-	flux account list-projects > project_table.test &&
+	flux account list-projects --table > project_table.test &&
 	cat <<-EOF >project_table.expected
 	project_id | project   | usage
 	-----------+-----------+------


### PR DESCRIPTION
#### Problem

The `view-project` and `list-projects` commands manually define their own formatting for their respective commands, which is different from the rest of the command suite, which are subclasses of a common `AccountingFormatter` class to standardize all output.

The `view-project` and `list-projects` commands also do not take an optional `-o/--format` argument to format the output using a Python format string, which is inconsistent with the rest of the flux-accounting command suite.

---

This PR adds a new `ProjectFormatter` subclass to the Python bindings so that the output of the `view-project` and `list-projects` commands are standard with the rest of the flux-accounting command suite. I've also added `--table` and `--fields` options to the `list-projects` command and a `--parsable` option to the `view-projects` command. Lastly, I've added `-o/--format` optional arguments to both commands.

