### PR TITLE
plugin: add a new `Job` class 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,7 +50,8 @@ TESTS = \
 	weighted_tree_test01.t \
 	data_reader_db_test01.t \
 	data_writer_db_test01.t \
-	accounting_test01.t
+	accounting_test01.t \
+	job_test02.t
 check_PROGRAMS = $(TESTS)
 
 TEST_EXTENSIONS = .t
@@ -103,6 +104,16 @@ accounting_test01_t_SOURCES = \
 	plugins/accounting.hpp
 accounting_test01_t_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir) $(JANSSON_CFLAGS)
 accounting_test01_t_LDADD = \
+	common/libtap/libtap.la \
+	$(JANSSON_LIBS)
+
+job_test02_t_SOURCES = \
+	plugins/test/job_test02.cpp \
+	plugins/job.cpp \
+	plugins/job.hpp \
+	plugins/jj.cpp
+job_test02_t_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir) $(JANSSON_CFLAGS)
+job_test02_t_LDADD = \
 	common/libtap/libtap.la \
 	$(JANSSON_LIBS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ noinst_HEADERS = \
 	fairness/writer/data_writer_db.hpp \
 	fairness/writer/data_writer_stdout.hpp \
 	plugins/accounting.hpp \
+	plugins/job.hpp \
 	plugins/jj.hpp
 
 fairness_libweighted_tree_la_SOURCES = \

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -8,6 +8,6 @@ jobtapdir = \
   $(fluxlibdir)/job-manager/plugins/
 
 jobtap_LTLIBRARIES = mf_priority.la
-mf_priority_la_SOURCES = mf_priority.cpp accounting.cpp jj.cpp
+mf_priority_la_SOURCES = mf_priority.cpp accounting.cpp jj.cpp job.cpp
 mf_priority_la_CPPFLAGS = -I$(top_srcdir)/src/plugins
 mf_priority_la_LDFLAGS = $(fluxplugin_ldflags) -module

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -29,6 +29,8 @@ extern "C" {
 #include <algorithm>
 #include <unordered_map>
 
+#include "job.hpp"
+
 // all attributes are per-user/bank
 class Association {
 public:

--- a/src/plugins/job.cpp
+++ b/src/plugins/job.cpp
@@ -1,0 +1,40 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include "job.hpp"
+
+int Job::count_resources (json_t *jobspec)
+{
+    struct jj_counts counts;
+    if (jj_get_counts_json (jobspec, &counts) < 0)
+        return -1;
+        
+    nnodes = counts.nnodes;
+    ncores = counts.nslots * counts.slot_size;
+    return 0;
+}
+
+
+void Job::add_dep (const std::string &dep)
+{
+    deps.push_back (dep);
+}
+
+
+bool Job::contains_dep (const std::string &dep) const
+{
+    return std::find (deps.begin (), deps.end (), dep) != deps.end ();
+}
+
+
+void Job::remove_dep (const std::string &dep)
+{
+    deps.erase (std::remove(deps.begin (), deps.end (), dep), deps.end ());
+}

--- a/src/plugins/job.hpp
+++ b/src/plugins/job.hpp
@@ -1,0 +1,60 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+// header file for the Job class
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/jobtap.h>
+#include <jansson.h>
+}
+
+#ifndef JOB_H
+#define JOB_H
+
+#include <vector>
+#include <string>
+#include <map>
+#include <iterator>
+#include <sstream>
+#include <algorithm>
+
+// custom job resource counting file
+#include "jj.hpp"
+
+class Job {
+public:
+    // attributes
+    flux_jobid_t id = 0;               // the ID of the job
+    std::vector<std::string> deps; // any dependencies on job
+    int nnodes = 0;                // the number of nodes requested
+    int ncores = 0;                // the number of cores requested
+    std::string queue;             // the queue the job was submitted under
+
+    // constructor
+    Job () = default;
+
+    // methods
+    // count the resources requested for a job
+    int count_resources (json_t *jobspec);
+
+    // add a dependency to the job's list of dependencies
+    void add_dep (const std::string &dep);
+
+    // determine if a job contains a certain dependency
+    bool contains_dep (const std::string &dep) const;
+
+    // remove a job dependency from a job's list of dependencies
+    void remove_dep (const std::string &dep);
+};
+
+#endif // JOB_H

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -34,6 +34,8 @@ extern "C" {
 #include "accounting.hpp"
 // custom job resource counting file
 #include "jj.hpp"
+// custom Job class file
+#include "job.hpp"
 
 // the plugin does not know about the association who submitted a job and will
 // assign default values to the association until it receives information from

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -30,7 +30,7 @@ extern "C" {
 #include <sstream>
 #include <cstdint>
 
-// custom bank_info class file
+// custom Association class file
 #include "accounting.hpp"
 // custom job resource counting file
 #include "jj.hpp"

--- a/src/plugins/test/job_test02.cpp
+++ b/src/plugins/test/job_test02.cpp
@@ -1,0 +1,126 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+    
+#include "src/plugins/job.hpp"
+#include "src/common/libtap/tap.h"
+
+
+// Ensure that the creation of a Job object will initialize its members to
+// default values.
+void test_job_default_initialization ()
+{
+    Job job;
+
+    ok (job.id == 0, "job ID is set to a default value of 0");
+    ok (job.nnodes == 0, "job nnodes count is set to a default value of 0");
+    ok (job.ncores == 0, "job ncores count is set to a default value of 0");
+    ok (job.deps.size () == 0, "job dependencies list is empty");
+}
+
+
+// Make sure that we can assign values to a Job object's members.
+void test_job_member_assignment ()
+{
+    Job job;
+    job.id = 1;
+    job.nnodes = 16;
+    job.ncores = 8;
+    job.add_dep ("dependency1");
+    job.add_dep ("dependency2");
+
+    ok (job.id == 1, "job ID can be set");
+    ok (job.nnodes == 16, "job nnodes can be defined");
+    ok (job.ncores == 8, "job ncores can be defined");
+    ok (job.deps.size () == 2, "job dependencies list has 2 dependencies");
+    ok (job.deps[0] == "dependency1", "first dependency is dependency1");
+    ok (job.deps[1] == "dependency2", "second dependency is dependency2");
+}
+
+
+// Make sure contains_dep () returns true when a Job contains a certain
+// dependency.
+void test_job_contains_dep_success ()
+{
+    Job job;
+    job.id = 2;
+    job.add_dep ("dependency1");
+    
+    ok (job.contains_dep ("dependency1") == true,
+        "contains_dep () returns true on success");
+}
+
+
+// Make sure contains_dep () returns false when a Job does not contain a
+// certain dependency.
+void test_job_contains_dep_failure ()
+{
+    Job job;
+    job.id = 3;
+    
+    ok (job.contains_dep ("foo") == false,
+        "contains_dep () returns false on failure");
+}
+
+
+// Make sure we can remove dependencies from a Job object using remove_dep ().
+void test_job_remove_dep_success ()
+{
+    Job job;
+    job.id = 4;
+    job.add_dep ("dependency1");
+    job.add_dep ("dependency2");
+    job.add_dep ("dependency3");
+    
+    ok (job.deps.size () == 3, "job dependencies list has 3 dependencies");
+    job.remove_dep ("dependency1");
+    ok (job.deps.size () == 2, "job dependencies get successfully removed");
+    ok (job.deps[0] == "dependency2", "dependency2 moves to first slot");
+    ok (job.deps[1] == "dependency3", "dependency3 moves to second slot");
+}
+
+
+// Make sure that a Job object's dependency list stays in tact even when
+// trying to remove a dependency that does not exist.
+void test_job_remove_dep_failure ()
+{
+    Job job;
+    job.id = 5;
+    job.add_dep ("dependency1");
+    
+    ok (job.deps.size () == 1, "job dependencies list has 1 dependency");
+    job.remove_dep ("foo");
+    ok (job.deps.size () == 1,
+        "job dependencies list in tact after trying to remove nonexistent dependency");
+}
+
+
+int main (int argc, char* argv[])
+{
+    test_job_default_initialization ();
+    test_job_member_assignment ();
+    test_job_contains_dep_success ();
+    test_job_contains_dep_failure ();
+    test_job_remove_dep_success ();
+    test_job_remove_dep_failure ();
+
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
#### Problem

As more and more flux-accounting dependencies are added to the priority plugin, it will be harder to keep track of certain attributes about jobs (and subsequently track them against an association's flux-accounting limits) without having to unpack those attributes in multiple callbacks. This gets cumbersome and makes tracking an association's jobs and limits very tedious.

---

This PR attempts to begin to alleviate this by adding a new `Job` class to be compiled with the rest of the plugin. A `Job` object stores things like the job's ID, counted resources, and any flux-accounting dependencies added to the job. Helper functions to check a job's resources and list of dependencies are also added to this class.

The goal with this class to eventually convert the `job.state.depend` and `job.state.inactive` callbacks to use this new class and its functions to clean up how dependencies and limits are checked, added, and removed from an association's set of running and active jobs (which I have a working implementation of, but will hold off for a subsequent PR barring this one's approval).

I've added basic unit tests for the `Job` class, its members, and checking and removing certain dependencies from a `Job` object.