### PR TITLE
`list-users`: add `--default-project` optional argument, man page

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,7 +25,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-add-queue.1 \
 	man1/flux-account-delete-queue.1 \
 	man1/flux-account-edit-queue.1 \
-	man1/flux-account-list-queues.1
+	man1/flux-account-list-queues.1 \
+	man1/flux-account-list-users.1
 
 MAN5_FILES_PRIMARY = \
 	man5/flux-config-accounting.5

--- a/doc/man1/flux-account-edit-user.rst
+++ b/doc/man1/flux-account-edit-user.rst
@@ -49,7 +49,7 @@ fields for a given association. The list of modifiable fields are as follows:
 
 .. option:: --max-nodes
 
-    The man number of nodes an association can have across all of their running
+    The max number of nodes an association can have across all of their running
     jobs.
 
 .. option:: --queues

--- a/doc/man1/flux-account-list-users.rst
+++ b/doc/man1/flux-account-list-users.rst
@@ -1,0 +1,74 @@
+.. flux-help-section: flux account
+
+==========================
+flux-account-list-users(1)
+==========================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **list-users** [OPTIONS]
+
+DESCRIPTION
+===========
+
+.. program:: flux account list-users
+
+:program:`flux account list-users` will list all of the associations in the
+``association_table``. By default, it will include every column in the
+``association_table``, but the output can be customized by specifying which
+columns to include. The table can also be filtered to return associations that
+meet certain criteria, such as those who belong to a certain bank, queue, or
+project, or those who have certain configured limits.
+
+.. option:: --cols
+
+    A list of columns from the table to include in the output. By default, all
+    columns are included.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.
+
+.. option:: --active
+
+    An association's active status (1 = active; 0 = inactive)
+
+.. option:: --shares
+
+    The amount of available resources their organization considers they should
+    be entitled to use relative to other competing users.
+
+.. option:: --max-running-jobs
+
+    The max number of running jobs the association can have at any given time.
+
+.. option:: --max-active-jobs
+
+    The max number of both pending and running jobs the association can have at
+    any given time.
+
+.. option:: --max-nodes
+
+    The max number of nodes an association can have across all of their running
+    jobs.
+    
+.. option:: --max-cores
+
+    The max number of nodes an association can have across all of their running
+    jobs.
+
+.. option:: --queues
+
+    A comma-separated list of all of the queues an association can run jobs
+    under.
+
+.. option:: --projects
+
+    A comma-separated list of all of the projects an association can run jobs
+    under.
+
+.. option:: --default-project
+
+    The default project an association belongs to.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -150,4 +150,11 @@ man_pages = [
         [author],
         5,
     ),
+    (
+        "man1/flux-account-list-users",
+        "flux-account-list-users",
+        "list all associations in the association_table",
+        [author],
+        1,
+    ),
 ]

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -283,10 +283,9 @@ def list_users(conn, cols=None, json_fmt=False, format_string="", **kwargs):
         conn: a SQLite connection object
         cols: a list of columns from the table to include in the output. By default, all
             columns are included.
-        filters: a list of optional constraints passed-in to filter the
-            association_table by.
         format_string: a format string defining how each row should be formatted. Column
             names should be used as placeholders.
+        **kwargs: a list of optional constraints to filter the association_table by.
     """
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.ASSOCIATION_TABLE

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -304,7 +304,7 @@ def list_users(conn, cols=None, json_fmt=False, format_string="", **kwargs):
         where_clauses = []
         filters_list = []
         for table_filter in table_filters:
-            if table_filter in ("queues", "projects"):
+            if table_filter in ("queues", "projects", "default_project"):
                 # we are filtering the table with a string; append wildcards ('%') to
                 # the string so we can match multiple cases (e.g the association belongs
                 # to more than one queue or project)

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -192,6 +192,7 @@ class AccountingService:
                 max_cores=msg.payload.get("max_cores"),
                 queues=msg.payload.get("queues"),
                 projects=msg.payload.get("projects"),
+                default_project=msg.payload.get("default_project"),
             )
 
             payload = {"list_users": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -138,6 +138,10 @@ def add_list_users_arg(subparsers):
         "--projects",
         metavar="PROJECTS",
     )
+    subparser_list_users.add_argument(
+        "--default-project",
+        metavar="DEFAULT_PROJECT",
+    )
 
 
 def add_add_user_arg(subparsers):

--- a/t/t1051-list-users.t
+++ b/t/t1051-list-users.t
@@ -59,7 +59,10 @@ test_expect_success 'edit associations to belong to different queues' '
 
 test_expect_success 'edit associations to belong to different projects' '
 	flux account edit-user user1 --projects="leviathan_wakes" &&
-	flux account edit-user user2 --bank=B --projects="leviathan_wakes,babylons_gate"
+	flux account edit-user user2 \
+		--bank=B \
+		--projects="leviathan_wakes,babylons_gate" \
+		--default-project="leviathan_wakes"
 '
 
 test_expect_success 'call list-users --help' '
@@ -148,6 +151,13 @@ test_expect_success 'customize output using a format string' '
 	flux account list-users -o "{username:<8}||{userid:<6}|{bank:<7}|" > format_string.out &&
 	grep "username||userid|bank   |" format_string.out &&
 	grep "user1   ||5011  |A      |" format_string.out
+'
+
+test_expect_success 'call list-users and pass --default-project' '
+	flux account list-users \
+		-o "{username:<8}||{userid:<6}|{bank:<7}|{default_project:<16}" \
+		--default-project="leviathan_wakes" > default_project.out &&
+	grep "user2   ||5012  |B      |leviathan_wakes" default_project.out
 '
 
 test_expect_success 'remove flux-accounting DB' '


### PR DESCRIPTION
#### Problem

The `list-users` command does not take `default_project` as an optional argument, but it would be nice to have in case a user wants to filter the table by `default_project`.

There is also no `man(1)` entry for the `list-users` command.

---

This PR adds `default_project` as an optional argument and fixes the docstring comment for the `list_users()` function. I've also added a man page for the command.

I also snuck in a minor spelling fix commit for the `edit-user(1)` page.