### PR TITLE
`flux-account`: add `@CLIMain` decorator

### DIFF
--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -9,6 +9,7 @@
 ###############################################################
 import argparse
 import sys
+import logging
 
 import flux
 import fluxacct.accounting
@@ -989,6 +990,10 @@ def select_accounting_function(args, output_file, parser):
         print(list(return_val.values())[0])
 
 
+LOGGER = logging.getLogger("flux-account")
+
+
+@flux.util.CLIMain(LOGGER)
 def main():
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
#### Problem

As mentioned in #620, the stack traces for errors raised in the flux-accounting commands are not suppressed by default even though a lot of the commands have custom error messages. This means that when an expected error occurs in flux-accounting (like adding a user to a bank that does not exist), the stack trace is very long and could be misleading to someone running the command.

---

This PR adds a decorator to `main()`  to enable suppression of large stack traces that prepend a custom error message raised from flux-accounting. Now, when an error occurs, the stack trace is suppressed and the error message looks more reasonable:

```console
$ flux account add-bank --parent-bank=foo B 1
flux-account: ERROR: error in add_bank: parent bank foo not found in bank table
```

Fixes #620 