### PR TITLE
bindings: remove redundant `try/except` blocks

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -100,8 +100,6 @@ def add_bank(conn, bank, shares, parent_bank=""):
             validate_parent_bank(cur, parent_bank)
     except ValueError as bad_parent_bank:
         raise ValueError(f"parent bank {bad_parent_bank} not found in bank table")
-    except sqlite3.OperationalError as exc:
-        raise sqlite3.OperationalError(exc)
 
     # check if bank already exists and is active in bank_table; if so, raise
     # a sqlite3.IntegrityError
@@ -149,30 +147,25 @@ def view_bank(
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.BANK_TABLE
 
-    try:
-        cur = conn.cursor()
+    cur = conn.cursor()
 
-        sql.validate_columns(cols, fluxacct.accounting.BANK_TABLE)
-        # construct SELECT statement
-        select_stmt = f"SELECT {', '.join(cols)} FROM bank_table WHERE bank=?"
-        cur.execute(select_stmt, (bank,))
+    sql.validate_columns(cols, fluxacct.accounting.BANK_TABLE)
+    # construct SELECT statement
+    select_stmt = f"SELECT {', '.join(cols)} FROM bank_table WHERE bank=?"
+    cur.execute(select_stmt, (bank,))
 
-        # initialize BankFormatter object
-        formatter = fmt.BankFormatter(cur, bank)
+    # initialize BankFormatter object
+    formatter = fmt.BankFormatter(cur, bank)
 
-        if format_string != "":
-            return formatter.as_format_string(format_string)
-        if tree:
-            if parsable:
-                return formatter.as_parsable_tree(bank)
-            return formatter.as_tree()
-        if users:
-            return formatter.with_users(bank)
-        return formatter.as_json()
-    except sqlite3.Error as err:
-        raise sqlite3.Error(err)
-    except ValueError as exc:
-        raise ValueError(exc)
+    if format_string != "":
+        return formatter.as_format_string(format_string)
+    if tree:
+        if parsable:
+            return formatter.as_parsable_tree(bank)
+        return formatter.as_tree()
+    if users:
+        return formatter.with_users(bank)
+    return formatter.as_json()
 
 
 def delete_bank(conn, bank, force=False):
@@ -300,24 +293,19 @@ def list_banks(
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.BANK_TABLE
 
-    try:
-        cur = conn.cursor()
+    cur = conn.cursor()
 
-        sql.validate_columns(cols, fluxacct.accounting.BANK_TABLE)
-        # construct SELECT statement
-        select_stmt = f"SELECT {', '.join(cols)} FROM bank_table"
-        if not inactive:
-            select_stmt += " WHERE active=1"
-        cur.execute(select_stmt)
+    sql.validate_columns(cols, fluxacct.accounting.BANK_TABLE)
+    # construct SELECT statement
+    select_stmt = f"SELECT {', '.join(cols)} FROM bank_table"
+    if not inactive:
+        select_stmt += " WHERE active=1"
+    cur.execute(select_stmt)
 
-        # initialize AccountingFormatter object
-        formatter = fmt.AccountingFormatter(cur)
-        if format_string != "":
-            return formatter.as_format_string(format_string)
-        if table:
-            return formatter.as_table()
-        return formatter.as_json()
-    except sqlite3.Error as err:
-        raise sqlite3.Error(err)
-    except ValueError as exc:
-        raise ValueError(exc)
+    # initialize AccountingFormatter object
+    formatter = fmt.AccountingFormatter(cur)
+    if format_string != "":
+        return formatter.as_format_string(format_string)
+    if table:
+        return formatter.as_table()
+    return formatter.as_json()

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -45,20 +45,17 @@ def project_is_active(cur, project):
 
 
 def view_project(conn, project, parsable=False, format_string=None):
-    try:
-        cur = conn.cursor()
-        # get the information pertaining to a project in the DB
-        cur.execute("SELECT * FROM project_table where project=?", (project,))
+    cur = conn.cursor()
+    # get the information pertaining to a project in the DB
+    cur.execute("SELECT * FROM project_table where project=?", (project,))
 
-        formatter = fmt.ProjectFormatter(cur, project)
+    formatter = fmt.ProjectFormatter(cur, project)
 
-        if format_string is not None:
-            return formatter.as_format_string(format_string)
-        if parsable:
-            return formatter.as_table()
-        return formatter.as_json()
-    except sqlite3.OperationalError as exc:
-        raise sqlite3.OperationalError(exc)
+    if format_string is not None:
+        return formatter.as_format_string(format_string)
+    if parsable:
+        return formatter.as_table()
+    return formatter.as_json()
 
 
 def add_project(conn, project):
@@ -126,22 +123,17 @@ def list_projects(conn, cols=None, table=False, format_string=None):
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.PROJECT_TABLE
 
-    try:
-        cur = conn.cursor()
+    cur = conn.cursor()
 
-        sql.validate_columns(cols, fluxacct.accounting.PROJECT_TABLE)
-        # construct SELECT statement
-        select_stmt = f"SELECT {', '.join(cols)} FROM project_table"
-        cur.execute(select_stmt)
+    sql.validate_columns(cols, fluxacct.accounting.PROJECT_TABLE)
+    # construct SELECT statement
+    select_stmt = f"SELECT {', '.join(cols)} FROM project_table"
+    cur.execute(select_stmt)
 
-        # initialize AccountingFormatter object
-        formatter = fmt.AccountingFormatter(cur)
-        if format_string is not None:
-            return formatter.as_format_string(format_string)
-        if table:
-            return formatter.as_table()
-        return formatter.as_json()
-    except sqlite3.Error as err:
-        raise sqlite3.Error(err)
-    except ValueError as exc:
-        raise ValueError(exc)
+    # initialize AccountingFormatter object
+    formatter = fmt.AccountingFormatter(cur)
+    if format_string is not None:
+        return formatter.as_format_string(format_string)
+    if table:
+        return formatter.as_table()
+    return formatter.as_json()

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -17,22 +17,17 @@ from fluxacct.accounting import sql_util as sql
 
 
 def view_queue(conn, queue, parsable=False, format_string=""):
-    try:
-        cur = conn.cursor()
-        # get the information pertaining to a queue in the DB
-        cur.execute("SELECT * FROM queue_table where queue=?", (queue,))
+    cur = conn.cursor()
+    # get the information pertaining to a queue in the DB
+    cur.execute("SELECT * FROM queue_table where queue=?", (queue,))
 
-        formatter = fmt.QueueFormatter(cur, queue)
+    formatter = fmt.QueueFormatter(cur, queue)
 
-        if format_string != "":
-            return formatter.as_format_string(format_string)
-        if parsable:
-            return formatter.as_table()
-        return formatter.as_json()
-    except sqlite3.OperationalError as exc:
-        raise sqlite3.OperationalError(exc)
-    except ValueError as exc:
-        raise ValueError(exc)
+    if format_string != "":
+        return formatter.as_format_string(format_string)
+    if parsable:
+        return formatter.as_table()
+    return formatter.as_json()
 
 
 def add_queue(
@@ -157,22 +152,17 @@ def list_queues(conn, cols=None, table=False, format_string=""):
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.QUEUE_TABLE
 
-    try:
-        cur = conn.cursor()
+    cur = conn.cursor()
 
-        sql.validate_columns(cols, fluxacct.accounting.QUEUE_TABLE)
-        # construct SELECT statement
-        select_stmt = f"SELECT {', '.join(cols)} FROM queue_table"
-        cur.execute(select_stmt)
+    sql.validate_columns(cols, fluxacct.accounting.QUEUE_TABLE)
+    # construct SELECT statement
+    select_stmt = f"SELECT {', '.join(cols)} FROM queue_table"
+    cur.execute(select_stmt)
 
-        # initialize AccountingFormatter object
-        formatter = fmt.AccountingFormatter(cur)
-        if format_string != "":
-            return formatter.as_format_string(format_string)
-        if table:
-            return formatter.as_table()
-        return formatter.as_json()
-    except sqlite3.Error as err:
-        raise sqlite3.Error(err)
-    except ValueError as exc:
-        raise ValueError(exc)
+    # initialize AccountingFormatter object
+    formatter = fmt.AccountingFormatter(cur)
+    if format_string != "":
+        return formatter.as_format_string(format_string)
+    if table:
+        return formatter.as_table()
+    return formatter.as_json()

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -163,6 +163,10 @@ class AccountingService:
             handle.respond(msg, payload)
         except KeyError as exc:
             handle.respond_error(msg, 0, f"view-user: missing key in payload: {exc}")
+        # SQLite errors and exceptions raised are related to the DB's operation and are
+        # not necessarily under the control of the programmer, e.g. the DB path cannot
+        # be found or transaction could not be processed
+        # (https://docs.python.org/3/library/sqlite3.html#sqlite3.OperationalError)
         except Exception as exc:
             handle.respond_error(msg, 0, f"view-user: {type(exc).__name__}: {exc}")
 


### PR DESCRIPTION
#### Problem

As noted in #624, a lot of the bindings still have `try/except` blocks from when flux-accounting did not have a systemd service and something that could actually catch any exceptions raised from the functions themselves. Thus, there is a lot of code in the bindings that looks like:

```python
except Exception:
    raise Exception
```

Now that the flux-accounting service has a more robust way of capturing and propagating errors that occur, these bindings should be refactored to just `raise` the exception.

---

This PR removes a lot of the `try/except` blocks in the python bindings that do not provide a custom error message and just re-`raise`s the error to the service.

I've also moved one of the multi-line comments that describes some of the reasons for `sqlite3.Error`s to the service since the comment was removed from the bindings.

Fixes #624 