### PR TITLE
plugin: utilize `bank` priority when calculating priority for a job

### DIFF
--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -77,6 +77,7 @@ public:
     std::vector<Job> held_jobs;        // vector to keep track of held Jobs
     std::vector<std::string> queues;   // list of accessible queues
     int queue_factor;                  // priority factor associated with queue
+    double bank_factor;                // priority factor associated with bank
     int active;                        // active status
     std::vector<std::string> projects; // list of accessible projects
     std::string def_project;           // default project

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -107,9 +107,11 @@ int64_t priority_calculation (flux_plugin_t *p,
 
     fshare_factor = b->fairshare;
     queue_factor = b->queue_factor;
+    bank_factor = b->bank_factor;
 
     priority = round ((fshare_weight * fshare_factor) +
                       (queue_weight * queue_factor) +
+                      (bank_weight * bank_factor) +
                       (urgency - 16));
 
     if (priority < 0)
@@ -945,6 +947,8 @@ static int new_cb (flux_plugin_t *p,
 
     // assign priority associated with validated queue
     b->queue_factor = get_queue_info (queue, b->queues, queues);
+    // assign priority associated with validated bank
+    b->bank_factor = get_bank_priority (b->bank_name.c_str (), banks);
 
     max_run_jobs = b->max_run_jobs;
     cur_active_jobs = b->cur_active_jobs;
@@ -1215,6 +1219,9 @@ static int job_updated (flux_plugin_t *p,
         a = a_new;
         // update the active jobs count of the updated bank
         a->cur_active_jobs++;
+
+        // assign priority associated with validated bank
+        a->bank_factor = get_bank_priority (a->bank_name.c_str (), banks);
 
         // re-pack the updated Association object to the job
         if (flux_jobtap_job_aux_set (p,

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -52,6 +52,7 @@ void add_user_to_map (
         a.held_jobs,
         a.queues,
         a.queue_factor,
+        a.bank_factor,
         a.active,
         a.projects,
         a.def_project,
@@ -71,10 +72,10 @@ void initialize_map (
     std::map<int, std::map<std::string, Association>> &users)
 {
     Association user1 = {"bank_A", 0.5, 5, 0, 7, 0, {},
-                         {}, 0, 1, {"*"}, "*", 2147483647, 2147483647, 0, 0,
+                         {}, 0, 0.0, 1, {"*"}, "*", 2147483647, 2147483647, 0, 0,
                          {}};
     Association user2 = {"bank_A", 0.5, 5, 0, 7, 0, {},
-                         {}, 0, 1, {"*"}, "*", 2147483647, 2147483647, 0, 0,
+                         {}, 0, 0.0, 1, {"*"}, "*", 2147483647, 2147483647, 0, 0,
                          {}};
 
     add_user_to_map (users, 1001, "bank_A", user1);
@@ -300,7 +301,7 @@ static void test_check_map_dne_true ()
     users_def_bank.clear ();
 
     Association tmp_user = {"DNE", 0.5, 5, 0, 7, 0, {},
-                            {}, 0, 1, {"*"}, "*", 2147483647, 2147483647,
+                            {}, 0, 0.0, 1, {"*"}, "*", 2147483647, 2147483647,
                             0, 0, {}};
     add_user_to_map (users, 9999, "DNE", tmp_user);
     users_def_bank[9999] = "DNE";

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -56,6 +56,7 @@ TESTSCRIPTS = \
 	t1051-list-users.t \
 	t1052-mf-priority-queue-limits.t \
 	t1053-issue631.t \
+	t1054-mf-priority-bank-priorities.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1054-mf-priority-bank-priorities.t
+++ b/t/t1054-mf-priority-bank-priorities.t
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+test_description='test priority plugin bank priority factor'
+
+. `dirname $0`/sharness.sh
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+# Configure the banks in flux-accounting to have varying priorities. These
+# priorities will affect the overall priority for a job.
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root --priority=1 A 1 &&
+	flux account add-bank --parent-bank=root --priority=2 B 1 &&
+	flux account add-bank --parent-bank=root --priority=3.5 C 1
+'
+
+test_expect_success 'add three different associations' '
+	flux account add-user --username=user1 --userid=50001 --bank=A &&
+	flux account add-user --username=user1 --userid=50001 --bank=B &&
+	flux account add-user --username=user1 --userid=50001 --bank=C
+'
+
+test_expect_success 'send the user and queue information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+# Configuring the priority factor weights like the following will ensure that
+# *only* the "bank" factor will be used when calculating the priority for a
+# job, i.e.:
+#
+# 		priority = (bank_priority * bank_weight) = (bank_priority * 100)
+test_expect_success 'make "bank" the only factor in priority calculation' '
+	cat >config/test.toml <<-EOT &&
+	[accounting.factor-weights]
+	fairshare = 0
+	queue = 0
+	bank = 100
+	EOT
+	flux config reload
+'
+
+test_expect_success 'stop the queue' '
+	flux queue stop
+'
+
+# priority = (bank_priority * bank_weight) = (1 * 100) = 100
+test_expect_success 'submit a job to bank A' '
+	job1=$(flux python ${SUBMIT_AS} 50001 sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job1} priority \
+		| jq '.context.priority' > job1.priority &&
+	grep "100" job1.priority &&
+	flux cancel ${job1}
+'
+
+# priority = (bank_priority * bank_weight) = (2 * 100) = 200
+test_expect_success 'submit a job to bank B' '
+	job2=$(flux python ${SUBMIT_AS} 50001 -S bank=B sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job2} priority \
+		| jq '.context.priority' > job2.priority &&
+	grep "200" job2.priority &&
+	flux cancel ${job2}
+'
+
+# priority = (bank_priority * bank_weight) = (3.5 * 100) = 350
+test_expect_success 'submit a job to bank C' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -S bank=C sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job3} priority \
+		| jq '.context.priority' > job3.priority &&
+	grep "350" job3.priority
+'
+
+# If a pending job is updated to run under a different bank, there is chance
+# its priority could be affected. In this case, a job is updated to run under
+# bank B instead of bank C, and thus its priority decreases from 350 to 200.
+test_expect_success 'update the bank of the pending job and check priority' '
+	flux update ${job3} bank=B &&
+	flux job wait-event -vt 3 --match-context=attributes.system.bank=B \
+		${job3} jobspec-update &&
+	flux job info ${job3} eventlog > job3.updated_priority &&
+	grep "\"name\":\"priority\",\"context\":{\"priority\":200}" \
+		job3.updated_priority &&
+	flux cancel ${job3}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Banks can now have an associated floating-point priority assigned to them, but they are not utilized anywhere in the plugin.

---

This PR unpacks the priority associated with a bank and utilizes it when calculating the priority for a job. If the bank is updated while a job is still pending, the plugin will unpack the new associated priority and use it when re-calculating the overall priority for a job.

I've added a new set of tests that simulate submitting jobs under multiple banks with different priorities to showcase how a job's priority can be affected depending on how bank priorities are configured. There is also an example in there of a job's priority changing as the result of updating their bank while the job is still pending.

Fixes #642