### PR TITLE
plugin: improve `Queue` class

### DIFF
--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -28,8 +28,36 @@ extern "C" {
 #include <sstream>
 #include <algorithm>
 #include <unordered_map>
+#include <cmath>
 
 #include "job.hpp"
+
+// - UNKNOWN_QUEUE: a queue is specified for a submitted job that flux-accounting
+// does not know about
+// - NO_QUEUE_SPECIFIED: no queue was specified for this job
+// - INVALID_QUEUE: the association does not have permission to run jobs under
+// this queue
+#define UNKNOWN_QUEUE 0
+#define NO_QUEUE_SPECIFIED 0
+#define INVALID_QUEUE -6
+
+// - UNKNOWN_PROJECT: a project that flux-accounting doesn't know about
+// - INVALID_PROJECT: a project that the association doesn't have permission
+// to charge jobs under
+#define UNKNOWN_PROJECT -6
+#define INVALID_PROJECT -7
+
+// min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
+// currently used or enforced in this plugin, so their values have no
+// effect in queue limit enforcement.
+class Queue {
+public:
+    int min_nodes_per_job = 0;
+    int max_nodes_per_job = std::numeric_limits<int>::max ();
+    int max_time_per_job = std::numeric_limits<int>::max ();
+    int priority = 0;
+    int max_running_jobs = std::numeric_limits<int>::max ();
+};
 
 // all attributes are per-user/bank
 class Association {
@@ -59,33 +87,6 @@ public:
 
     // methods
     json_t* to_json () const;    // convert object to JSON string
-};
-
-// - UNKNOWN_QUEUE: a queue is specified for a submitted job that flux-accounting
-// does not know about
-// - NO_QUEUE_SPECIFIED: no queue was specified for this job
-// - INVALID_QUEUE: the association does not have permission to run jobs under
-// this queue
-#define UNKNOWN_QUEUE 0
-#define NO_QUEUE_SPECIFIED 0
-#define INVALID_QUEUE -6
-
-// - UNKNOWN_PROJECT: a project that flux-accounting doesn't know about
-// - INVALID_PROJECT: a project that the association doesn't have permission
-// to charge jobs under
-#define UNKNOWN_PROJECT -6
-#define INVALID_PROJECT -7
-
-// min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
-// currently used or enforced in this plugin, so their values have no
-// effect in queue limit enforcement.
-class Queue {
-public:
-    int min_nodes_per_job;
-    int max_nodes_per_job;
-    int max_time_per_job;
-    int priority;
-    int max_running_jobs;
 };
 
 // get an Association object that points to user/bank in the users map;

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -52,6 +52,7 @@ extern "C" {
 // effect in queue limit enforcement.
 class Queue {
 public:
+    std::string name = "";
     int min_nodes_per_job = 0;
     int max_nodes_per_job = std::numeric_limits<int>::max ();
     int max_time_per_job = std::numeric_limits<int>::max ();

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -432,6 +432,7 @@ static void rec_q_cb (flux_t *h,
         Queue *q;
         q = &queues[queue];
 
+        q->name = queue;
         q->min_nodes_per_job = min_nodes_per_job;
         q->max_nodes_per_job = max_nodes_per_job;
         q->max_time_per_job = max_time_per_job;

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -90,9 +90,9 @@ void initialize_map (
  * helper function to add test queues to the queues map
  */
 void initialize_queues () {
-    queues["bronze"] = {0, 5, 60, 100, 100};
-    queues["silver"] = {0, 5, 60, 200, 100};
-    queues["gold"] = {0, 5, 60, 300, 100};
+    queues["bronze"] = {"bronze", 0, 5, 60, 100, 100};
+    queues["silver"] = {"silver", 0, 5, 60, 200, 100};
+    queues["gold"] = {"gold", 0, 5, 60, 300, 100};
 }
 
 

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -291,9 +291,6 @@ static void test_check_map_dne_true ()
 
 int main (int argc, char* argv[])
 {
-    // declare the number of tests that we plan to run
-    plan (15);
-
     // add users to the test map
     initialize_map (users);
     // add queues to the test queues map

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -262,6 +262,29 @@ static void test_get_project_info_invalid_project ()
 }
 
 
+// make sure we can determine if an Association is under the max running jobs
+// limit for a queue
+static void test_under_queue_max_running_jobs_true ()
+{
+    Association a = users[1001]["bank_A"];
+    Queue bronze = queues["bronze"];
+    ok ((a.queue_usage["bronze"] < bronze.max_running_jobs) == true,
+        "association is under the max running jobs limit for the queue");
+}
+
+
+static void test_under_queue_max_running_jobs_false ()
+{
+    Association a = users[1001]["bank_A"];
+    Queue bronze = queues["bronze"];
+    // simulate the Association being at their queue max running jobs limit
+    bronze.max_running_jobs = 5;
+    a.queue_usage["bronze"] = 5;
+    ok ((a.queue_usage["bronze"] < bronze.max_running_jobs) == false,
+        "association is at their max running jobs limit for the queue");
+}
+
+
 // ensure false is returned because we have valid flux-accounting data in map
 static void test_check_map_dne_false ()
 {
@@ -313,6 +336,8 @@ int main (int argc, char* argv[])
     test_get_project_info_invalid_project ();
     test_check_map_dne_false ();
     test_check_map_dne_true ();
+    test_under_queue_max_running_jobs_true ();
+    test_under_queue_max_running_jobs_false ();
 
     // indicate we are done testing
     done_testing ();


### PR DESCRIPTION
#### Problem

The `Queue` class definition is below the `Association` class definition, but there will eventually be a need to pass a `Queue` object to method(s) in the `Association` class. There is also no default initialization for the attributes of a `Queue` object. Additionally, the `Queue` class has no attribute for the name of the queue, which would be nice to have.

---

This PR moves some macro definitions as well as the `Queue` class definition to the top of the `accounting.hpp` file. It also adds a `name` attribute to the `Queue` class as well as add some default values to the existing attributes. As a result, I've adjusted the callback in the plugin that unpacks queue information from the flux-accounting DB as well as some unit tests to also include the name of the queue.

I've also added a couple of unit tests to `accounting_test01` to simulate comparing an Association's current running jobs count in a queue to a queue's max running jobs limit.

Like #608, this is laying the groundwork for improving the way flux-accounting dependencies are checked and handled in the priority plugin.