### PR TITLE
`add-user(1)`: clarify how default project is set

### DIFF
--- a/doc/man1/flux-account-add-user.rst
+++ b/doc/man1/flux-account-add-user.rst
@@ -68,7 +68,9 @@ be defined upon user creation.
 .. option:: --projects
 
     A comma-separated list of all of the projects an association can run jobs
-    under.
+    under. If this option is passed, the **first** project listed will become
+    the association's default project. The association's default can be changed
+    with :man1:`flux-account-edit-user`.
 
 EXAMPLES
 --------


### PR DESCRIPTION
#### Problem

It is not totally clear from reading `add-user(1)` that the first project listed will become the association's default project when passing `--projects` to the `add-user` command.

---

This PR just adds a note to the man page to clarify how the default project is set.