### PR TITLE
`flux-account`: standardize prefixes for error messages

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -170,9 +170,9 @@ def view_bank(
             return formatter.with_users(bank)
         return formatter.as_json()
     except sqlite3.Error as err:
-        raise sqlite3.Error(f"view-bank: an sqlite3.Error occurred: {err}")
+        raise sqlite3.Error(err)
     except ValueError as exc:
-        raise ValueError(f"view-bank: {exc}")
+        raise ValueError(exc)
 
 
 def delete_bank(conn, bank, force=False):
@@ -318,6 +318,6 @@ def list_banks(
             return formatter.as_table()
         return formatter.as_json()
     except sqlite3.Error as err:
-        raise sqlite3.Error(f"list-banks: an sqlite3.Error occurred: {err}")
+        raise sqlite3.Error(err)
     except ValueError as exc:
-        raise ValueError(f"list-banks: {exc}")
+        raise ValueError(exc)

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -58,7 +58,7 @@ def view_project(conn, project, parsable=False, format_string=None):
             return formatter.as_table()
         return formatter.as_json()
     except sqlite3.OperationalError as exc:
-        raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
+        raise sqlite3.OperationalError(exc)
 
 
 def add_project(conn, project):
@@ -142,6 +142,6 @@ def list_projects(conn, cols=None, table=False, format_string=None):
             return formatter.as_table()
         return formatter.as_json()
     except sqlite3.Error as err:
-        raise sqlite3.Error(f"list-projects: an sqlite3.Error occurred: {err}")
+        raise sqlite3.Error(err)
     except ValueError as exc:
-        raise ValueError(f"list-projects: {exc}")
+        raise ValueError(exc)

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -30,9 +30,9 @@ def view_queue(conn, queue, parsable=False, format_string=""):
             return formatter.as_table()
         return formatter.as_json()
     except sqlite3.OperationalError as exc:
-        raise sqlite3.OperationalError(f"an sqlite3.OperationalError occurred: {exc}")
+        raise sqlite3.OperationalError(exc)
     except ValueError as exc:
-        raise ValueError(f"view-queue: {exc}")
+        raise ValueError(exc)
 
 
 def add_queue(
@@ -173,6 +173,6 @@ def list_queues(conn, cols=None, table=False, format_string=""):
             return formatter.as_table()
         return formatter.as_json()
     except sqlite3.Error as err:
-        raise sqlite3.Error(f"list-queues: an sqlite3.Error occurred: {err}")
+        raise sqlite3.Error(err)
     except ValueError as exc:
-        raise ValueError(f"list-queues: {exc}")
+        raise ValueError(exc)

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -266,11 +266,9 @@ def view_user(
     # found or transaction could not be processed
     # (https://docs.python.org/3/library/sqlite3.html#sqlite3.OperationalError)
     except sqlite3.OperationalError as exc:
-        raise sqlite3.OperationalError(
-            f"view-user: an sqlite3.OperationalError occurred: {exc}"
-        )
+        raise sqlite3.OperationalError(exc)
     except ValueError as exc:
-        raise ValueError(f"view-user: {exc}")
+        raise ValueError(exc)
 
 
 def list_users(conn, cols=None, json_fmt=False, format_string="", **kwargs):
@@ -326,9 +324,9 @@ def list_users(conn, cols=None, json_fmt=False, format_string="", **kwargs):
             return formatter.as_json()
         return formatter.as_table()
     except sqlite3.Error as err:
-        raise sqlite3.Error(f"list-users: an sqlite3.Error occurred: {err}")
+        raise sqlite3.Error(err)
     except ValueError as exc:
-        raise ValueError(f"list-users: {exc}")
+        raise ValueError(exc)
 
 
 def add_user(

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -163,17 +163,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"view-user: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"view-user: {val_err}")
-        except sqlite3.OperationalError as sql_err:
-            handle.respond_error(
-                msg, 0, f"view-user: sqlite3.OperationalError: {sql_err}"
-            )
         except Exception as exc:
-            # fall through to a non-OSError exception
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"view-user: {type(exc).__name__}: {exc}")
 
     # pylint: disable=no-self-use
     def list_users(self, handle, watcher, msg, arg):
@@ -203,7 +194,7 @@ class AccountingService:
         except KeyError as exc:
             handle.respond_error(msg, 0, f"list-users: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(msg, 0, f"list-users: {exc}")
+            handle.respond_error(msg, 0, f"list-users: {type(exc).__name__}: {exc}")
 
     def add_user(self, handle, watcher, msg, arg):
         try:
@@ -228,14 +219,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"add-user: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"add-user: {val_err}")
-        except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"add-user: {integ_err}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"add-user: {type(exc).__name__}: {exc}")
 
     def delete_user(self, handle, watcher, msg, arg):
         try:
@@ -252,9 +237,7 @@ class AccountingService:
         except KeyError as exc:
             handle.respond_error(msg, 0, f"delete-user: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"delete-user: {type(exc).__name__}: {exc}")
 
     def edit_user(self, handle, watcher, msg, arg):
         try:
@@ -280,12 +263,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"edit-user: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"edit-user: {val_err}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"edit-user: {type(exc).__name__}: {exc}")
 
     def view_bank(self, handle, watcher, msg, arg):
         try:
@@ -304,16 +283,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"view-bank: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"view-bank: {val_err}")
-        except sqlite3.OperationalError as sql_err:
-            handle.respond_error(
-                msg, 0, f"view-bank: sqlite3.OperationalError: {sql_err}"
-            )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"view-bank: {type(exc).__name__}: {exc}")
 
     def add_bank(self, handle, watcher, msg, arg):
         try:
@@ -329,18 +300,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"add-bank: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"add-bank: {val_err}")
-        except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"add-bank: {integ_err}")
-        except sqlite3.OperationalError as sql_err:
-            handle.respond_error(
-                msg, 0, f"add-bank: sqlite3.OperationalError: {sql_err}"
-            )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"add-bank: {type(exc).__name__}: {exc}")
 
     def delete_bank(self, handle, watcher, msg, arg):
         try:
@@ -351,14 +312,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"delete-bank: missing key in payload: {exc}")
-        except sqlite3.OperationalError as sql_err:
-            handle.respond_error(
-                msg, 0, f"delete-bank: sqlite3.OperationalError: {sql_err}"
-            )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"delete-bank: {type(exc).__name__}: {exc}")
 
     def edit_bank(self, handle, watcher, msg, arg):
         try:
@@ -374,12 +329,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"edit-bank: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"edit-bank: {val_err}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"edit-bank: {type(exc).__name__}: {exc}")
 
     def list_banks(self, handle, watcher, msg, arg):
         try:
@@ -396,14 +347,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"list-banks: missing key in payload: {exc}")
-        except ValueError as exc:
-            handle.respond_error(msg, 0, f"list-banks: {exc}")
-        except sqlite3.Error as exc:
-            handle.respond_error(msg, 0, f"list-banks: a SQLite error occurred: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"list-banks: {type(exc).__name__}: {exc}")
 
     # pylint: disable=no-self-use
     def view_job_records(self, handle, watcher, msg, arg):
@@ -429,7 +374,7 @@ class AccountingService:
             )
         except Exception as exc:
             handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
+                msg, 0, f"view-job-records: {type(exc).__name__}: {exc}"
             )
 
     def update_usage(self, handle, watcher, msg, arg):
@@ -444,12 +389,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"update-usage: missing key in payload: {exc}")
-        except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"update-usage: {integ_err}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"update-usage: {type(exc).__name__}: {exc}")
 
     def add_queue(self, handle, watcher, msg, arg):
         try:
@@ -469,9 +410,7 @@ class AccountingService:
         except KeyError as exc:
             handle.respond_error(msg, 0, f"add-queue: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"add-queue: {type(exc).__name__}: {exc}")
 
     def view_queue(self, handle, watcher, msg, arg):
         try:
@@ -487,16 +426,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"view-queue: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"view-queue: {val_err}")
-        except sqlite3.OperationalError as sql_err:
-            handle.respond_error(
-                msg, 0, f"view-queue: sqlite3.OperationalError: {sql_err}"
-            )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"view-queue: {type(exc).__name__}: {exc}")
 
     def delete_queue(self, handle, watcher, msg, arg):
         try:
@@ -507,12 +438,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"delete-queue: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"delete-queue: {val_err}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"delete-queue: {type(exc).__name__}: {exc}")
 
     def edit_queue(self, handle, watcher, msg, arg):
         try:
@@ -531,12 +458,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"edit-queue: missing key in payload: {exc}")
-        except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"edit-queue: {integ_err}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"edit-queue: {type(exc).__name__}: {exc}")
 
     def add_project(self, handle, watcher, msg, arg):
         try:
@@ -548,9 +471,7 @@ class AccountingService:
         except KeyError as exc:
             handle.respond_error(msg, 0, f"add-project: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"add-project: {type(exc).__name__}: {exc}")
 
     def view_project(self, handle, watcher, msg, arg):
         try:
@@ -566,16 +487,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"view-project: missing key in payload: {exc}")
-        except ValueError as val_err:
-            handle.respond_error(msg, 0, f"view-project: {val_err}")
-        except sqlite3.OperationalError as sql_err:
-            handle.respond_error(
-                msg, 0, f"view-project: sqlite3.OperationalError: {sql_err}"
-            )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"view-project: {type(exc).__name__}: {exc}")
 
     def delete_project(self, handle, watcher, msg, arg):
         try:
@@ -589,9 +502,7 @@ class AccountingService:
                 msg, 0, f"delete-project: missing key in payload: {exc}"
             )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"delete-project: {type(exc).__name__}: {exc}")
 
     def list_projects(self, handle, watcher, msg, arg):
         try:
@@ -610,9 +521,7 @@ class AccountingService:
                 msg, 0, f"list-projects: missing key in payload: {exc}"
             )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"list-projects: {type(exc).__name__}: {exc}")
 
     def scrub_old_jobs(self, handle, watcher, msg, arg):
         try:
@@ -626,9 +535,7 @@ class AccountingService:
                 msg, 0, f"scrub-old-jobs: missing key in payload: {exc}"
             )
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"scrub-old-jobs: {type(exc).__name__}: {exc}")
 
     def export_db(self, handle, watcher, msg, arg):
         try:
@@ -644,9 +551,7 @@ class AccountingService:
         except KeyError as exc:
             handle.respond_error(msg, 0, f"export-db: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"export-db: {type(exc).__name__}: {exc}")
 
     def pop_db(self, handle, watcher, msg, arg):
         try:
@@ -662,9 +567,7 @@ class AccountingService:
         except KeyError as exc:
             handle.respond_error(msg, 0, f"pop-db: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"pop-db: {type(exc).__name__}: {exc}")
 
     def list_queues(self, handle, watcher, msg, arg):
         try:
@@ -680,14 +583,8 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"list-queues: missing key in payload: {exc}")
-        except ValueError as exc:
-            handle.respond_error(msg, 0, f"list-queues: {exc}")
-        except sqlite3.Error as exc:
-            handle.respond_error(msg, 0, f"list-queues: a SQLite error occurred: {exc}")
         except Exception as exc:
-            handle.respond_error(
-                msg, 0, f"a non-OSError exception was caught: {str(exc)}"
-            )
+            handle.respond_error(msg, 0, f"list-queues: {type(exc).__name__}: {exc}")
 
 
 LOGGER = logging.getLogger("flux-uri")

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -162,11 +162,13 @@ class AccountingService:
             # handle a flux-accounting.view_user request
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"view-user: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in view-user: {val_err}")
+            handle.respond_error(msg, 0, f"view-user: {val_err}")
         except sqlite3.OperationalError as sql_err:
-            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
+            handle.respond_error(
+                msg, 0, f"view-user: sqlite3.OperationalError: {sql_err}"
+            )
         except Exception as exc:
             # fall through to a non-OSError exception
             handle.respond_error(
@@ -199,9 +201,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"list-users: missing key in payload: {exc}")
         except Exception as exc:
-            handle.respond_error(msg, 0, str(exc))
+            handle.respond_error(msg, 0, f"list-users: {exc}")
 
     def add_user(self, handle, watcher, msg, arg):
         try:
@@ -225,11 +227,11 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"add-user: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in add_user: {val_err}")
+            handle.respond_error(msg, 0, f"add-user: {val_err}")
         except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"error in add_user: {integ_err}")
+            handle.respond_error(msg, 0, f"add-user: {integ_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -248,7 +250,7 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"delete-user: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -277,9 +279,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"edit-user: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in edit_user: {val_err}")
+            handle.respond_error(msg, 0, f"edit-user: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -301,11 +303,13 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"view-bank: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in view-bank: {val_err}")
+            handle.respond_error(msg, 0, f"view-bank: {val_err}")
         except sqlite3.OperationalError as sql_err:
-            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
+            handle.respond_error(
+                msg, 0, f"view-bank: sqlite3.OperationalError: {sql_err}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -324,13 +328,15 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"add-bank: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in add_bank: {val_err}")
+            handle.respond_error(msg, 0, f"add-bank: {val_err}")
         except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"error in add_bank: {integ_err}")
+            handle.respond_error(msg, 0, f"add-bank: {integ_err}")
         except sqlite3.OperationalError as sql_err:
-            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
+            handle.respond_error(
+                msg, 0, f"add-bank: sqlite3.OperationalError: {sql_err}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -344,9 +350,11 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"delete-bank: missing key in payload: {exc}")
         except sqlite3.OperationalError as sql_err:
-            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
+            handle.respond_error(
+                msg, 0, f"delete-bank: sqlite3.OperationalError: {sql_err}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -365,9 +373,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"edit-bank: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in edit_bank: {val_err}")
+            handle.respond_error(msg, 0, f"edit-bank: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -387,11 +395,11 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"list-banks: missing key in payload: {exc}")
         except ValueError as exc:
-            handle.respond_error(msg, 0, f"{exc}")
+            handle.respond_error(msg, 0, f"list-banks: {exc}")
         except sqlite3.Error as exc:
-            handle.respond_error(msg, 0, f"a SQLite error occurred: {exc}")
+            handle.respond_error(msg, 0, f"list-banks: a SQLite error occurred: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -416,7 +424,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(
+                msg, 0, f"view-job-records: missing key in payload: {exc}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -433,9 +443,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"update-usage: missing key in payload: {exc}")
         except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"error in add_queue: {integ_err}")
+            handle.respond_error(msg, 0, f"update-usage: {integ_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -457,7 +467,7 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"add-queue: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -476,11 +486,13 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"view-queue: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in view-queue: {val_err}")
+            handle.respond_error(msg, 0, f"view-queue: {val_err}")
         except sqlite3.OperationalError as sql_err:
-            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
+            handle.respond_error(
+                msg, 0, f"view-queue: sqlite3.OperationalError: {sql_err}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -494,9 +506,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"delete-queue: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in edit-queue: {val_err}")
+            handle.respond_error(msg, 0, f"delete-queue: {val_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -518,9 +530,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"edit-queue: missing key in payload: {exc}")
         except sqlite3.IntegrityError as integ_err:
-            handle.respond_error(msg, 0, f"error in add_project: {integ_err}")
+            handle.respond_error(msg, 0, f"edit-queue: {integ_err}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -534,7 +546,7 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"add-project: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -553,11 +565,13 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"view-project: missing key in payload: {exc}")
         except ValueError as val_err:
-            handle.respond_error(msg, 0, f"error in view-project: {val_err}")
+            handle.respond_error(msg, 0, f"view-project: {val_err}")
         except sqlite3.OperationalError as sql_err:
-            handle.respond_error(msg, 0, f"sqlite3.OperationalError: {sql_err}")
+            handle.respond_error(
+                msg, 0, f"view-project: sqlite3.OperationalError: {sql_err}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -571,7 +585,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(
+                msg, 0, f"delete-project: missing key in payload: {exc}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -590,7 +606,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(
+                msg, 0, f"list-projects: missing key in payload: {exc}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -604,7 +622,9 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(
+                msg, 0, f"scrub-old-jobs: missing key in payload: {exc}"
+            )
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -622,7 +642,7 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"export-db: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -640,7 +660,7 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"pop-db: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"
@@ -659,11 +679,11 @@ class AccountingService:
 
             handle.respond(msg, payload)
         except KeyError as exc:
-            handle.respond_error(msg, 0, f"missing key in payload: {exc}")
+            handle.respond_error(msg, 0, f"list-queues: missing key in payload: {exc}")
         except ValueError as exc:
-            handle.respond_error(msg, 0, f"{exc}")
+            handle.respond_error(msg, 0, f"list-queues: {exc}")
         except sqlite3.Error as exc:
-            handle.respond_error(msg, 0, f"a SQLite error occurred: {exc}")
+            handle.respond_error(msg, 0, f"list-queues: a SQLite error occurred: {exc}")
         except Exception as exc:
             handle.respond_error(
                 msg, 0, f"a non-OSError exception was caught: {str(exc)}"

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -104,7 +104,7 @@ test_expect_success 'edit the max_active_jobs of an existing user' '
 
 test_expect_success 'trying to view a user who does not exist in the DB should raise a ValueError' '
 	test_must_fail flux account view-user user9999 > user_nonexistent.out 2>&1 &&
-	grep "view-user: user user9999 not found in association_table" user_nonexistent.out
+	grep "user9999 not found in association_table" user_nonexistent.out
 '
 
 test_expect_success 'trying to view a user that does exist in the DB should return some information' '
@@ -137,7 +137,7 @@ test_expect_success 'remove a user account' '
 test_expect_success 'remove a user with --force' '
 	flux account delete-user user5011 A --force &&
 	test_must_fail flux account view-user user5011 > user5011_nonexistent.out 2>&1 &&
-	grep "view-user: user user5011 not found in association_table" user5011_nonexistent.out
+	grep "user5011 not found in association_table" user5011_nonexistent.out
 '
 
 test_expect_success 'remove a user with --force/make sure default bank gets updated' '

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -166,19 +166,19 @@ test_expect_success 'call list-banks with a format string' '
 test_expect_success 'delete a bank with --force; ensure users also get deleted' '
 	flux account delete-bank C --force &&
 	test_must_fail flux account view-bank C > nonexistent_bank.out 2>&1 &&
-	grep "view-bank: bank C not found in bank_table" nonexistent_bank.out &&
+	grep "bank C not found in bank_table" nonexistent_bank.out &&
 	test_must_fail flux account view-user user5014 > nonexistent_user.out 2>&1 &&
-	grep "view-user: user user5014 not found in association_table" nonexistent_user.out
+	grep "user user5014 not found in association_table" nonexistent_user.out
 '
 
 test_expect_success 'delete a bank with multiple sub-banks and users with --force' '
 	flux account delete-bank D --force &&
 	test_must_fail flux account view-bank E > bankE_noexist.out 2>&1 &&
-	grep "view-bank: bank E not found in bank_table" bankE_noexist.out &&
+	grep "bank E not found in bank_table" bankE_noexist.out &&
 	test_must_fail flux account view-bank F > bankF_noexist.out 2>&1 &&
-	grep "view-bank: bank F not found in bank_table" bankF_noexist.out &&
+	grep "bank F not found in bank_table" bankF_noexist.out &&
 	test_must_fail flux account view-user user5030 > nonexistent_user.out 2>&1 &&
-	grep "view-user: user user5030 not found in association_table" nonexistent_user.out
+	grep "user user5030 not found in association_table" nonexistent_user.out
 '
 
 test_expect_success 'remove flux-accounting DB' '


### PR DESCRIPTION
#### Problem

A lot of the exception handlers in `flux-account-service.py` either have the wrong prefix or no prefix at all. Now that
flux-accounting has better formatting for printing out error messages (i.e. it disables the huge stack trace by default), it should take better care of making sure that error messages raised by flux-accounting have an appropriate format.

---

This PR standardizes the prefixes in the exception handlers for the different commands in the flux-accounting service. For functions in the Python bindings that have the command prefix in their `except` block, I've removed them, since they are now all located in `flux-account-service.py`.

I've also removed the prefix for the general `Exception` block since it was pointed out in #597 that a function could in fact return an `OSError`. 