### PR TITLE
github: upgrade codecov-action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,12 @@ jobs:
 
     - name: coverage report
       if: success() && matrix.coverage
-      run: DOCKER_REPO= bash <(curl -s https://codecov.io/bash)
+      env:
+        DOCKER_REPO:
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{matrix.coverage_flags}}
 
     - name: annotate errors
       if: failure() || cancelled()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: validate commits
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,6 @@
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \
 	t0000-sharness.t \


### PR DESCRIPTION
#### Problem

The flux-accounting `codecov` action is out-of-date and needs to be updated.

---

This PR upgrades the `codecov-action` to v5.