### PR TITLE
doc: drop `sphinx < 6.0.0`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,2 @@
-sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18


### PR DESCRIPTION
#### Problem

The `requirements.txt` file for flux-accounting documentation requires `sphinx < 6.0.0`, but we would like to upgrade sphinx to the latest version.

---

This PR drops the `sphinx < 6.0.0` requirement.