### PR TITLE
`add-user`: add `--fairshare` as an optional argument

### DIFF
--- a/doc/man1/flux-account-add-user.rst
+++ b/doc/man1/flux-account-add-user.rst
@@ -41,6 +41,11 @@ be defined upon user creation.
     The amount of available resources their organization considers they should
     be entitled to use relative to other competing users.
 
+.. option:: --fairshare
+
+    The ratio between the amount of resources an association is allocated
+    versus the amount actually consumed.
+
 .. option:: --max-running-jobs
 
     The max number of running jobs the association can have at any given time.

--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -86,14 +86,14 @@ def populate_db(conn, users=None, banks=None):
 
                     u.add_user(
                         conn,
-                        username,
-                        bank,
-                        uid,
-                        shares,
-                        max_running_jobs,
-                        max_active_jobs,
-                        max_nodes,
-                        queues,
+                        username=username,
+                        bank=bank,
+                        uid=uid,
+                        shares=shares,
+                        max_running_jobs=max_running_jobs,
+                        max_active_jobs=max_active_jobs,
+                        max_nodes=max_nodes,
+                        queues=queues,
                     )
         except IOError as err:
             print(err)

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -338,6 +338,7 @@ def add_user(
     bank,
     uid=65534,
     shares=1,
+    fairshare=0.5,
     max_running_jobs=5,
     max_active_jobs=7,
     max_nodes=2147483647,
@@ -397,10 +398,10 @@ def add_user(
             """
             INSERT INTO association_table (creation_time, mod_time, username,
                                            userid, bank, default_bank, shares,
-                                           max_running_jobs, max_active_jobs,
+                                           fairshare, max_running_jobs, max_active_jobs,
                                            max_nodes, max_cores, queues, projects,
                                            default_project)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(time.time()),
@@ -410,6 +411,7 @@ def add_user(
                 bank,
                 default_bank,
                 shares,
+                fairshare,
                 max_running_jobs,
                 max_active_jobs,
                 max_nodes,

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -210,6 +210,7 @@ class AccountingService:
                 bank=msg.payload["bank"],
                 uid=msg.payload["userid"],
                 shares=msg.payload["shares"],
+                fairshare=msg.payload["fairshare"],
                 max_running_jobs=msg.payload["max_running_jobs"],
                 max_active_jobs=msg.payload["max_active_jobs"],
                 max_nodes=msg.payload["max_nodes"],

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -172,6 +172,13 @@ def add_add_user_arg(subparsers):
         metavar="SHARES",
     )
     subparser_add_user.add_argument(
+        "--fairshare",
+        help="fairshare",
+        type=float,
+        default=0.5,
+        metavar="FAIRSHARE",
+    )
+    subparser_add_user.add_argument(
         "--max-running-jobs",
         help="max number of jobs that can be running at the same time",
         default=5,


### PR DESCRIPTION
#### Problem

The `fairshare` attribute for associations is not configurable in the `add-user` command, meaning that every association that gets added to the flux-accounting database **has** to have a `fairshare` value of 0.5. There might be a case where an admin might want to add an association with a different fairshare value, but in order to do this, they have to
open a SQLite shell, connect to the DB, and execute a SQL statement.

---

This PR adds `fairshare` as an optional argument to the `add-user` command, which allows an admin to customize the `fairshare` value for an association if they want to. The default is kept at 0.5.

I've also added the optional argument to the `add-user(1)` man page.
