### PR TITLE
`.gitignore`: add files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ config/test-driver
 /aclocal.m4
 /configure
 /configure.scan
+configure~
 /stamp-h1
 
 # https://www.gnu.org/software/libtool/
@@ -79,3 +80,7 @@ config.status
 # docs intermediate files
 /doc/man*/*.xml
 /doc/_build
+
+# local editor config dirs
+.vscode
+.DS_Store

--- a/etc/.gitignore
+++ b/etc/.gitignore
@@ -1,0 +1,1 @@
+/flux-accounting.service


### PR DESCRIPTION
#### Problem

There are a number of files that are flagged by git as untracked files but can safely be ignored, such as editor-specific files and `.service` files in the `etc/` directory.

---

This PR adds these files to `.gitignore`.