### PR TITLE
view-* man pages: add -o/--format optional arg

### DIFF
--- a/doc/man1/flux-account-view-bank.rst
+++ b/doc/man1/flux-account-view-bank.rst
@@ -39,3 +39,7 @@ database hierarchy.
 .. option:: --fields
 
     Customize which fields are returned in the output of ``view-bank``.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.

--- a/doc/man1/flux-account-view-user.rst
+++ b/doc/man1/flux-account-view-user.rst
@@ -31,3 +31,7 @@ well as customizing which fields are returned.
 .. option:: --list-banks
 
     Concisely list all of the banks a user belongs to.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.


### PR DESCRIPTION
#### Problem

The `view-bank` and `view-user` man pages do not list the `-o/--format` optional argument in the command descriptions which was added in #600.

---

This PR adds the `-o/--format` optional argument to both the `view-bank` and `view-user` man pages.