### PR TITLE
`add-user`: add `--default-project` as an optional argument

### DIFF
--- a/doc/man1/flux-account-add-user.rst
+++ b/doc/man1/flux-account-add-user.rst
@@ -72,6 +72,10 @@ be defined upon user creation.
     the association's default project. The association's default can be changed
     with :man1:`flux-account-edit-user`.
 
+.. option:: --default-project
+
+    The default project an association will run jobs under.
+
 EXAMPLES
 --------
 

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -344,6 +344,7 @@ def add_user(
     max_cores=2147483647,
     queues="",
     projects="*",
+    default_project=None,
 ):
     cur = conn.cursor()
 
@@ -386,10 +387,16 @@ def add_user(
         except ValueError as bad_project:
             raise ValueError(f"project {bad_project} does not exist in project_table")
 
-    # determine default_project for user; if no other projects
-    # were specified, use '*' as the default. If a project was
-    # specified, then use the first one as the default
-    default_project = set_default_project(projects)
+    # Determine the default project for user. If no projects were specified, use '*' as
+    # the default. If projects were specified and a default project name was not passed,
+    # use the first project specified as the default.
+    if not default_project:
+        default_project = set_default_project(projects)
+    else:
+        # a default project was specified; make sure it is also a part of the projects
+        # list, and if not, add it
+        if default_project not in projects.split(","):
+            projects += f",{default_project}"
 
     try:
         # insert the user values into association_table

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -218,6 +218,7 @@ class AccountingService:
                 max_cores=msg.payload["max_cores"],
                 queues=msg.payload["queues"],
                 projects=msg.payload["projects"],
+                default_project=msg.payload["default_project"],
             )
 
             payload = {"add_user": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -218,6 +218,12 @@ def add_add_user_arg(subparsers):
         default="*",
         metavar="PROJECTS",
     )
+    subparser_add_user.add_argument(
+        "--default-project",
+        help="the default project for the association to submit jobs under",
+        default=None,
+        metavar="DEFAULT_PROJECT",
+    )
 
 
 def add_delete_user_arg(subparsers):

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -168,6 +168,17 @@ test_expect_success 'list all of the projects currently registered in project_ta
 	grep -f project_table.expected project_table.test
 '
 
+test_expect_success 'add an association with a default project specified' '
+	flux account add-user \
+		--username=user5025 \
+		--userid=5025 \
+		--bank=B \
+		--default-project=project_2 &&
+	flux account view-user user5025 > default_project.out &&
+	grep "\"default_project\": \"project_2\"" default_project.out &&
+	grep "\"projects\": \"\*,project_2\"" default_project.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

The `add-user` command does not have an option to specify a default project when adding an association for the first time. The
behavior currently is to pass a list of projects where the first one is treated as the default. It would be convenient to have an option to also just specify a default project by itself.

---

This PR (built on top of #618) adds a new optional argument to the add-user command: `--default-project`, which takes a string representing the name of the default project an association will submit jobs under. It checks for the existence of this argument when determining the default project for an association before taking the first project listed in `projects` to keep backwards compatibility.

It a default project is specified, it makes sure that it is also present in `projects`, and if not, it adds it.

I've added a simple test that exercises use of this option as well as updated `add-user(1)` with the new option.