### PR TITLE
plugin: improve how dependency logic works with new `Job` class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,7 +51,8 @@ TESTS = \
 	data_reader_db_test01.t \
 	data_writer_db_test01.t \
 	accounting_test01.t \
-	job_test02.t
+	job_test02.t \
+	dependencies_test03.t
 check_PROGRAMS = $(TESTS)
 
 TEST_EXTENSIONS = .t
@@ -114,6 +115,18 @@ job_test02_t_SOURCES = \
 	plugins/jj.cpp
 job_test02_t_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir) $(JANSSON_CFLAGS)
 job_test02_t_LDADD = \
+	common/libtap/libtap.la \
+	$(JANSSON_LIBS)
+
+dependencies_test03_t_SOURCES = \
+	plugins/test/dependencies_test03.cpp \
+	plugins/job.cpp \
+	plugins/job.hpp \
+	plugins/jj.cpp \
+	plugins/accounting.cpp \
+	plugins/accounting.hpp
+dependencies_test03_t_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir) $(JANSSON_CFLAGS)
+dependencies_test03_t_LDADD = \
 	common/libtap/libtap.la \
 	$(JANSSON_LIBS)
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -252,14 +252,3 @@ int get_project_info (const char *project,
 
     return 0;
 }
-
-
-int max_run_jobs_per_queue (const std::map<std::string, Queue> &queues,
-                            const std::string &queue)
-{
-    auto it = queues.find (queue);
-    if (it == queues.end ())
-        return -1;
-
-    return it->second.max_running_jobs;
-}

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -39,146 +39,119 @@ Association* get_association (int userid,
 
 json_t* Association::to_json () const
 {
-    json_t *user_queues = json_array ();
-    if (!user_queues) {
-        return nullptr;
-    }
+    json_t *user_queues = nullptr;
+    json_t *user_projects = nullptr;
+    json_t *temp = nullptr;
+    json_t *queue_usage_json = nullptr;
+    json_t *hj_json = nullptr;
+    json_t *job_json = nullptr;
+    json_t *deps_array = nullptr;
+    json_t *dep_str = nullptr;
+    json_t *u = nullptr;
+
+    user_queues = json_array ();
+    if (!user_queues)
+        goto error;
     for (const auto &queue : queues) {
-        json_t *temp;
         if (!(temp = json_string (queue.c_str ()))
-            || json_array_append_new (user_queues, temp) < 0) {
-            json_decref (user_queues);
-            return nullptr;
-        }
+            || json_array_append_new (user_queues, temp) < 0)
+            goto error;
     }
+    // set temp to nullptr here to avoid a double free in case of an error
+    temp = nullptr;
 
-    json_t *user_projects = json_array ();
-    if (!user_projects) {
-        json_decref (user_queues);
-        return nullptr;
-    }
+    user_projects = json_array ();
+    if (!user_projects)
+        goto error;
     for (const auto &project : projects) {
-        json_t *temp;
         if (!(temp = json_string (project.c_str ()))
-            || json_array_append_new (user_projects, temp) < 0) {
-            json_decref (user_queues);
-            json_decref (user_projects);
-            return nullptr;
-        }
+            || json_array_append_new (user_projects, temp) < 0)
+            goto error;
     }
+    temp = nullptr;
 
-    json_t *queue_usage_json = json_object ();
-    if (!queue_usage_json) {
-        json_decref (user_queues);
-        json_decref (user_projects);
-        return nullptr;
-    }
+    queue_usage_json = json_object ();
+    if (!queue_usage_json)
+        goto error;
     for (const auto &entry : queue_usage) {
         if (json_object_set_new (queue_usage_json,
                                  entry.first.c_str (),
-                                 json_integer (entry.second)) < 0) {
-            json_decref (user_queues);
-            json_decref (user_projects);
-            json_decref (queue_usage_json);
-            return nullptr;
-        }
+                                 json_integer (entry.second)) < 0)
+            goto error;
     }
 
-    json_t *hj_json = json_object ();
-    if (!hj_json) {
-        json_decref (user_queues);
-        json_decref (user_projects);
-        json_decref (queue_usage_json);
-        return nullptr;
-    }
+    hj_json = json_object ();
+    if (!hj_json)
+        goto error;
 
     for (const auto &entry : held_jobs) {
         const Job &job = entry;
-        json_t *job_json = json_pack ("{s:i, s:i, s:s, s:o}",
-                                      "nnodes", job.nnodes,
-                                      "ncores", job.ncores,
-                                      "queue", job.queue.c_str (),
-                                      "deps", json_array ());
+        job_json = json_pack ("{s:i, s:i, s:s, s:o}",
+                              "nnodes", job.nnodes,
+                              "ncores", job.ncores,
+                              "queue", job.queue.c_str (),
+                              "deps", json_array ());
 
-        if (!job_json) {
-            json_decref (user_queues);
-            json_decref (user_projects);
-            json_decref (queue_usage_json);
-            json_decref (hj_json);
-            return nullptr;
-        }
+        if (!job_json)
+            goto error;
 
-        json_t *deps_array = json_array ();
-        if (!deps_array) {
-            json_decref (user_queues);
-            json_decref (user_projects);
-            json_decref (queue_usage_json);
-            json_decref (hj_json);
-            json_decref (job_json);
-            return nullptr;
-        }
+        deps_array = json_array ();
+        if (!deps_array)
+            goto error;
 
         for (const auto &dep : job.deps) {
-            json_t *dep_str = json_string (dep.c_str ());
-            if (!dep_str || json_array_append_new (deps_array, dep_str) < 0) {
-                json_decref (user_queues);
-                json_decref (user_projects);
-                json_decref (queue_usage_json);
-                json_decref (hj_json);
-                json_decref (deps_array);
-                json_decref (job_json);
-                return nullptr;
-            }
+            dep_str = json_string (dep.c_str ());
+            if (!dep_str || json_array_append_new (deps_array, dep_str) < 0)
+                goto error;
         }
 
-        if (json_object_set_new (job_json, "deps", deps_array) < 0) {
-            json_decref (user_queues);
-            json_decref (user_projects);
-            json_decref (queue_usage_json);
-            json_decref (hj_json);
-            json_decref (deps_array);
-            json_decref (job_json);
-            return nullptr;
-        }
+        if (json_object_set_new (job_json, "deps", deps_array) < 0)
+            goto error;
 
         // use job id (flux_jobid_t) as string key
         char keybuf[32];
         snprintf (keybuf, sizeof(keybuf), "%ld", entry.id);
-        if (json_object_set_new (hj_json, keybuf, job_json) < 0) {
-            json_decref (user_queues);
-            json_decref (user_projects);
-            json_decref (queue_usage_json);
-            json_decref (hj_json);
-            return nullptr;
-        }
+        if (json_object_set_new (hj_json, keybuf, job_json) < 0)
+            goto error;
     }
 
     // 'o' steals the reference for both held_job_ids and user_queues
-    json_t *u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i"
-                           " s:o, s:i, s:o, s:s, s:i, s:i, s:i,"
-                           " s:i, s:i, s:o, s:o}",
-                           "bank_name", bank_name.c_str (),
-                           "fairshare", fairshare,
-                           "max_run_jobs", max_run_jobs,
-                           "cur_run_jobs", cur_run_jobs,
-                           "max_active_jobs", max_active_jobs,
-                           "cur_active_jobs", cur_active_jobs,
-                           "queues", user_queues,
-                           "queue_factor", queue_factor,
-                           "projects", user_projects,
-                           "def_project", def_project.c_str (),
-                           "max_nodes", max_nodes,
-                           "max_cores", max_cores,
-                           "cur_nodes", cur_nodes,
-                           "cur_cores", cur_cores,
-                           "active", active,
-                           "queue_usage", queue_usage_json,
-                           "held_jobs", hj_json);
+    u = json_pack ("{s:s, s:f, s:i, s:i, s:i, s:i"
+                   " s:o, s:i, s:o, s:s, s:i, s:i, s:i,"
+                   " s:i, s:i, s:o, s:o}",
+                   "bank_name", bank_name.c_str (),
+                   "fairshare", fairshare,
+                   "max_run_jobs", max_run_jobs,
+                   "cur_run_jobs", cur_run_jobs,
+                   "max_active_jobs", max_active_jobs,
+                   "cur_active_jobs", cur_active_jobs,
+                   "queues", user_queues,
+                   "queue_factor", queue_factor,
+                   "projects", user_projects,
+                   "def_project", def_project.c_str (),
+                   "max_nodes", max_nodes,
+                   "max_cores", max_cores,
+                   "cur_nodes", cur_nodes,
+                   "cur_cores", cur_cores,
+                   "active", active,
+                   "queue_usage", queue_usage_json,
+                   "held_jobs", hj_json);
 
     if (!u)
-        return nullptr;
+        goto error;
 
     return u;
+
+error:
+    json_decref (user_queues);
+    json_decref (user_projects);
+    json_decref (temp);
+    json_decref (queue_usage_json);
+    json_decref (hj_json);
+    json_decref (deps_array);
+    json_decref (job_json);
+    json_decref (u);
+    return nullptr;
 }
 
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -252,3 +252,21 @@ int get_project_info (const char *project,
 
     return 0;
 }
+
+
+bool Association::under_max_run_jobs ()
+{
+    bool under_assoc_max_run_jobs = cur_run_jobs < max_run_jobs;
+
+    return under_assoc_max_run_jobs;
+}
+
+
+bool Association::under_queue_max_run_jobs (
+                                const std::string &queue,
+                                std::map<std::string, Queue> queues) {
+    bool under_queue_max_run_jobs = queue_usage[queue] <
+                                    queues[queue].max_running_jobs;
+
+    return under_queue_max_run_jobs;
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -124,8 +124,4 @@ int get_project_info (const char *project,
                       std::vector<std::string> &permissible_projects,
                       std::vector<std::string> projects);
 
-// fetch the max number of running jobs a queue can have per-association
-int max_run_jobs_per_queue (const std::map<std::string, Queue> &queues,
-                            const std::string &queue);
-
 #endif // ACCOUNTING_H

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -47,6 +47,10 @@ extern "C" {
 #define UNKNOWN_PROJECT -6
 #define INVALID_PROJECT -7
 
+// dependency names for flux-accounting dependencies
+#define D_QUEUE_MRJ "max-run-jobs-queue"
+#define D_ASSOC_MRJ "max-running-jobs-user-limit"
+
 // min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
 // currently used or enforced in this plugin, so their values have no
 // effect in queue limit enforcement.
@@ -88,6 +92,11 @@ public:
 
     // methods
     json_t* to_json () const;    // convert object to JSON string
+    // check to see if a job can be released from all flux-accounting
+    // dependencies
+    bool under_max_run_jobs ();
+    bool under_queue_max_run_jobs (const std::string &queue,
+                                   std::map<std::string, Queue> queues);
 };
 
 // get an Association object that points to user/bank in the users map;

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -74,7 +74,7 @@ public:
     int cur_run_jobs;                  // current number of running jobs
     int max_active_jobs;               // max number of active jobs
     int cur_active_jobs;               // current number of active jobs
-    std::vector<long int> held_jobs;   // list of currently held job ID's
+    std::vector<Job> held_jobs;        // vector to keep track of held Jobs
     std::vector<std::string> queues;   // list of accessible queues
     int queue_factor;                  // priority factor associated with queue
     int active;                        // active status
@@ -86,9 +86,6 @@ public:
     int cur_cores;                     // current number of used cores
     std::unordered_map<std::string, int>
       queue_usage;                     // track num of running jobs per queue
-    std::unordered_map<std::string,
-                       std::vector<long int>>
-      queue_held_jobs;                // keep track of held job ID's per queue
 
     // methods
     json_t* to_json () const;    // convert object to JSON string

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -906,13 +906,7 @@ static int depend_cb (flux_plugin_t *p,
         // safely assign "queue" to an std::string
         std::string value (queue);
         // fetch max number of running jobs in this queue
-        int queue_max_run_jobs = max_run_jobs_per_queue (queues, queue);
-        if (queue_max_run_jobs < 0) {
-            // can't find a max_run_jobs limit for this queue because it
-            // might not be defined in the flux-accounting DB, so just set
-            // it to a large number
-            queue_max_run_jobs = std::numeric_limits<int>::max ();
-        }
+        int queue_max_run_jobs = queues[queue].max_running_jobs;
 
         // look up the association's current number of running jobs;
         // if queue cannot be found, an entry in the Association object will be
@@ -1295,13 +1289,7 @@ static int inactive_cb (flux_plugin_t *p,
             b->queue_usage[queue]--;
 
             // fetch max number of running jobs in queue
-            int queue_max_run_jobs = max_run_jobs_per_queue (queues, queue);
-            if (queue_max_run_jobs < 0) {
-                // can't find a max_run_jobs limit for this queue because it
-                // might not be defined in the flux-accounting DB, so just set
-                // it to a large number
-                queue_max_run_jobs = std::numeric_limits<int>::max ();
-            }
+            int queue_max_run_jobs = queues[queue].max_running_jobs;
 
             if ((b->queue_held_jobs[queue].size () > 0) &&
                 (b->queue_usage[queue] < queue_max_run_jobs)) {

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -189,7 +189,7 @@ static void add_special_association (flux_plugin_t *p, flux_t *h, int userid)
     a->max_active_jobs = 1000;
     a->cur_active_jobs = 0;
     a->active = 1;
-    a->held_jobs = std::vector<long int>();
+    a->held_jobs = std::vector<Job>();
     a->max_nodes = INT16_MAX;
     a->max_cores = INT16_MAX;
 
@@ -874,12 +874,16 @@ static int depend_cb (flux_plugin_t *p,
     Association *b;
     char *queue = NULL;
     std::string dependency;
+    json_t *jobspec = NULL;
+    Job job;
+    std::string queue_str;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s:i, s:I, s{s{s{s?s}}}}",
+                                "{s:i, s:I, s:o, s{s{s{s?s}}}}",
                                 "userid", &userid, "id", &id,
+                                "jobspec", &jobspec,
                                 "jobspec", "attributes", "system",
                                 "queue", &queue) < 0) {
         flux_log (h,
@@ -902,33 +906,37 @@ static int depend_cb (flux_plugin_t *p,
         return -1;
     }
 
-    if (queue != NULL) {
-        // safely assign "queue" to an std::string
-        std::string value (queue);
-        // fetch max number of running jobs in this queue
-        int queue_max_run_jobs = queues[queue].max_running_jobs;
-
-        // look up the association's current number of running jobs;
-        // if queue cannot be found, an entry in the Association object will be
-        // initialized with a current running jobs count of 0
-        int assoc_cur_run_jobs = b->queue_usage[queue];
-        if (assoc_cur_run_jobs >= queue_max_run_jobs) {
+    if (jobspec == NULL) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB, "mf_priority",
+                                     0, "job.state.depend: failed to unpack " \
+                                     "jobspec");
+        return -1;
+    } else {
+        // if a queue cannot be found, just set it to ""
+        queue_str = queue ? queue : "";
+        // look up the association's current number of running jobs in this
+        // queue; if it cannot be found in the map, an entry in the Association
+        // object will be initialized with a current running jobs count of 0
+        if (!b->under_queue_max_run_jobs (queue_str, queues)) {
             // association is already at their max number of running jobs
             // in this queue; add a dependency
-            dependency = "max-run-jobs-queue";
-            if (flux_jobtap_dependency_add (p, id, dependency.c_str ()) < 0)
+            if (flux_jobtap_dependency_add (p, id, D_QUEUE_MRJ) < 0)
                 goto error;
-            b->queue_held_jobs[queue].push_back (id);
+            job.add_dep (D_QUEUE_MRJ);
         }
-    }
-
-    if ((b->max_run_jobs > 0) && (b->cur_run_jobs == b->max_run_jobs)) {
-        // association is already at their max running jobs count; add a
-        // dependency to hold the job until an already running one finishes
-        dependency = "max-running-jobs-user-limit";
-        if (flux_jobtap_dependency_add (p, id, dependency.c_str ()) < 0)
-            goto error;
-        b->held_jobs.push_back (id);
+        if (!b->under_max_run_jobs ()) {
+            // association is already at their max running jobs count; add a
+            // dependency to hold the job until an already running one finishes
+            if (flux_jobtap_dependency_add (p, id, D_ASSOC_MRJ) < 0)
+                goto error;
+            job.add_dep (D_ASSOC_MRJ);
+        }
+        if (job.deps.size () > 0) {
+            // Job has at least one dependency; store it in Association object
+            job.id = id;
+            job.queue = queue_str;
+            b->held_jobs.emplace_back (job);
+        }
     }
 
     return 0;
@@ -1224,6 +1232,7 @@ static int inactive_cb (flux_plugin_t *p,
     json_t *jobspec = NULL;
     char *queue = NULL;
     std::string dependency;
+    std::string queue_str;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1281,41 +1290,50 @@ static int inactive_cb (flux_plugin_t *p,
         }
     }
 
-    if (queue != NULL) {
-        // safely assign "queue" to an std::string
-        std::string value (queue);
-        if (b->queue_usage[queue] > 0) {
-            // decrement the counter of running jobs the association in queue
-            b->queue_usage[queue]--;
+    // if a queue cannot be found, just set it to ""
+    queue_str = queue ? queue : "";
+    if (b->queue_usage[queue_str] > 0)
+        // decrement num of running jobs the association has in queue
+        b->queue_usage[queue_str]--;
 
-            // fetch max number of running jobs in queue
-            int queue_max_run_jobs = queues[queue].max_running_jobs;
+    if (!b->held_jobs.empty ()) {
+        // the Association has at least one held Job; begin looping through
+        // held Jobs and see if they satisfy the requirements to be released
+        auto it = b->held_jobs.begin ();
+        while (it != b->held_jobs.end ()) {
+            // grab held Job object
+            Job &held_job = *it;
 
-            if ((b->queue_held_jobs[queue].size () > 0) &&
-                (b->queue_usage[queue] < queue_max_run_jobs)) {
-                // association has at least one held job in queue;
-                // remove the dependency from the first held job
-                dependency = "max-run-jobs-queue";
-                long int id = b->queue_held_jobs[queue].front ();
+            // is the association under the max running jobs limit for the
+            // queue the held job is submitted under?
+            if (b->under_queue_max_run_jobs (held_job.queue, queues) &&
+                held_job.contains_dep (D_QUEUE_MRJ)) {
                 if (flux_jobtap_dependency_remove (p,
-                                                   id,
-                                                   dependency.c_str ()) < 0)
+                                                   held_job.id,
+                                                   D_QUEUE_MRJ) < 0)
                     goto error;
-                b->queue_held_jobs[queue].erase (
-                    b->queue_held_jobs[queue].begin ()
-                );
+                held_job.remove_dep (D_QUEUE_MRJ);
             }
-        }
-    }
+            // is association under their overall max running jobs limit?
+            if (b->under_max_run_jobs () &&
+                held_job.contains_dep (D_ASSOC_MRJ)) {
+                if (flux_jobtap_dependency_remove (p,
+                                                   held_job.id,
+                                                   D_ASSOC_MRJ) < 0)
+                    goto error;
+                held_job.remove_dep (D_ASSOC_MRJ);
+            }
 
-    // if the user/bank combo has any currently held jobs and the user is now
-    // under their max jobs limit, remove the dependency from first held job
-    if ((b->held_jobs.size () > 0) && (b->cur_run_jobs < b->max_run_jobs)) {
-        long int jobid = b->held_jobs.front ();
-        dependency = "max-running-jobs-user-limit";
-        if (flux_jobtap_dependency_remove (p, jobid, dependency.c_str ()) < 0)
-            goto error;
-        b->held_jobs.erase (b->held_jobs.begin ());
+            if (held_job.deps.empty ())
+                // the Job no longer has any flux-accounting dependencies on
+                // it; remove it from the Association's vector of held jobs
+                // (erase () will return the next valid iterator)
+                it = b->held_jobs.erase (it);
+            else
+                // the job did not meet all requirements to be released;
+                // move onto the next Job
+                ++it;
+        }
     }
 
     return 0;

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -59,8 +59,7 @@ void add_user_to_map (
         a.max_cores,
         a.cur_nodes,
         a.cur_cores,
-        a.queue_usage,
-        a.queue_held_jobs
+        a.queue_usage
     };
 }
 
@@ -73,10 +72,10 @@ void initialize_map (
 {
     Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {},
                          {}, 0, 1, {"*"}, "*", 2147483647, 2147483647, 0, 0,
-                         {}, {}};
+                         {}};
     Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {},
                          {}, 0, 1, {"*"}, "*", 2147483647, 2147483647, 0, 0,
-                         {}, {}};
+                         {}};
 
     add_user_to_map (users, 1001, "bank_A", user1);
     users_def_bank[1001] = "bank_A";
@@ -302,7 +301,7 @@ static void test_check_map_dne_true ()
 
     Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {},
                             {}, 0, 1, {"*"}, "*", 2147483647, 2147483647,
-                            0, 0, {}, {}};
+                            0, 0, {}};
     add_user_to_map (users, 9999, "DNE", tmp_user);
     users_def_bank[9999] = "DNE";
 

--- a/src/plugins/test/dependencies_test03.cpp
+++ b/src/plugins/test/dependencies_test03.cpp
@@ -1,0 +1,334 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <map>
+#include <string>
+
+#include "src/plugins/accounting.hpp"
+#include "src/plugins/job.hpp"
+#include "src/common/libtap/tap.h"
+
+// define a test users map to run tests on
+std::map<int, std::map<std::string, Association>> users;
+// define a test queues map
+std::map<std::string, Queue> queues;
+
+
+/*
+ * add an association
+ */
+void initialize_map (
+    std::map<int, std::map<std::string, Association>> &users)
+{
+    Association user1 {};
+    user1.bank_name = "bank_A";
+    user1.max_run_jobs = 1;
+    user1.max_active_jobs = 2;
+    user1.queues = {"bronze", "silver", "gold"};
+
+    users[50001]["bank_A"] = user1;
+}
+
+
+/*
+ * helper function to add test queues to the queues map
+ */
+void initialize_queues () {
+    queues["bronze"] = {};
+    queues["bronze"].max_running_jobs = 3;
+    queues["silver"] = {};
+    queues["silver"].max_running_jobs = 2;
+    queues["gold"] = {};
+    queues["gold"].max_running_jobs = 1;
+}
+
+
+/*
+ * Scenario 1: The association has the following limit configuration:
+ *
+ * max_run_jobs: 1
+ * max_active_jobs: 2
+ *
+ * So, a second submitted job cannot run until the currently running one
+ * completes. The second submitted job will have the per-association max
+ * running jobs limit added to it.
+ */
+void max_run_jobs_per_association ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_run_jobs = 1;
+    a->cur_active_jobs = 2;
+
+    // add held Job to Association object
+    Job job;
+    job.id = 1;
+    job.add_dep (D_ASSOC_MRJ);
+    a->held_jobs.emplace_back (job);
+
+    ok (a->held_jobs.size () == 1,
+        "association has one held job due to per-association "
+        "max_run_jobs limit");
+    ok (job.deps.size () == 1,
+        "held job has one dependency added to it");
+}
+
+
+// The check to see if the association is under their per-association max
+// running jobs limit will return false since cur_run_jobs == 1.
+void under_max_run_jobs_per_association_false ()
+{
+    Association *a = &users[50001]["bank_A"];
+
+    ok (a->under_max_run_jobs () == false,
+        "association still has a running job");
+}
+
+
+// When the currently running job completes and the cur_run_jobs counter is
+// decremented, the check to see if they are under their max_run_jobs limit
+// will return true since now cur_run_jobs == 0. So, the held job can have
+// its dependency removed.
+void under_max_run_jobs_per_association_true ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_run_jobs = 0;
+    a->cur_active_jobs = 1;
+    Job held_job = a->held_jobs.front ();
+
+    ok (a->under_max_run_jobs () == true,
+        "association is now under max_run_jobs limit");
+
+    // check that held job contains the max-run-jobs per-association limit
+    ok (held_job.contains_dep (D_ASSOC_MRJ) == true,
+        "held job contains a max running jobs per-association limit");
+    ok (held_job.contains_dep (D_QUEUE_MRJ) == false,
+        "held job does not contain a max running jobs per-queue limit");
+
+    held_job.remove_dep (D_ASSOC_MRJ);
+    // check that held job no longer contains any dependencies
+    ok (held_job.deps.size () == 0,
+        "held job has no dependencies associated with it");
+
+    // erase held job from association's held_jobs vector
+    a->held_jobs.clear ();
+    ok (a->held_jobs.size () == 0,
+        "association has no more held jobs");
+}
+
+
+/*
+ * Scenario 2: The association has the following limit configuration:
+ *
+ * max_run_jobs: 1
+ * max_active_jobs: 2
+ *
+ * The queue that they are submitting jobs to has the following limit:
+ *
+ * max_running_jobs: 1
+ *
+ * A second submitted job to the queue will have *both* the per-association
+ * max-run-jobs and the per-queue max-run-jobs limits added to it.
+ */
+void max_run_jobs_per_queue_and_per_association ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_run_jobs = 1;
+    a->cur_active_jobs = 2;
+    a->queue_usage["gold"] = 1; // one running job in gold queue
+
+    // add held Job to Association object
+    Job job;
+    job.id = 2;
+    job.queue = "gold";
+    job.add_dep (D_ASSOC_MRJ);
+    job.add_dep (D_QUEUE_MRJ);
+    a->held_jobs.emplace_back (job);
+
+    ok (a->held_jobs.size () == 1,
+        "asociation has one held job due to max-run-jobs per-association and "
+        "per-queue limits");
+    ok (job.deps.size () == 2,
+        "held job has max-run-jobs per-association and per-queue dependencies "
+        "added to it");
+}
+
+
+// Since the association has a limit of just 1 max running job *and* the gold
+// queue has a limit of just 1 max running job, the checks to see if the
+// association is under *either* their per-association or per-queue
+// max-run-jobs limits are false.
+void under_max_run_jobs_per_association_and_per_queue_false ()
+{
+    Association *a = &users[50001]["bank_A"];
+    Job held_job = a->held_jobs.front ();
+    ok (a->under_max_run_jobs () == false,
+        "association still has a running job");
+    ok (a->under_queue_max_run_jobs (held_job.queue, queues) == false,
+        "association still has a running job in gold queue");
+}
+
+
+// Once a currently running job completes and cur_run_jobs counters for both
+// the association's overall cur_run_jobs count and its cur_run_jobs count for
+// the queue are decremented, the checks to see if the association is under
+// their limits are now true.
+void under_max_run_jobs_per_association_and_per_queue_true ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_run_jobs = 0;
+    a->cur_active_jobs = 1;
+    a->queue_usage["gold"] = 0;
+    Job held_job = a->held_jobs.front ();
+
+    ok (a->under_max_run_jobs () == true,
+        "association is now under max-run-jobs per-association limit");
+    ok (a->under_queue_max_run_jobs (held_job.queue, queues) == true,
+        "association is now under max-run-jobs per-queue limit");
+
+    // check that held job contains both limits
+    ok (held_job.contains_dep (D_ASSOC_MRJ) == true,
+        "held job contains a max running jobs per-association limit");
+    ok (held_job.contains_dep (D_QUEUE_MRJ) == true,
+        "held job contains a max running jobs per-queue limit");
+
+    held_job.remove_dep (D_ASSOC_MRJ);
+    held_job.remove_dep (D_QUEUE_MRJ);
+
+    // check that held job no longer contains any dependencies
+    ok (held_job.deps.size () == 0,
+        "held job has no dependencies associated with it");
+
+    // erase held job from association's held_jobs vector
+    a->held_jobs.clear ();
+    ok (a->held_jobs.size () == 0,
+        "association has no more held jobs");
+}
+
+
+/*
+ * Scenario 3: The association has the following limit configuration:
+ *
+ * max_run_jobs: 10
+ * max_active_jobs: 1000
+ *
+ * The queue that they are submitting jobs to has the following limit:
+ *
+ * max_running_jobs: 1
+ *
+ * A second submitted job to the queue will have *just* the per-queue
+ * max-run-jobs limit added to it.
+ */
+void max_run_jobs_per_queue ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->max_active_jobs = 1000;
+    a->max_run_jobs = 10;
+    a->cur_run_jobs = 1;
+    a->cur_active_jobs = 2;
+    a->queue_usage["gold"] = 1;
+
+    // add held Job to Association object
+    Job job;
+    job.id = 3;
+    job.queue = "gold";
+    job.add_dep (D_QUEUE_MRJ);
+    a->held_jobs.emplace_back (job);
+
+    ok (a->held_jobs.size () == 1,
+        "second job gets held due to max-run-jobs per-queue limit");
+    ok (job.deps.size () == 1,
+        "held job has max-run-jobs per-queue dependency added to it");
+}
+
+
+// The check to see if the association is under their per-queue max running
+// jobs limit will return false since cur_run_jobs for this queue == 1.
+void under_max_run_jobs_per_queue_false ()
+{
+    Association *a = &users[50001]["bank_A"];
+    Job held_job = a->held_jobs.front ();
+
+    ok (a->under_queue_max_run_jobs (held_job.queue, queues) == false,
+        "association still has a running job in gold queue");
+}
+
+
+// Once a currently running job completes and cur_run_jobs counters are
+// decremented, the checks to see if the association is under their max running
+// jobs limit for the queue is now true.
+void under_max_run_jobs_per_queue_true ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_run_jobs = 0;
+    a->cur_active_jobs = 1;
+    a->queue_usage["gold"] = 0;
+    Job held_job = a->held_jobs.front ();
+
+    ok (a->under_max_run_jobs () == true,
+        "association now under max-run-jobs per-association limit");
+    ok (a->under_queue_max_run_jobs (held_job.queue, queues) == true,
+        "association now under max-run-jobs per-queue limit");
+
+    // check that held job contains both limits
+    ok (held_job.contains_dep (D_ASSOC_MRJ) == false,
+        "held job does not contain a max running jobs per-association limit");
+    ok (held_job.contains_dep (D_QUEUE_MRJ) == true,
+        "held job contains a max running jobs per-queue limit");
+
+    held_job.remove_dep (D_QUEUE_MRJ);
+
+    // check that held job no longer contains any dependencies
+    ok (held_job.deps.size () == 0,
+        "held job has no dependencies associated with it");
+
+    // erase held job from association's held_jobs vector
+    a->held_jobs.clear ();
+    ok (a->held_jobs.size () == 0,
+        "association has no more held jobs");
+}
+
+
+int main (int argc, char* argv[])
+{
+    // add an association
+    initialize_map (users);
+    // add queues to the test queues map
+    initialize_queues ();
+
+    max_run_jobs_per_association ();
+    under_max_run_jobs_per_association_false ();
+    under_max_run_jobs_per_association_true ();
+
+    max_run_jobs_per_queue_and_per_association ();
+    under_max_run_jobs_per_association_and_per_queue_false ();
+    under_max_run_jobs_per_association_and_per_queue_true ();
+
+    max_run_jobs_per_queue ();
+    under_max_run_jobs_per_queue_false ();
+    under_max_run_jobs_per_queue_true ();
+
+    // indicate we are done testing
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
#### Problem

The priority plugin has to manually extract and check info about both the job and the association that is submitting the job for
any potential flux-accounting limits in both `job.state.depend` and `job.state.inactive`. As more and more dependencies are added to keep track of in flux-accounting, it will get more cumbersome to have to do these checks in the callbacks without the use of a `Job` object that can store this information across multiple callbacks.

---

This PR changes the how `job.state.depend` and `job.state.inactive` callbacks handle adding & removing dependencies from jobs as they encounter various (and future) flux-accounting limits. It condenses the need to store held jobs _both_ in a vector of just job IDs and a map that stores which job IDs are stored with which queue into the `held_jobs` vector, which instead of being a vector of just job IDs, is now a vector of class `Job`, which contains attributes such as its job IDs, the queue it was submitted in, counted resources, and any flux-accounting dependencies associated with the job.

The `job.state.depend` callback now pushes back any and all dependencies potentially added to a Job's `deps` vector. In `job.state.inactive` all held jobs for an association are iterated through to see if they satisfy any and all requirements to have their dependencies removed - for now, there are just two: the per-queue max-running-jobs limit and the per-association max-running-jobs limit. But, as more flux-accounting-specific dependencies are removed, these can be added to the callback (or potentially abstracted into one or more helper functions).

I've also restructured the `held_jobs` member of each association's set of information returned with `flux jobtap query` to include the entire `Job` object instead of just the job ID. 