### PR TITLE
job-usage update: move update out of service and into own script

### DIFF
--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -179,7 +179,7 @@ The scripts should be run by :core:man1:`flux-cron`:
 
  # /etc/flux/system/cron.d/accounting
 
- 30 * * * * bash -c "flux account-fetch-job-records; flux account update-usage; flux account-update-fshare; flux account-priority-update"
+ 30 * * * * bash -c "flux account-fetch-job-records; flux account-update-usage; flux account-update-fshare; flux account-priority-update"
 
 Periodically fetching and storing job records in the flux-accounting database
 can cause the DB to grow large in size. Since there comes a point where job

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -162,4 +162,5 @@ dist_fluxcmd_SCRIPTS = \
 	cmd/flux-account-priority-update.py \
 	cmd/flux-account-update-db.py \
 	cmd/flux-account-service.py \
-	cmd/flux-account-fetch-job-records.py
+	cmd/flux-account-fetch-job-records.py \
+	cmd/flux-account-update-usage.py

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -38,6 +38,7 @@ def update_t_inactive(acct_conn, last_t_inactive, user, bank):
             bank,
         ),
     )
+    acct_conn.commit()
 
 
 def get_last_job_ts(acct_conn, user, bank):
@@ -95,6 +96,7 @@ def update_hist_usg_col(acct_conn, usg_h, user, bank):
             bank,
         ),
     )
+    acct_conn.commit()
 
 
 def update_curr_usg_col(acct_conn, usg_h, user, bank):
@@ -113,6 +115,7 @@ def update_curr_usg_col(acct_conn, usg_h, user, bank):
             bank,
         ),
     )
+    acct_conn.commit()
 
 
 def apply_decay_factor(decay, acct_conn, user=None, bank=None):
@@ -271,6 +274,7 @@ def check_end_hl(acct_conn, pdhl):
             WHERE cluster='cluster'
             """
         acct_conn.execute(update_timestamp_stmt, ((float(end_hl) + hl_period),))
+        acct_conn.commit()
 
 
 def calc_bank_usage(acct_conn, cur, bank):
@@ -294,6 +298,7 @@ def calc_bank_usage(acct_conn, cur, bank):
             bank,
         ),
     )
+    acct_conn.commit()
 
     return total_usage
 
@@ -318,6 +323,7 @@ def calc_parent_bank_usage(acct_conn, cur, bank):
     # update the usage for this bank itself
     u_job_usage = "UPDATE bank_table SET job_usage=? WHERE bank=?"
     cur.execute(u_job_usage, (total_usage, bank))
+    acct_conn.commit()
 
     return total_usage
 
@@ -327,8 +333,6 @@ def update_job_usage(acct_conn, pdhl=1):
         "beginning job-usage update for flux-accounting DB; "
         "slow response times may occur"
     )
-    # begin transaction for all of the updates in the DB
-    acct_conn.execute("BEGIN TRANSACTION")
 
     s_assoc = "SELECT username, bank, default_bank FROM association_table"
     cur = acct_conn.cursor()

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -105,7 +105,6 @@ class AccountingService:
             "add_bank",
             "delete_bank",
             "edit_bank",
-            "update_usage",
             "add_queue",
             "delete_queue",
             "edit_queue",
@@ -382,21 +381,6 @@ class AccountingService:
             handle.respond_error(
                 msg, 0, f"view-job-records: {type(exc).__name__}: {exc}"
             )
-
-    def update_usage(self, handle, watcher, msg, arg):
-        try:
-            val = jobs.update_job_usage(
-                self.conn,
-                msg.payload["priority_decay_half_life"],
-            )
-
-            payload = {"update_job_usage": val}
-
-            handle.respond(msg, payload)
-        except KeyError as exc:
-            handle.respond_error(msg, 0, f"update-usage: missing key in payload: {exc}")
-        except Exception as exc:
-            handle.respond_error(msg, 0, f"update-usage: {type(exc).__name__}: {exc}")
 
     def add_queue(self, handle, watcher, msg, arg):
         try:

--- a/src/cmd/flux-account-update-usage.py
+++ b/src/cmd/flux-account-update-usage.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import logging
+import sqlite3
+import argparse
+import sys
+import os
+
+import fluxacct.accounting
+from fluxacct.accounting import job_usage_calculation as job_usage
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s: %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+LOGGER = logging.getLogger(__name__)
+
+
+def set_db_loc(args):
+    path = args.path if args.path else fluxacct.accounting.DB_PATH
+
+    return path
+
+
+def est_sqlite_conn(path):
+    # try to open database file; will exit with -1 if database file not found
+    if not os.path.isfile(path):
+        print(f"Database file does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    db_uri = "file:" + path + "?mode=rw"
+    try:
+        conn = sqlite3.connect(db_uri, uri=True)
+        # set foreign keys constraint
+        conn.execute("PRAGMA foreign_keys = 1")
+    except sqlite3.OperationalError as exc:
+        print(f"Unable to open database file: {db_uri}", file=sys.stderr)
+        print(f"Exception: {exc}")
+        sys.exit(1)
+
+    return conn
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+        Description: Send a bulk update of user information from a
+        flux-accounting database to the multi-factor priority plugin.
+        """
+    )
+
+    parser.add_argument(
+        "-p", "--path", dest="path", help="specify location of database file"
+    )
+    parser.add_argument(
+        "--priority-decay-half-life",
+        default=1,
+        type=int,
+        help="number of weeks for a job's usage contribution to a half-life decay",
+        metavar="PRIORITY DECAY HALF LIFE",
+    )
+    args = parser.parse_args()
+
+    path = set_db_loc(args)
+    conn = est_sqlite_conn(path)
+
+    job_usage.update_job_usage(conn, args.priority_decay_half_life)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -33,7 +33,7 @@ test_expect_success 'create hierarchy output from t_small_no_tie.db' '
 '
 
 test_expect_success 'run update fshare script - small_no_tie.db' '
-	flux account update-usage &&
+	flux account-update-usage -p $(pwd)/t_small_no_tie.db &&
 	flux account-update-fshare -p $(pwd)/t_small_no_tie.db
 '
 
@@ -50,7 +50,7 @@ test_expect_success 'update usage column in t_small_no_tie.db' '
 '
 
 test_expect_success 'run update fshare script - small_no_tie.db' '
-	flux account update-usage &&
+	flux account-update-usage -p $(pwd)/t_small_no_tie.db &&
 	flux account-update-fshare -p $(pwd)/t_small_no_tie.db
 '
 

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -55,7 +55,7 @@ test_expect_success 'submit a job that does not run' '
 
 test_expect_success 'run scripts to update job usage and fair-share' '
 	flux account-fetch-job-records -p ${DB_PATH} &&
-	flux account -p ${DB_PATH} update-usage &&
+	flux account-update-usage -p ${DB_PATH} &&
 	flux account-update-fshare -p ${DB_PATH}
 '
 
@@ -108,7 +108,7 @@ test_expect_success 'view job records for a user and direct it to a file' '
 '
 
 test_expect_success 'run update-usage and update-fshare commands' '
-	flux account -p ${DB_PATH} update-usage &&
+	flux account-update-usage -p ${DB_PATH} &&
 	flux account-update-fshare -p ${DB_PATH}
 '
 
@@ -131,7 +131,7 @@ test_expect_success 'run custom job-list script' '
 '
 
 test_expect_success 'run update-usage and update-fshare commands' '
-	flux account -p ${DB_PATH} update-usage &&
+	flux account-update-usage -p ${DB_PATH} &&
 	flux account-update-fshare -p ${DB_PATH}
 '
 
@@ -145,7 +145,7 @@ test_expect_success 'check that job usage and fairshare values get updated' '
 # for a user, their job usage factor should not be affected; this test is taken
 # from the set of job-archive interface Python unit tests
 test_expect_success 'call update-usage in the same half-life period where no jobs are run' '
-	flux account -p ${DB_PATH} update-usage &&
+	flux account-update-usage -p ${DB_PATH} &&
 	flux account-update-fshare -p ${DB_PATH} &&
 	flux account -p ${DB_PATH} view-user $username > query2.json &&
 	test_debug "jq -S . <query2.json" &&

--- a/t/t1026-flux-account-perms.t
+++ b/t/t1026-flux-account-perms.t
@@ -74,15 +74,6 @@ test_expect_success 'edit-bank should not be accessible by all users' '
 	)
 '
 
-test_expect_success 'update-usage should not be accessible by all users' '
-	newid=$(($(id -u)+1)) &&
-	( export FLUX_HANDLE_ROLEMASK=0x2 &&
-	  export FLUX_HANDLE_USERID=$newid &&
-		test_must_fail flux account update-usage > no_access_update-usage.out 2>&1 &&
-		grep "Request requires owner credentials" no_access_update-usage.out
-	)
-'
-
 test_expect_success 'add-queue should not be accessible by all users' '
 	newid=$(($(id -u)+1)) &&
 	( export FLUX_HANDLE_ROLEMASK=0x2 &&

--- a/t/t1036-hierarchy-small-no-tie-db.t
+++ b/t/t1036-hierarchy-small-no-tie-db.t
@@ -44,7 +44,7 @@ test_expect_success 'update usage and fair-share for the users/banks' '
 	flux python ${UPDATE_USAGE} ${SMALL_NO_TIE} leaf.2.2 3 &&
 	flux python ${UPDATE_USAGE} ${SMALL_NO_TIE} leaf.3.1 0 &&
 	flux python ${UPDATE_USAGE} ${SMALL_NO_TIE} leaf.3.2 1 &&
-	flux account update-usage &&
+	flux account-update-usage -p ${SMALL_NO_TIE} &&
 	flux account-update-fshare -p ${SMALL_NO_TIE}
 '
 

--- a/t/t1037-hierarchy-small-tie-db.t
+++ b/t/t1037-hierarchy-small-tie-db.t
@@ -45,7 +45,7 @@ test_expect_success 'update usage and fair-share for the users/banks' '
 	flux python ${UPDATE_USAGE} ${SMALL_TIE} leaf.2.2 1 &&
 	flux python ${UPDATE_USAGE} ${SMALL_TIE} leaf.2.3 1 &&
 	flux python ${UPDATE_USAGE} ${SMALL_TIE} leaf.3.2 1 &&
-	flux account update-usage &&
+	flux account-update-usage -p ${SMALL_TIE} &&
 	flux account-update-fshare -p ${SMALL_TIE}
 '
 

--- a/t/t1038-hierarchy-small-tie-all-db.t
+++ b/t/t1038-hierarchy-small-tie-all-db.t
@@ -48,7 +48,7 @@ test_expect_success 'update usage and fair-share for the users/banks' '
 	flux python ${UPDATE_USAGE} ${SMALL_TIE_ALL} leaf.3.1 1000 &&
 	flux python ${UPDATE_USAGE} ${SMALL_TIE_ALL} leaf.3.2 100 &&
 	flux python ${UPDATE_USAGE} ${SMALL_TIE_ALL} leaf.3.3 100 &&
-	flux account update-usage &&
+	flux account-update-usage -p ${SMALL_TIE_ALL} &&
 	flux account-update-fshare -p ${SMALL_TIE_ALL}
 '
 

--- a/t/t1049-issue580.t
+++ b/t/t1049-issue580.t
@@ -29,7 +29,7 @@ test_expect_success 'add users/banks to DB' '
 
 test_expect_success 'update usage and fair-share for the users/banks' '
 	flux python ${UPDATE_USAGE} ${TEST_DB} leaf.1.1 19115069644.16
-	flux account update-usage
+	flux account-update-usage -p ${TEST_DB}
 '
 
 test_expect_success 'ensure update-fshare works with a huge job usage value' '

--- a/t/t1053-issue631.t
+++ b/t/t1053-issue631.t
@@ -70,7 +70,7 @@ test_expect_success 'edit job usage for associations in bank E (total usage = 10
 '
 
 test_expect_success 'call update-usage, update-fshare' '
-	flux account update-usage &&
+	flux account-update-usage -p ${DB_PATH} &&
 	flux account-update-fshare -p ${DB_PATH}
 '
 


### PR DESCRIPTION
#### Problem

As mentioned in #655, the `update-usage` command is a part of the flux-accounting service, which means that when it is running (especially on a large flux-accounting DB that can take a lot of time), it will halt the execution of other flux-accounting commands (even ones that just read from the DB) until the `update-usage` command finishes running. This command should be moved to its own script that establishes a separate connection to the DB so other flux-accounting commands can run while job usage values are being updated.

---

This PR creates a new Python command script in the `src/cmd/` directory called `flux-account-update-usage.py`, a script that will just call `update_job_usage()`, pretty much exactly similar to what the `update-usage` command in the flux-accounting service was doing. 

As a result, the `update-usage` command is removed from the flux-accounting service and both the testsuite and the documentation have been updated to reflect the new change (i.e. calling `flux account-update-usage` instead of `flux account update-usage`).