### PR TITLE
doc: add new "Limits" page

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -93,6 +93,7 @@ EXTRA_DIST = \
 	components/fair-share.rst \
 	components/job-usage-calculation.rst \
 	components/projects.rst \
+	components/limits.rst \
 	$(RST_FILES) \
 	man1/index.rst
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -87,6 +87,12 @@ EXTRA_DIST = \
 	domainrefs.py \
 	requirements.txt \
 	guide/accounting-guide.rst \
+	guide/sanity-checklist.rst \
+	guide/images/lgplv3-147x51.png \
+	components/database-administration.rst \
+	components/fair-share.rst \
+	components/job-usage-calculation.rst \
+	components/projects.rst \
 	$(RST_FILES) \
 	man1/index.rst
 

--- a/doc/components/limits.rst
+++ b/doc/components/limits.rst
@@ -1,0 +1,104 @@
+.. _limits:
+
+######
+Limits
+######
+
+********
+Overview
+********
+
+The multi-factor priority plugin in flux-accounting not only performs
+validation for associations and priority calculation for jobs; it can also
+administer and enforce limits on a per-association and per-queue basis. Limits
+are another way to ensure fair behavior of systems that see a lot of
+simultaneous activity from a large number of users.
+
+Hard Limits vs. Soft Limits
+===========================
+
+There are two different kinds of limits in flux-accounting: **hard limits** and
+**soft limits**. Hard limits will prevent an association from submitting a job
+altogether and will report a message as to why the job cannot proceed past
+validation. Soft limits will allow a job to be submitted but will prevent it
+from running until a prerequisite has been met.
+
+There is just one hard limit in flux-accounting:
+
+(per-association) max active jobs
+  The max number of active jobs an association can have at any given time.
+
+The soft limits in flux-accounting are composed of:
+
+(per-association) max running jobs
+  The max number of running jobs an association can have at any given time.
+
+(per-association) max resources
+  The max number of resources (total cores + total nodes) an association can
+  have across their running jobs at any given time.
+
+(per-queue) max running jobs
+  The max number of running jobs an association can have in a given queue at
+  any given time.
+
+.. note::
+    For more details on the difference between an active job and a running job,
+    see the `virtual states`_ section of RFC 21.
+
+An example
+==========
+
+The difference between hard and soft limits might be best described by example.
+Let's configure an association to have a limit configuration of at most 1
+running job and 2 active jobs:
+
+.. code-block:: console
+
+    $ flux account add-user --username=buster --bank=giants --max-running-jobs=1 --max-active-jobs=2
+
+``buster`` can submit a job and the priority plugin will generate a priority
+for this job and pass it on to the scheduler to begin running. If ``buster``
+submits a second job while the first one is running, this second job will be
+held until the first job completes. Specifically, a dependency_ will be added
+to the job to hold it in the ``DEPEND`` state until the first job has
+transitioned to the ``INACTIVE`` state. The name of the dependency can be found
+in the job's eventlog:
+
+.. code-block:: console
+
+    $ flux job eventlog JOBID
+    dependency-add description="max-resources-user-limit"
+
+After the first job has transitioned to ``INACTIVE``, the dependency will be
+removed and the job can proceed to have its priority calculated and move on to
+the scheduler to be run:
+
+.. code-block:: console
+
+    dependency-remove description="max-resources-user-limit"
+    depend
+    priority priority=50000
+    alloc annotations={"sched":{"resource_summary":"rank0/core[0-1]"}}
+
+If ``buster`` submits a *third* job while the first job is still running and
+the second job is waiting in ``DEPEND``, it will be rejected due to the
+association's max active jobs limit:
+
+.. code-block:: console
+
+    $ flux submit my_job
+    flux-job: user has max active jobs
+
+These limits can be configured and modified after an association or a queue
+has been created in flux-accounting with the ``edit-user`` and ``edit-queue``
+commands. After modifying limits for either an association or a queue, be sure
+to update the priority plugin with the new data written to the flux-accounting
+database:
+
+.. code-block:: console
+
+    $ flux account-priority-update
+
+.. _virtual states: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_21.html#virtual-states
+
+.. _dependency: https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/troubleshooting.html#job-dependencies

--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -384,23 +384,13 @@ fair-share, you can adjust each factor's weight accordingly:
  $ flux account edit-factor --factor=bank --weight=500
  $ flux account-priority-update
 
+Limits
+======
+
 In addition to generating an integer priority for submitted jobs in a Flux
-system instance, the multi-factor priority plugin also enforces per-association
-job limits to regulate use of the system. The two per-association limits
-enforced by this plugin are:
-
-* **max_active_jobs**: a limit on how many *active* jobs an association can have at
-  any given time. Jobs submitted after this limit has been hit will be rejected
-  with a message saying that the association has hit their active jobs limit.
-
-* **max_running_jobs**: a limit on how many *running* jobs an association can have
-  at any given time. Jobs submitted after this limit has been hit will be held
-  by adding a ``max-running-jobs-user-limit`` dependency until one of the
-  association's currently running jobs finishes running.
-
-Both "types" of jobs, *running* and *active*, are based on Flux's definitions
-of job states_. *Active* jobs can be in any state but INACTIVE. *Running* jobs
-are jobs in either RUN or CLEANUP states.
+system instance, the multi-factor priority plugin also enforces various limits
+to regulate use of the system. For more details on the types of limits and how
+they are enforced, see :doc:`../components/limits`.
 
 Queue Permissions Configuration
 ===============================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,4 +17,5 @@ Table of Contents
    components/fair-share
    components/job-usage-calculation
    components/projects
+   components/limits
    index_man


### PR DESCRIPTION
####  Problem

There is a little description in the flux-accounting guide about on limits in the priority plugin, but it is incomplete (it is
missing the max resources per-association limit) and could use some more explanation and perhaps an example.

---

This PR adds a new page to the flux-accounting docs about how limits work in flux-accounting. It provides an example on the difference between soft limits and hard limits and creates a reference to the new "Limits" page in the flux-accounting guide.

Fixes #666 