### PR TITLE
doc: remove `jinja2 < 3.1.0` requirement

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,3 @@
 sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
-jinja2<3.1.0


### PR DESCRIPTION
#### Problem

GitHub dependabot is reporting moderate security vulnerabilities detected with `jinja2 < 3.1.4`, but flux-accounting has `jinja2 < 3.1.0` listed in its `requirements.txt` file.

---

Remove the `jinja2` version requirement from `requirements.txt`.