### PR TITLE
doc: update docs with bank factor

### DIFF
--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -360,12 +360,15 @@ fair-share
 queue
   A configurable factor assigned to a queue.
 
+bank
+  A configurable factor assigned to a bank.
+
 urgency
   A user-controlled factor to prioritize their own jobs.
 
 Thus the priority :math:`P` is calculated as follows:
 
-:math:`P = (F_{fairshare} \times W_{fairshare}) + (F_{queue} \times W_{queue}) + (F_{urgency} - 16)`
+:math:`P = (F_{fairshare} \times W_{fairshare}) + (F_{queue} \times W_{queue}) + (F_{bank} \times W_{bank}) + (F_{urgency} - 16)`
 
 Each of these factors can be configured with a custom weight to increase their
 relevance to the final calculation of a job's integer priority. By default,
@@ -379,6 +382,7 @@ fair-share, you can adjust each factor's weight accordingly:
  [accounting.factor-weights]
  fairshare = 1000
  queue = 100000
+ bank = 500
 
 In addition to generating an integer priority for submitted jobs in a Flux
 system instance, the multi-factor priority plugin also enforces per-association

--- a/doc/man1/flux-account-add-bank.rst
+++ b/doc/man1/flux-account-add-bank.rst
@@ -24,6 +24,10 @@ configured when adding the bank.
 
     The name of the parent bank.
 
+.. option:: --priority
+
+    An associated priority to be applied to jobs submitted under this bank.
+
 EXAMPLES
 --------
 

--- a/doc/man1/flux-account-edit-bank.rst
+++ b/doc/man1/flux-account-edit-bank.rst
@@ -27,6 +27,10 @@ fields for a given bank. The list of modifiable fields are as follows:
     The amount of available resources their organization considers the bank 
     should be entitled to use relative to other competing banks.
 
+.. option:: --priority
+
+    An associated priority to be applied to jobs submitted under this bank.
+
 EXAMPLES
 --------
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -71,6 +71,9 @@ std::map<std::string, int> priority_weights;
  *
  * queue: a factor that can further affect the priority of a job based on the
  *     queue passed in.
+ *
+ * bank: a factor that can further affect the priority of a job based on the
+ *     bank the job is submitted under.
  */
 int64_t priority_calculation (flux_plugin_t *p,
                               flux_plugin_arg_t *args,


### PR DESCRIPTION
#### Problem

The docs are missing the addition of the bank factor, which was added in #643, #645, and #647.

---

This PR just updates the docs throughout flux-accounting to include the addition of the bank factor.