### PR TITLE
NEWS: add release notes for v0.45.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+flux-accounting version 0.45.0 - 2025-05-21
+-------------------------------------------
+
+#### Fixes
+
+* bindings: remove redundant `try/except` blocks (#625)
+
+* `.gitignore`: add files to `.gitignore` (#627)
+
+* `list-*` commands: make table output default (#626)
+
+* `calc_usage_factor()`: add update of current usage when no new jobs are
+found in new half-life period (#630)
+
+* `update-usage`: fix usage aggregation in multi-level bank hierarchies (#632)
+
+* `update-usage`: add INFO-level logging (#628)
+
+* python: improve logger format in `update-usage`, create module-level logger
+in `create-db` (#633)
+
+#### Documentation
+
+* doc: add `man(1)` pages for project commands (#634)
+
+#### Testsuite
+
+* github: upgrade codecov-action to v5 (#629)
+
 flux-accounting version 0.44.0 - 2025-05-06
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.45.0`.

---

This PR adds some release notes. Once this lands, I'll create an annotated tag with the following:

```
git tag -a v0.45.0 -m "Tag v0.45.0" && git push upstream v0.45.0
```