### PR TITLE
`list-*` commands: make table output default

### DIFF
--- a/doc/man1/flux-account-list-banks.rst
+++ b/doc/man1/flux-account-list-banks.rst
@@ -28,7 +28,7 @@ but the output can be customized by specifying which columns to include.
     A list of columns from the table to include in the output. By default, all
     columns are included.
 
-.. option:: --table
+.. option:: --json
 
-    Output data in table format. By default, the format of any returned data is
-    in JSON.
+    Output data in JSON format. By default, the format of any returned data is
+    in a table format.

--- a/doc/man1/flux-account-list-queues.rst
+++ b/doc/man1/flux-account-list-queues.rst
@@ -30,10 +30,10 @@ to include.
     A list of columns from the table to include in the output. By default, all
     columns are included.
 
-.. option:: --table
+.. option:: --json
 
-    Output data in table format. By default, the format of any returned data is
-    in JSON.
+    Output data in JSON format. By default, the format of any returned data is
+    in a table format.
 
 .. option:: -o/--format
 

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -274,7 +274,7 @@ def list_banks(
     conn,
     inactive=False,
     cols=None,
-    table=False,
+    json_fmt=False,
     format_string="",
 ):
     """
@@ -306,6 +306,6 @@ def list_banks(
     formatter = fmt.AccountingFormatter(cur)
     if format_string != "":
         return formatter.as_format_string(format_string)
-    if table:
-        return formatter.as_table()
-    return formatter.as_json()
+    if json_fmt:
+        return formatter.as_json()
+    return formatter.as_table()

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -110,7 +110,7 @@ def delete_project(conn, project):
     return 0
 
 
-def list_projects(conn, cols=None, table=False, format_string=None):
+def list_projects(conn, cols=None, json_fmt=False, format_string=None):
     """
     List all of the available projects registered in the project_table.
 
@@ -134,6 +134,6 @@ def list_projects(conn, cols=None, table=False, format_string=None):
     formatter = fmt.AccountingFormatter(cur)
     if format_string is not None:
         return formatter.as_format_string(format_string)
-    if table:
-        return formatter.as_table()
-    return formatter.as_json()
+    if json_fmt:
+        return formatter.as_json()
+    return formatter.as_table()

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -137,7 +137,7 @@ def edit_queue(
     return 0
 
 
-def list_queues(conn, cols=None, table=False, format_string=""):
+def list_queues(conn, cols=None, json_fmt=False, format_string=""):
     """
     List all queues in queue_table.
 
@@ -163,6 +163,6 @@ def list_queues(conn, cols=None, table=False, format_string=""):
     formatter = fmt.AccountingFormatter(cur)
     if format_string != "":
         return formatter.as_format_string(format_string)
-    if table:
-        return formatter.as_table()
-    return formatter.as_json()
+    if json_fmt:
+        return formatter.as_json()
+    return formatter.as_table()

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -513,7 +513,7 @@ class AccountingService:
             val = p.list_projects(
                 self.conn,
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
-                msg.payload["table"],
+                msg.payload["json"],
                 msg.payload["format"],
             )
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -578,7 +578,7 @@ class AccountingService:
             val = qu.list_queues(
                 self.conn,
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
-                msg.payload["table"],
+                msg.payload["json"],
                 msg.payload["format"],
             )
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -342,7 +342,7 @@ class AccountingService:
                 self.conn,
                 msg.payload["inactive"],
                 msg.payload["fields"].split(",") if msg.payload.get("fields") else None,
-                msg.payload["table"],
+                msg.payload["json"],
                 msg.payload["format"],
             )
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -891,10 +891,10 @@ def add_list_queues_arg(subparsers):
         metavar="QUEUE,MIN_NODES_PER_JOB,MAX_NODES_PER_JOB,MAX_TIME_PER_JOB,PRIORITY",
     )
     subparser_list_queues.add_argument(
-        "--table",
+        "--json",
         action="store_const",
         const=True,
-        help="list all queues in table format",
+        help="print output in JSON format",
     )
     subparser_list_queues.add_argument(
         "-o",

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -776,10 +776,10 @@ def add_list_projects_arg(subparsers):
         metavar="PROJECT_ID,PROJECT,USAGE",
     )
     subparser_list_projects.add_argument(
-        "--table",
+        "--json",
         action="store_const",
         const=True,
-        help="list all projects in table format",
+        help="list all projects in json format",
     )
     subparser_list_projects.add_argument(
         "-o",

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -556,10 +556,10 @@ def add_list_banks_arg(subparsers):
         metavar="BANK_ID,BANK,ACTIVE,PARENT_BANK,SHARES,JOB_USAGE",
     )
     subparser_list_banks.add_argument(
-        "--table",
+        "--json",
         action="store_const",
         const=True,
-        help="list all banks in table format",
+        help="print output in JSON format",
     )
     subparser_list_banks.add_argument(
         "-o",

--- a/t/python/t1008_banks_output.py
+++ b/t/python/t1008_banks_output.py
@@ -73,7 +73,7 @@ class TestAccountingCLI(unittest.TestCase):
         ]
         """
         )
-        test = b.list_banks(conn)
+        test = b.list_banks(conn, json_fmt=True)
         self.assertEqual(expected.strip(), test.strip())
 
     # test JSON output with custom columns
@@ -90,7 +90,7 @@ class TestAccountingCLI(unittest.TestCase):
         ]
         """
         )
-        test = b.list_banks(conn, cols=["bank_id"])
+        test = b.list_banks(conn, json_fmt=True, cols=["bank_id"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_custom_two(self):
@@ -108,7 +108,7 @@ class TestAccountingCLI(unittest.TestCase):
         ]
         """
         )
-        test = b.list_banks(conn, cols=["bank_id", "bank"])
+        test = b.list_banks(conn, json_fmt=True, cols=["bank_id", "bank"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_custom_three(self):
@@ -128,7 +128,7 @@ class TestAccountingCLI(unittest.TestCase):
         ]
         """
         )
-        test = b.list_banks(conn, cols=["bank_id", "bank", "active"])
+        test = b.list_banks(conn, json_fmt=True, cols=["bank_id", "bank", "active"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_custom_four(self):
@@ -150,7 +150,9 @@ class TestAccountingCLI(unittest.TestCase):
         ]
         """
         )
-        test = b.list_banks(conn, cols=["bank_id", "bank", "active", "parent_bank"])
+        test = b.list_banks(
+            conn, json_fmt=True, cols=["bank_id", "bank", "active", "parent_bank"]
+        )
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_custom_five(self):
@@ -175,7 +177,9 @@ class TestAccountingCLI(unittest.TestCase):
         """
         )
         test = b.list_banks(
-            conn, cols=["bank_id", "bank", "active", "parent_bank", "shares"]
+            conn,
+            json_fmt=True,
+            cols=["bank_id", "bank", "active", "parent_bank", "shares"],
         )
         self.assertEqual(expected.strip(), test.strip())
 
@@ -204,6 +208,7 @@ class TestAccountingCLI(unittest.TestCase):
         )
         test = b.list_banks(
             conn,
+            json_fmt=True,
             cols=["bank_id", "bank", "active", "parent_bank", "shares", "job_usage"],
         )
         self.assertEqual(expected.strip(), test.strip())
@@ -217,7 +222,7 @@ class TestAccountingCLI(unittest.TestCase):
         2       | A    | 1      | root        | 1      | 0.0       
         """
         )
-        test = b.list_banks(conn, table=True)
+        test = b.list_banks(conn)
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_table_custom_one(self):
@@ -229,7 +234,7 @@ class TestAccountingCLI(unittest.TestCase):
         2            
         """
         )
-        test = b.list_banks(conn, table=True, cols=["bank_id"])
+        test = b.list_banks(conn, cols=["bank_id"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_table_custom_two(self):
@@ -241,7 +246,7 @@ class TestAccountingCLI(unittest.TestCase):
         2       | A      
         """
         )
-        test = b.list_banks(conn, table=True, cols=["bank_id", "bank"])
+        test = b.list_banks(conn, cols=["bank_id", "bank"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_table_custom_three(self):
@@ -253,7 +258,7 @@ class TestAccountingCLI(unittest.TestCase):
         2       | A    | 1     
         """
         )
-        test = b.list_banks(conn, table=True, cols=["bank_id", "bank", "active"])
+        test = b.list_banks(conn, cols=["bank_id", "bank", "active"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_table_custom_four(self):
@@ -265,9 +270,7 @@ class TestAccountingCLI(unittest.TestCase):
         2       | A    | 1      | root
         """
         )
-        test = b.list_banks(
-            conn, table=True, cols=["bank_id", "bank", "active", "parent_bank"]
-        )
+        test = b.list_banks(conn, cols=["bank_id", "bank", "active", "parent_bank"])
         self.assertEqual(expected.strip(), test.strip())
 
     def test_list_banks_table_custom_five(self):
@@ -281,7 +284,6 @@ class TestAccountingCLI(unittest.TestCase):
         )
         test = b.list_banks(
             conn,
-            table=True,
             cols=["bank_id", "bank", "active", "parent_bank", "shares"],
         )
         self.assertEqual(expected.strip(), test.strip())
@@ -297,7 +299,6 @@ class TestAccountingCLI(unittest.TestCase):
         )
         test = b.list_banks(
             conn,
-            table=True,
             cols=["bank_id", "bank", "active", "parent_bank", "shares", "job_usage"],
         )
         self.assertEqual(expected.strip(), test.strip())

--- a/t/t1024-flux-account-queues.t
+++ b/t/t1024-flux-account-queues.t
@@ -129,18 +129,18 @@ test_expect_success 'trying to view a queue that does not exist should raise a V
 
 test_expect_success 'call list-queues' '
 	flux account list-queues > list_queues.out &&
-	grep "\"queue\": \"standby\"" list_queues.out &&
-	grep "\"queue\": \"expedite\"" list_queues.out &&
-	grep "\"queue\": \"queue_1\"" list_queues.out &&
-	grep "\"queue\": \"queue_2\"" list_queues.out
+	grep "standby" list_queues.out &&
+	grep "expedite" list_queues.out &&
+	grep "queue_1" list_queues.out &&
+	grep "queue_2" list_queues.out
 '
 
 test_expect_success 'call list-queues and customize output' '
-	flux account list-queues --fields=queue,priority --table > list_queues_table.out &&
-	grep "standby  | 0" list_queues_table.out &&
-	grep "expedite | 20000" list_queues_table.out &&
-	grep "queue_1  | 0" list_queues_table.out &&
-	grep "queue_2  | 0" list_queues_table.out
+	flux account list-queues --fields=queue,priority --json > list_queues_json.out &&
+	grep "\"queue\": \"standby\"" list_queues_json.out &&
+	grep "\"queue\": \"expedite\"" list_queues_json.out &&
+	grep "\"queue\": \"queue_1\"" list_queues_json.out &&
+	grep "\"queue\": \"queue_2\"" list_queues_json.out
 '
 
 test_expect_success 'call list-queues with a format string' '

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -44,7 +44,7 @@ test_expect_success 'add some queues to the DB' '
 '
 
 test_expect_success 'list contents of project_table before adding projects' '
-	flux account list-projects --table > project_table.test &&
+	flux account list-projects > project_table.test &&
 	cat <<-EOF >project_table.expected
 	project_id | project | usage
 	-----------+---------+------
@@ -157,7 +157,7 @@ test_expect_success 'reset the projects list for an association' '
 '
 
 test_expect_success 'list all of the projects currently registered in project_table' '
-	flux account list-projects --table > project_table.test &&
+	flux account list-projects > project_table.test &&
 	cat <<-EOF >project_table.expected
 	project_id | project   | usage
 	-----------+-----------+------


### PR DESCRIPTION
#### Problem

The `list-users` command outputs in a table format by default, which was discussed by multiple Flux developers to be the preferred default (see https://github.com/flux-framework/flux-accounting/pull/597). However, the rest of the `list-*` command outputs in JSON by default instead of in a table format.

---

This PR changes the default behavior for the `list-*` commands to output in a table format by default instead of JSON format to match the `list-users` command.

I've also adjusted tests and man pages to reflect the change in the behavior for these commands.