### PR TITLE
doc: add `man(1)` for project commands

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -26,7 +26,11 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-delete-queue.1 \
 	man1/flux-account-edit-queue.1 \
 	man1/flux-account-list-queues.1 \
-	man1/flux-account-list-users.1
+	man1/flux-account-list-users.1 \
+	man1/flux-account-add-project.1 \
+	man1/flux-account-view-project.1 \
+	man1/flux-account-delete-project.1 \
+	man1/flux-account-list-projects.1
 
 MAN5_FILES_PRIMARY = \
 	man5/flux-config-accounting.5

--- a/doc/man1/flux-account-add-project.rst
+++ b/doc/man1/flux-account-add-project.rst
@@ -1,0 +1,36 @@
+.. flux-help-section: flux account
+
+===========================
+flux-account-add-project(1)
+===========================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **add-project** PROJECT
+
+DESCRIPTION
+===========
+
+.. program:: flux account add-project
+
+:program:`flux account add-project` will add a new project to the
+``project_table`` in the flux-accounting database. Associations can reference
+these in their `projects` attribute, allowing them to charge specific projects
+at job submission.
+
+EXAMPLES
+--------
+
+To add a project, just specify a name:
+
+.. code-block:: console
+
+    $ flux account add-project my_project
+
+Then, associations can reference these projects:
+
+.. code-block:: console
+
+    $ flux account add-user --username=user1 --bank=A --projects=my_project

--- a/doc/man1/flux-account-delete-project.rst
+++ b/doc/man1/flux-account-delete-project.rst
@@ -1,0 +1,23 @@
+.. flux-help-section: flux account
+
+==============================
+flux-account-delete-project(1)
+==============================
+
+SYNOPSIS
+========
+
+**flux** **account** **delete-project** PROJECT
+
+DESCRIPTION
+===========
+
+.. program:: flux account delete-project
+
+:program:`flux account delete-project` will remove a project from the
+``project_table`` in the flux-accounting database. Note that removing a project
+from this table will not automatically remove any references to this project
+elsewhere in the flux-accounting DB, particularly the ``association_table``.
+If associations still reference this project, a ``WARNING`` message will be
+returned reminding the user to also remove this project from all associations'
+rows.

--- a/doc/man1/flux-account-list-projects.rst
+++ b/doc/man1/flux-account-list-projects.rst
@@ -1,0 +1,34 @@
+.. flux-help-section: flux account
+
+=============================
+flux-account-list-projects(1)
+=============================
+
+SYNOPSIS
+========
+
+**flux** **account** **list-projects**
+
+DESCRIPTION
+===========
+
+.. program:: flux account list-projects
+
+:program:`flux account list-projects` will list all of the projects in the
+``project_table``. By default, it will include every column in the
+``project_table``, but the output can be customized by specifying which columns
+to include.
+
+.. option:: --fields
+
+    A list of columns from the table to include in the output. By default, all
+    columns are included.
+
+.. option:: --json
+
+    Output data in JSON format. By default, the format of any returned data is
+    in a table format.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.

--- a/doc/man1/flux-account-view-project.rst
+++ b/doc/man1/flux-account-view-project.rst
@@ -1,0 +1,27 @@
+.. flux-help-section: flux account
+
+============================
+flux-account-view-project(1)
+============================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **view-project** PROJECT
+
+DESCRIPTION
+===========
+
+.. program:: flux account view-project
+
+:program:`flux account view-project` returns basic information about a project
+defined in the ``project_table``.
+
+.. option:: --parsable
+
+    Prints all information about the project on one line.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -157,4 +157,32 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-add-project",
+        "flux-account-add-project",
+        "add a project to the project_table",
+        [author],
+        1,
+    ),
+    (
+        "man1/flux-account-view-project",
+        "flux-account-view-project",
+        "view information about a project in the flux-accounting database",
+        [author],
+        1,
+    ),
+    (
+        "man1/flux-account-delete-project",
+        "flux-account-delete-project",
+        "delete a project from the flux-accounting database",
+        [author],
+        1,
+    ),
+    (
+        "man1/flux-account-list-projects",
+        "flux-account-list-projects",
+        "list all projects in the project_table",
+        [author],
+        1,
+    ),
 ]


### PR DESCRIPTION
#### Problem

There are no man pages for the various commands that deal with projects.

---

This PR adds `man(1)` pages for all of the commands that deal with projects.