### PR TITLE
`delete-queue`: add warning statement when deleting a queue still referenced by associations

### DIFF
--- a/t/t1024-flux-account-queues.t
+++ b/t/t1024-flux-account-queues.t
@@ -150,6 +150,12 @@ test_expect_success 'call list-queues with a format string' '
 	grep "standby ||60" format_string.out
 '
 
+test_expect_success 'remove a queue that is referenced by at least one association' '
+	flux account edit-user user5014 --queues="queue_2" &&
+	flux account delete-queue queue_2 > warning_message.out &&
+	grep "WARNING: user(s) in the association_table still reference this queue." warning_message.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

A queue can be deleted from the `queue_table` but still be referenced by associations in the `association_table`, i.e. an
association can still list that queue in its `queues` column. An admin who calls the `delete-queue` command should be warned that they should also edit any association rows in the `association_table` to account for deleting a queue.

---

This PR adds a check in `delete_queue()` to see if any associations have the queue being deleted still referenced in their `queues` attribute. If so, it issues a warning statement letting the admin know they should also edit any and all associations' rows to account for deleting a queue.

I've also added a basic test to make sure that the warning statement gets issued when removing a queue still referenced by an association.