### PR TITLE
doc: add `man(1)` pages for priority factor commands

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -29,7 +29,11 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-add-project.1 \
 	man1/flux-account-view-project.1 \
 	man1/flux-account-delete-project.1 \
-	man1/flux-account-list-projects.1
+	man1/flux-account-list-projects.1 \
+	man1/flux-account-view-factor.1 \
+	man1/flux-account-edit-factor.1 \
+	man1/flux-account-list-factors.1 \
+	man1/flux-account-reset-factors.1
 
 RST_FILES  = \
 	$(MAN1_FILES_PRIMARY:.1=.rst)

--- a/doc/man1/flux-account-edit-factor.rst
+++ b/doc/man1/flux-account-edit-factor.rst
@@ -1,0 +1,26 @@
+.. flux-help-section: flux account
+
+===========================
+flux-account-edit-factor(1)
+===========================
+
+SYNOPSIS
+========
+
+**flux** **account** **edit-factor** --factor=FACTOR --weight=WEIGHT
+
+DESCRIPTION
+===========
+
+.. program:: flux account edit-factor
+
+:program:`flux account edit-factor` will change the the configured weight for a
+given priority factor. The weight passed in must be an integer.
+
+.. option:: --factor
+
+    The name of the factor being configured.
+
+.. option:: --weight
+
+    The integer weight associated with the priority factor.

--- a/doc/man1/flux-account-list-factors.rst
+++ b/doc/man1/flux-account-list-factors.rst
@@ -1,0 +1,34 @@
+.. flux-help-section: flux account
+
+============================
+flux-account-list-factors(1)
+============================
+
+SYNOPSIS
+========
+
+**flux** **account** **list-factors** FACTOR
+
+DESCRIPTION
+===========
+
+.. program:: flux account list-factors
+
+:program:`flux account list-factors` will list all of the priority factors in
+the ``priority_factor_weight_table``. By default, it will include every column
+in the ``priority_factor_weight_table``, but the output can be customized by
+specifying which columns to include.
+
+.. option:: --fields
+
+    A list of columns from the table to include in the output. By default, all
+    columns are included.
+
+.. option:: --json
+
+    Output data in JSON format. By default, the format of any returned data is
+    in a table format.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.

--- a/doc/man1/flux-account-reset-factors.rst
+++ b/doc/man1/flux-account-reset-factors.rst
@@ -1,0 +1,18 @@
+.. flux-help-section: flux account
+
+=============================
+flux-account-reset-factors(1)
+=============================
+
+SYNOPSIS
+========
+
+**flux** **account** **reset-factors**
+
+DESCRIPTION
+===========
+
+.. program:: flux account reset-factors
+
+:program:`flux account reset-factors` will reset all of the priority factors to
+their default weights.

--- a/doc/man1/flux-account-view-factor.rst
+++ b/doc/man1/flux-account-view-factor.rst
@@ -1,0 +1,27 @@
+.. flux-help-section: flux account
+
+===========================
+flux-account-view-factor(1)
+===========================
+
+SYNOPSIS
+========
+
+**flux** **account** **view-factor** FACTOR [OPTIONS]
+
+DESCRIPTION
+===========
+
+.. program:: flux account view-factor
+
+:program:`flux account view-factor` will list the configured integer weight
+for a given priority factor.
+
+.. option:: --json
+
+    Output data in JSON format. By default, the format of any returned data is
+    in a table format.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.

--- a/doc/man1/flux-account.rst
+++ b/doc/man1/flux-account.rst
@@ -178,3 +178,34 @@ update-usage
 
 scrub-old-jobs
 ^^^^^^^^^^^^^^
+
+JOB PRIORITY CONFIGURATION
+==========================
+
+view-factor
+^^^^^^^^^^^
+
+View the configured integer weight for a given priority factor.
+
+See :man1:`flux-account-view-factor` for more details.
+
+edit-factor
+^^^^^^^^^^^
+
+Edit the configured integer weight for a given priority factor.
+
+See :man1:`flux-account-edit-factor` for more details.
+
+list-factors
+^^^^^^^^^^^^
+
+List all of the priority factors and their weights.
+
+See :man1:`flux-account-list-factors` for more details.
+
+reset-factors
+^^^^^^^^^^^^^
+
+Reset all of the priority factors to their default weights.
+
+See :man1:`flux-account-reset-factors` for more details.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -178,4 +178,32 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-view-factor",
+        "flux-account-view-factor",
+        "view the configured integer weight for a given priority factor",
+        [author],
+        1,
+    ),
+    (
+        "man1/flux-account-edit-factor",
+        "flux-account-edit-factor",
+        "edit the configured integer weight for a given priority factor",
+        [author],
+        1,
+    ),
+    (
+        "man1/flux-account-list-factors",
+        "flux-account-list-factors",
+        "list all of the priority factors and their weights",
+        [author],
+        1,
+    ),
+    (
+        "man1/flux-account-reset-factors",
+        "flux-account-reset-factors",
+        "reset all of the priority factors to their default weights",
+        [author],
+        1,
+    ),
 ]


### PR DESCRIPTION
#### Problem

There are no man pages for the commands that deal with viewing and modifying the priority factors in the flux-accounting database.

---

This PR adds `man(1)` pages for all of the commands that deal with viewing and modifying priority factor weights.

Fixes #664