### PR TITLE
commands: add new `jobs` command to view priority breakdowns of jobs

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -94,6 +94,7 @@ EXTRA_DIST = \
 	components/job-usage-calculation.rst \
 	components/projects.rst \
 	components/limits.rst \
+	components/job-priorities.rst \
 	$(RST_FILES) \
 	man1/index.rst
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -33,7 +33,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-view-factor.1 \
 	man1/flux-account-edit-factor.1 \
 	man1/flux-account-list-factors.1 \
-	man1/flux-account-reset-factors.1
+	man1/flux-account-reset-factors.1 \
+	man1/flux-account-jobs.1
 
 RST_FILES  = \
 	$(MAN1_FILES_PRIMARY:.1=.rst)

--- a/doc/components/job-priorities.rst
+++ b/doc/components/job-priorities.rst
@@ -1,0 +1,240 @@
+.. _job-priorities:
+
+##############
+Job Priorities
+##############
+
+********
+Overview
+********
+
+Job priorities in flux-accounting are an integer value that represent how
+important a job is. Priorities can range from 0 to 4294967295, where the higher
+the number, the higher the priority the job is. Priorities are calculated as a
+result of a number of different factors that all play a varying level of
+importance. In this document, we will explain the factors that contribute to
+the calculation of a job's priority as well as how to customize how job
+priority is calculated.
+
+************************
+The Priority Calculation
+************************
+
+As mentioned in the :doc:`../guide/accounting-guide`, the priority plugin
+generates an integer priority for incoming jobs using a number of factors. Each
+factor :math:`F` has an associated integer weight :math:`W` that determines its
+importance in the overall priority calculation. A job's priority :math:`P` can
+be represented as:
+
+.. math::
+
+  P = (F_{fairshare} \times W_{fairshare})
+      + (F_{queue} \times W_{queue})
+      + (F_{bank} \times W_{bank})
+      + ((F_{urgency} - 16) \times W_{urgency})
+
+The current factors represented in the priority equation described above are:
+
+fair-share
+  The ratio between the amount of resources allocated vs. resources
+  consumed. See the :ref:`Glossary definition <glossary-section>` for a more
+  detailed explanation of how fair-share is utilized within flux-accounting.
+
+queue
+  A configurable factor assigned to a queue.
+
+bank
+  A configurable factor assigned to a bank.
+
+urgency
+  A user-controlled factor to prioritize their own jobs.
+
+Each of these factors can be configured with a custom weight to increase their
+relevance to the final calculation of a job's integer priority. By default,
+each factor has the following weight:
+
++------------+---------+
+| factor     | weight  |
++============+=========+
+| fair-share | 100000  |
++------------+---------+
+| queue      | 10000   |
++------------+---------+
+| bank       | 0       |
++------------+---------+
+| urgency    | 1000    |
++------------+---------+
+
+These can be modified to change how a job's priority is calculated. For
+example, if you wanted the queue to be more of a factor than fair-share, you
+can adjust each factor's weight accordingly:
+
+.. code-block:: console
+
+    $ flux account edit-factor --factor=fairshare --weight=1000
+    $ flux account edit-factor --factor=queue --weight=100000
+    $ flux account edit-factor --factor=bank --weight=500
+    $ flux account-priority-update
+
+An example
+==========
+
+Let's say an association is running a job for the first time to a queue and
+bank that have no effect on the job's priority. Then, the calculation for this
+job's priority becomes very straightforward:
+
+.. math::
+
+    P = (F_{fairshare} \times W_{fairshare})
+      + (F_{queue} \times W_{queue})
+      + (F_{bank} \times W_{bank})
+      + (W_{urgency} \times (F_{urgency} - 16))
+
+.. math::
+    P = (0.5 \times 100000)
+      + (0 \times 10000)
+      + (0 \times 0)
+      + (1000 \times (16 - 16))
+
+.. math::
+    P = 50000 + 0 + 0 + 0
+
+.. math::
+    P = 50000
+
+As the association continues to submit more jobs and their (along with other
+members of their bank) usage of the system increases, their fair-share value
+will reflect this usage and positively or negatively affect future job
+priorities.
+
+.. note::
+    For a more detailed description on how fair-share is calculated, see
+    :doc:`fair-share`.
+
+**********************************
+Configuring Other Priority Factors
+**********************************
+
+To further refine how other factors, such as the bank and/or queue the
+association is submitting jobs under, contribute to a job's resulting priority,
+specific priority values can be assigned to each individual bank and/or queue.
+
+An example
+==========
+
+Let's create the following flux-accounting bank hierarchy: below the ``root``
+bank there are three sub banks which hold associations: ``A``, ``B``, and
+``C``:
+
+.. code-block:: text
+
+    root
+    ├── A
+    │   ├── user1
+    │   └── user2
+    ├── B
+    │   ├── user3
+    │   └── user4
+    └── C
+        ├── user2
+        └── user5
+
+And each bank is configured to have a different priority associated with it,
+where bank ``A`` is the most important and bank ``C`` is the least important:
+
+.. code-block:: console
+
+    $ flux account edit-bank A --priority=300
+    $ flux account edit-bank B --priority=100
+    $ flux account edit-bank C --priority=-5
+
+And the ``bank`` factor is configured to have a weight :math:`> 0`:
+
+.. code-block:: console
+
+    $ flux account edit-factor --factor=bank --weight=10
+
+If ``user2`` has equivalent fair-share values in both banks ``A`` and ``C`` and
+submits jobs under both banks, each job will end up with significantly
+different priorities:
+
+.. math::
+    P_{job\_A} = (0.5 \times 100000)
+      + (0 \times 10000)
+      + (300 \times 10)
+      + (1000 \times (16 - 16))
+
+.. math::
+    P_{job\_A} = 50000 + 0 + 3000 + 0
+
+.. math::
+    P_{job\_A} = 53000
+
+.. math::
+    P_{job\_C} = (0.5 \times 100000)
+      + (0 \times 10000)
+      + (300 \times -5)
+      + (1000 \times (16 - 16))
+
+.. math::
+    P_{job\_C} = 50000 + 0 - 1500 + 0
+
+.. math::
+    P_{job\_C} = 48500
+
+The same principle can be configured to queues, resulting in a multivariate
+equation that considers multiple factors when calculating the priority for a
+job.
+
+**********************
+Viewing Job Priorities
+**********************
+
+On a system with many associations, banks, and queues, it could become
+difficult and somewhat tedious to have to reverse engineer how a priority for a
+particular job has been calculated, especially if flux-accounting has been
+running for an extended period of time, associations have weeks worth of usage
+contributing to their fair-share values, some banks are getting more usage than
+others, etc. So, flux-accounting provides a way to view a breakdown of the way
+a job's priority was calculated on the command line.
+
+``flux account jobs`` will output a breakdown of the various components that
+factored into a job's priority for a given user. Options can be passed to filter
+jobs submitted under a particular bank or a particular queue.
+
+.. note::
+    For more details on usage of the ``flux account jobs`` command, see
+    :man1:`flux-account-jobs`.
+
+An example
+==========
+
+Let's imagine a flux-accounting database configured to have an association
+``bonds`` submitting a job under a bank ``A`` with priority :math:`100` and
+queue ``bronze`` with priority :math:`1`. In this scenario, banks are
+configured to contribute to a job's priority calculation with a factor of
+:math:`1000`. So, the job priority calculation for a job :math:`P` becomes:
+
+.. math::
+
+    P = (F_{fairshare} \times 100000)
+      + (F_{queue} \times 10000)
+      + (F_{bank} \times 1000)
+      + (1000 \times (F_{urgency} - 16))
+  
+To view a breakdown of this job's priority, simply run
+``flux account jobs bonds``:
+
+.. code-block:: console
+
+    $ flux account jobs bonds
+    JOBID          USER     BANK    BANKPRIO  BANKFACT  QUEUE   QPRIO  QFACT  FAIRSHARE FSFACTOR  URGENCY URGFACT PRIORITY
+    fnYtwBV        bonds    A       100.0     1000      bronze  1      10000  0.5       100000    16      1000    160000 
+
+.. warning::
+    Changing priority factor weights could result in inaccurate breakdowns of
+    job priorities that were calculated using different factor weights (such as
+    jobs that have already been submitted and are running or jobs that have
+    already completed). This is because the ``jobs`` command pulls the *latest*
+    factor weights from the flux-accounting database, which could have been
+    updated since the time a job was submitted.

--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -346,61 +346,14 @@ Multi-Factor Priority Plugin
 ****************************
 
 The multi-factor priority plugin is a jobtap_ plugin that generates
-an integer job priority for incoming jobs in a Flux system instance. It uses
-a number of factors to calculate a priority and, in the future, can add more
-factors. Each factor :math:`F` has an associated integer weight :math:`W`
-that determines its importance in the overall priority calculation. The
-current factors present in the multi-factor priority plugin are:
+an integer job priority for incoming jobs in a Flux system instance. 
 
-fair-share
-  The ratio between the amount of resources allocated vs. resources
-  consumed. See the :ref:`Glossary definition <glossary-section>` for a more
-  detailed explanation of how fair-share is utilized within flux-accounting.
+Priority Calculation
+====================
 
-queue
-  A configurable factor assigned to a queue.
-
-bank
-  A configurable factor assigned to a bank.
-
-urgency
-  A user-controlled factor to prioritize their own jobs.
-
-Thus the priority :math:`P` is calculated as follows:
-
-.. math::
-
-  P = (F_{fairshare} \times W_{fairshare})
-      + (F_{queue} \times W_{queue})
-      + (F_{bank} \times W_{bank})
-      + ((F_{urgency} - 16) \times W_{urgency})
-
-Each of these factors can be configured with a custom weight to increase their
-relevance to the final calculation of a job's integer priority. By default,
-each factor has the following weight:
-
-+------------+---------+
-| factor     | weight  |
-+============+=========+
-| fair-share | 100000  |
-+------------+---------+
-| queue      | 10000   |
-+------------+---------+
-| bank       | 0       |
-+------------+---------+
-| urgency    | 1000    |
-+------------+---------+
-
-These can be modified to change how a job's priority is calculated. For
-example, if you wanted the queue to be more of a factor than fair-share, you
-can adjust each factor's weight accordingly:
-
-.. code-block:: console
-
- $ flux account edit-factor --factor=fairshare --weight=1000
- $ flux account edit-factor --factor=queue --weight=100000
- $ flux account edit-factor --factor=bank --weight=500
- $ flux account-priority-update
+It uses a number of factors to calculate a priority and, in the future, can add
+more factors. For more details on how job priorities are calculated, see
+:doc:`../components/job-priorities`.
 
 Limits
 ======

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,4 +18,5 @@ Table of Contents
    components/job-usage-calculation
    components/projects
    components/limits
+   components/job-priorities
    index_man

--- a/doc/man1/flux-account-jobs.rst
+++ b/doc/man1/flux-account-jobs.rst
@@ -1,0 +1,31 @@
+.. flux-help-section: flux account
+
+====================
+flux-account-jobs(1)
+====================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **jobs** USERNAME [OPTIONS]
+
+DESCRIPTION
+===========
+
+.. program:: flux account jobs
+
+:program:`flux account jobs` will output a breakdown of an association's job's
+priority calculations. Jobs can be filtered by bank or by queue.
+
+.. option:: --bank
+
+    Filter to only output jobs that have run under a specific bank.
+
+.. option:: --queue
+
+    Filter to only output jobs that have run under a specific queue.
+
+.. option:: -o/--format
+
+    Specify output format using Python's string format syntax.

--- a/doc/man1/flux-account.rst
+++ b/doc/man1/flux-account.rst
@@ -209,3 +209,10 @@ reset-factors
 Reset all of the priority factors to their default weights.
 
 See :man1:`flux-account-reset-factors` for more details.
+
+jobs
+^^^^
+
+View a breakdown of an association's job priorities.
+
+See :man1:`flux-account-jobs` for more details.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -206,4 +206,11 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-jobs",
+        "flux-account-jobs",
+        "view a breakdown of an association's job priorities",
+        [author],
+        1,
+    ),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -546,3 +546,4 @@ ParentBank
 UserID
 bankA
 parsable
+fnYtwBV

--- a/src/bindings/python/fluxacct/accounting/priorities.py
+++ b/src/bindings/python/fluxacct/accounting/priorities.py
@@ -9,9 +9,184 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
+import json
+
+import flux
+from flux.job.JobID import JobID
 import fluxacct.accounting
 from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import sql_util as sql
+
+###############################################################
+#                                                             #
+#                          Classes                            #
+#                                                             #
+###############################################################
+class Association:
+    """
+    An association (a tuple of username+bank) in the flux-accounting DB.
+    Args:
+        username: the username of the association.
+        bank: the name of the bank of the association.
+        fairshare: the association's fair-share value.
+    """
+
+    def __init__(self, username, bank, fairshare):
+        self.username = username
+        self.bank = bank
+        self.fairshare = fairshare
+
+
+class Bank:
+    """
+    A bank in the flux-accounting DB.
+    Args:
+        name: the name of the bank.
+        priority: the priority associated with the bank.
+    """
+
+    def __init__(self, name, priority):
+        self.name = name
+        self.priority = priority
+
+
+class Queue:
+    """
+    A queue in the flux-accounting DB.
+    Args:
+        name: the name of the queue.
+        priority: the priority associated with the queue.
+    """
+
+    def __init__(self, name, priority):
+        self.name = name
+        self.priority = priority
+
+
+###############################################################
+#                                                             #
+#                     Helper Functions                        #
+#                                                             #
+###############################################################
+def initialize_associations(cur, username, bank=None):
+    """
+    Create Association objects to be used when generating output for the
+    "jobs" command.
+
+    Args:
+        cur: A SQLite Cursor object used to execute a query.
+        username: The username of the association.
+        bank: The bank name of the association. If no bank is specified, the
+            query will fetch every association that has the specified username.
+    """
+    associations = {}
+    s_assocs = "SELECT username,bank,fairshare FROM association_table WHERE username=?"
+
+    if bank is not None:
+        s_assocs += " AND bank=?"
+        cur.execute(
+            s_assocs,
+            (
+                username,
+                bank,
+            ),
+        )
+    else:
+        cur.execute(s_assocs, (username,))
+
+    result = cur.fetchall()
+    if not result:
+        raise ValueError(f"could not find entry for {username} in association_table")
+
+    for row in result:
+        associations[(row["username"], row["bank"])] = Association(
+            username=row["username"], bank=row["bank"], fairshare=row["fairshare"]
+        )
+
+    return associations
+
+
+def initialize_banks(cur, bank=None):
+    """
+    Create Bank objects to be used when generating output for the "jobs"
+    command.
+
+    Args:
+        cur: A SQLite Cursor object used to execute a query.
+        bank: The bank name. If no bank is specified, the query will fetch
+            every bank and its associated priority.
+    """
+    banks = {}
+    s_bank_prio = "SELECT bank,priority FROM bank_table"
+
+    if bank is not None:
+        s_bank_prio += " WHERE bank=?"
+        cur.execute(s_bank_prio, (bank,))
+    else:
+        cur.execute(s_bank_prio)
+
+    result = cur.fetchall()
+    if not result:
+        raise ValueError(f"could not find entry for {bank} in bank_table")
+
+    for row in result:
+        banks[row["bank"]] = Bank(name=row["bank"], priority=row["priority"])
+
+    return banks
+
+
+def initialize_queues(cur, queue=None):
+    """
+    Create Queue objects to be used when generating output for the "jobs"
+    command.
+
+    Args:
+        cur: A SQLite Cursor object used to execute a query.
+        queue: The queue name. If no queue is specified, the query will fetch
+            every queue and its associated priority.
+    """
+    queues = {}
+    s_queue_prio = "SELECT queue,priority FROM queue_table"
+
+    if queue is not None:
+        s_queue_prio += " WHERE queue=?"
+        cur.execute(s_queue_prio, (queue,))
+    else:
+        cur.execute(s_queue_prio)
+
+    result = cur.fetchall()
+    if not result:
+        # the query failed to fetch any results; since queues might not be
+        # configured in flux-accounting, just return an empty dict
+        return {}
+
+    for row in result:
+        queues[row["queue"]] = Queue(name=row["queue"], priority=row["priority"])
+
+    return queues
+
+
+def as_format_string(column_names, rows, format_string):
+    """
+    Format a list of rows (as lists) using a format string and column names.
+
+    Args:
+        column_names: The names of the columns, used as format placeholders.
+        rows: Rows of data.
+        format_string: A format string with placeholders like {COLNAME}.
+    """
+    try:
+        header = format_string.format(**{col: col for col in column_names})
+        formatted_rows = [
+            format_string.format(**dict(zip(column_names, row))) for row in rows
+        ]
+        return "\n".join([header] + formatted_rows)
+    except KeyError as exc:
+        raise ValueError(
+            f"Invalid column name in format string: {exc.args[0]}.\n"
+            f"Available columns: {', '.join(column_names)}"
+        )
+
 
 ###############################################################
 #                                                             #
@@ -127,3 +302,88 @@ def reset_factors(conn):
 
     conn.commit()
     return 0
+
+
+def job_priorities(conn, username, bank=None, queue=None, format_string=None):
+    """
+    List a breakdown for the priority calculation for every active job for a given
+    username. Filter the user's jobs by bank and/or by queue.
+    Args:
+        conn: the SQLite Connection object.
+        username: the username of the association.
+        bank: filter jobs by a bank.
+        queue: filter jobs by a queue.
+        format_string: optional format string for custom output.
+    """
+    handle = flux.Flux()
+    cur = conn.cursor()
+
+    # initialize all associations that have the username passed in and the
+    # priority associated with any banks or queues (if no bank or queue is
+    # passed in, *every* bank and queue's priority will be fetched)
+    associations = initialize_associations(cur, username, bank)
+    banks = initialize_banks(cur, bank)
+    queues = initialize_queues(cur, queue)
+    # fetch integer weight associated with each priority factor
+    factors = list_factors(conn, json_fmt=True)
+    priority_weights = {item["factor"]: item["weight"] for item in json.loads(factors)}
+
+    joblist = (
+        flux.job.JobList(handle, max_entries=0, user=username, queue=queue)
+        if queue
+        else flux.job.JobList(handle, max_entries=0, user=username)
+    )
+    jobs = list(joblist.jobs())
+
+    row_dicts = []
+    for job in jobs:
+        # the following if-condition will return all jobs (regardless of bank) if one
+        # is not specified or will just filter jobs based on a specific bank since
+        # JobList() does not filter on bank
+        if bank is None or job.bank == bank:
+            row = {
+                "JOBID": JobID(job.id).f58,
+                "USER": job.username,
+                "BANK": job.bank,
+                "BANKPRIO": banks[job.bank].priority,
+                "BANKFACT": priority_weights.get("bank", 0),
+                "QUEUE": job.queue,
+                # if queues are not configured in flux-accounting, the "queues" dict
+                # will have no values in it, so we need to make sure that this has a
+                # default of 0 to indicate it is not affecting a job's priority
+                "QPRIO": getattr(queues.get(job.queue), "priority", 0),
+                "QFACT": priority_weights.get("queue", 0),
+                "FAIRSHARE": getattr(
+                    associations.get((job.username, job.bank)), "fairshare", 0.0
+                ),
+                "FSFACTOR": priority_weights.get("fairshare", 0),
+                "URGENCY": job.urgency,
+                "URGFACT": priority_weights.get("urgency", 0),
+                "PRIORITY": job.priority,
+            }
+            row_dicts.append(row)
+
+    if format_string:
+        column_names = list(row_dicts[0].keys()) if row_dicts else []
+        rows = [list(row.values()) for row in row_dicts]
+        return as_format_string(column_names, rows, format_string)
+
+    # use default formatting
+    header = (
+        f"{'JOBID':<15}{'USER':<9}"
+        f"{'BANK':<8}{'BANKPRIO':<10}{'BANKFACT':<10}"
+        f"{'QUEUE':<8}{'QPRIO':<7}{'QFACT':<7}"
+        f"{'FAIRSHARE':<10}{'FSFACTOR':<10}"
+        f"{'URGENCY':<8}{'URGFACT':<8}"
+        f"{'PRIORITY':<8}"
+    )
+    rows = [
+        f"{r['JOBID']:<15}{r['USER']:<9}"
+        f"{r['BANK']:<8}{r['BANKPRIO']:<10}{r['BANKFACT']:<10}"
+        f"{r['QUEUE']:<8}{r['QPRIO']:<7}{r['QFACT']:<7}"
+        f"{r['FAIRSHARE']:<10}{r['FSFACTOR']:<10}"
+        f"{r['URGENCY']:<8}{r['URGFACT']:<8}"
+        f"{r['PRIORITY']:<8}"
+        for r in row_dicts
+    ]
+    return f"{header}\n" + "\n".join(rows)

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -99,6 +99,7 @@ class AccountingService:
             "list_users",
             "view_factor",
             "list_factors",
+            "jobs",
         ]
 
         privileged_endpoints = [
@@ -674,6 +675,24 @@ class AccountingService:
             )
         except Exception as exc:
             handle.respond_error(msg, 0, f"reset-factors: {type(exc).__name__}: {exc}")
+
+    def jobs(self, handle, watcher, msg, arg):
+        try:
+            val = prio.job_priorities(
+                conn=self.conn,
+                username=msg.payload["username"],
+                bank=msg.payload.get("bank"),
+                queue=msg.payload.get("queue"),
+                format_string=msg.payload.get("format"),
+            )
+
+            payload = {"jobs": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"jobs: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"jobs: {type(exc).__name__}: {exc}")
 
 
 LOGGER = logging.getLogger("flux-uri")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -1009,6 +1009,41 @@ def add_reset_priority_factors_arg(subparsers):
     subparser_reset_factors.set_defaults(func="reset_factors")
 
 
+def add_jobs_arg(subparsers):
+    subparser_jobs = subparsers.add_parser(
+        "jobs",
+        help="see a compact breakdown of active job's and how their priorities were calculated",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_jobs.set_defaults(func="jobs")
+    subparser_jobs.add_argument(
+        "username",
+        help="username to look up jobs for",
+        type=str,
+        metavar="USERNAME",
+    )
+    subparser_jobs.add_argument(
+        "--bank",
+        help="list all jobs under a certain bank",
+        type=str,
+        metavar="BANK",
+    )
+    subparser_jobs.add_argument(
+        "--queue",
+        help="list all jobs under a certain queue",
+        type=str,
+        metavar="QUEUE",
+    )
+    subparser_jobs.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="specify output format using Python's string format syntax",
+        metavar="FORMAT",
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -1041,6 +1076,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_edit_priority_factor_arg(subparsers)
     add_list_priority_factors(subparsers)
     add_reset_priority_factors_arg(subparsers)
+    add_jobs_arg(subparsers)
 
 
 def set_db_location(args):
@@ -1089,6 +1125,7 @@ def select_accounting_function(args, output_file, parser):
         "edit_factor": "accounting.edit_factor",
         "list_factors": "accounting.list_factors",
         "reset_factors": "accounting.reset_factors",
+        "jobs": "accounting.jobs",
     }
 
     if args.func in func_map:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -59,6 +59,7 @@ TESTSCRIPTS = \
 	t1054-mf-priority-bank-priorities.t \
 	t1055-flux-account-priorities.t \
 	t1056-mf-priority-urgency-factor.t \
+	t1057-flux-account-jobs.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1057-flux-account-jobs.t
+++ b/t/t1057-flux-account-jobs.t
@@ -1,0 +1,267 @@
+#!/bin/bash
+
+test_description='test listing job priority breakdowns using flux account jobs'
+
+. `dirname $0`/sharness.sh
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+# Configure the banks to have drastically different priorities, where
+# bank A has the highest priority and bank C has the lowest.
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 --priority=100 &&
+	flux account add-bank --parent-bank=root B 1 --priority=10 &&
+	flux account add-bank --parent-bank=root C 1 --priority=1
+'
+
+# Configure the queues in flux-accounting to also have drastically different
+# priorities, where gold has the highest priority and bronze has the lowest.
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze --priority=1 &&
+	flux account add-queue silver --priority=100 &&
+	flux account add-queue gold --priority=1000
+'
+
+test_expect_success 'add three different associations' '
+	username=$(whoami) &&
+	uid=$(id -u) &&
+	flux account add-user --username=${username} --userid=${uid} --bank=A --queues=bronze,silver,gold &&
+	flux account add-user --username=${username} --userid=${uid} --bank=B --queues=bronze,silver,gold &&
+	flux account add-user --username=${username} --userid=${uid} --bank=C --queues=bronze,silver,gold
+'
+
+test_expect_success 'edit the associations to have different fairshare values' '
+	flux account edit-user ${username} --bank=A --fairshare=0.99 &&
+	flux account edit-user ${username} --bank=B --fairshare=0.50 &&
+	flux account edit-user ${username} --bank=C --fairshare=0.08
+'
+
+test_expect_success 'configure flux with those queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	[queues.gold]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'configure priority plugin with bank factor weight' '
+	flux account edit-factor --factor=bank --weight=1000
+'
+
+test_expect_success 'send flux-accounting information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+# Submit three different jobs to different banks but under the same queue.
+# job priority = (bank priority * bank weight)
+#                + (queue priority * queue weight)
+#                + (fairshare * fairshare weight)
+#
+# job 1 priority calculation:
+# priority = (bank A priority * bank weight)
+#            + (bronze queue priority * queue weight)
+#            + (user fairshare * fairshare weight)
+# priority = (100 * 1000) + (1 * 10000) + (0.99 * 100000)
+# priority = 100000 + 10000 + 99000
+# priority = 209000
+test_expect_success 'submit job 1' '
+	job1=$(flux submit -S bank=A --queue=bronze sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job1} priority \
+		| jq '.context.priority' > job1.priority &&
+	grep "209000" job1.priority
+'
+
+# job 2 priority calculation:
+# priority = (bank B priority * bank weight)
+#            + (bronze queue priority * queue weight)
+#            + (user fairshare * fairshare weight)
+# priority = (10 * 1000) + (1 * 10000) + (0.50 * 100000)
+# priority = 10000 + 10000 + 50000
+# priority = 70000
+test_expect_success 'submit job 2' '
+	job2=$(flux submit -S bank=B --queue=bronze sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job2} priority \
+		| jq '.context.priority' > job2.priority &&
+	grep "70000" job2.priority
+'
+
+# job 3 priority calculation:
+# priority = (bank C priority * bank weight)
+#            + (bronze queue priority * queue weight)
+#            + (user fairshare * fairshare weight)
+# priority = (1 * 1000) + (1 * 10000) + (0.08 * 100000)
+# priority = 1000 + 10000 + 8000
+# priority = 19000
+test_expect_success 'submit job 3' '
+	job3=$(flux submit -S bank=C --queue=bronze sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job3} priority \
+		| jq '.context.priority' > job3.priority &&
+	grep "19000" job3.priority
+'
+
+test_expect_success 'passing in a username that is not found in flux-accounting DB fails' '
+	test_must_fail flux account jobs foo > error_association.out 2>&1 &&
+	grep "could not find entry for foo in association_table" error_association.out
+'
+
+# By default, we can just specify a username and fetch all of their jobs under
+# every bank and every queue. Make sure that each job returns the correct
+# priority.
+test_expect_success 'call flux account jobs (returns all user jobs)' '
+	flux account jobs ${username} > all_jobs.out &&
+	grep "${job1}" all_jobs.out | grep 209000 &&
+	grep "${job2}" all_jobs.out | grep 70000 &&
+	grep "${job3}" all_jobs.out | grep 19000
+'
+
+# We can filter to only return jobs that are running under a certain bank but
+# are running under any queue.
+test_expect_success 'filter jobs by a specific bank' '
+	flux account jobs ${username} --bank=A > bank_A_jobs.out &&
+	grep "${job1}" bank_A_jobs.out | grep 209000
+'
+
+# We can filter to only return jobs that are running under a certain queue but
+# are running under any bank.
+test_expect_success 'filter jobs by a specific queue' '
+	flux account jobs ${username} --queue=bronze > queue_bronze_jobs.out &&
+	grep "${job1}" queue_bronze_jobs.out | grep 209000 &&
+	grep "${job2}" queue_bronze_jobs.out | grep 70000 &&
+	grep "${job3}" queue_bronze_jobs.out | grep 19000
+'
+
+# Submit two different jobs to different queues but the same bank.
+# job 4 priority calculation:
+# priority = (bank C priority * bank weight)
+#            + (silver queue priority * queue weight)
+#            + (user fairshare * fairshare weight)
+# priority = (1 * 1000) + (100 * 10000) + (0.08 * 100000)
+# priority = 1000 + 1000000 + 8000
+# priority = 1009000
+test_expect_success 'submit job 4' '
+	job4=$(flux submit -S bank=C --queue=silver sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job4} priority \
+		| jq '.context.priority' > job4.priority &&
+	grep "1009000" job4.priority
+'
+
+# job 5 priority calculation:
+# priority = (bank C priority * bank weight)
+#            + (gold queue priority * queue weight)
+#            + (user fairshare * fairshare weight)
+# priority = (1 * 1000) + (1000 * 10000) + (0.08 * 100000)
+# priority = 1000 + 10000000 + 8000
+# priority = 10009000
+test_expect_success 'submit job 5' '
+	job5=$(flux submit -S bank=C --queue=gold sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job5} priority \
+		| jq '.context.priority' > job5.priority &&
+	grep "10009000" job5.priority
+'
+
+test_expect_success 'filter jobs by the silver queue' '
+	flux account jobs ${username} --queue=silver > queue_silver_jobs.out &&
+	grep "${job4}" queue_silver_jobs.out | grep 1009000
+'
+
+test_expect_success 'filter jobs by the gold queue' '
+	flux account jobs ${username} --queue=gold > queue_gold_jobs.out &&
+	grep "${job5}" queue_gold_jobs.out | grep 10009000
+'
+
+test_expect_success 'run flux account jobs with a format string' '
+	flux account jobs ${username} \
+		--bank=C \
+		-o "{BANK:<8} | {PRIORITY:<10}" \
+		> bank_C_jobs.format_string &&
+	grep "BANK     | PRIORITY" bank_C_jobs.format_string &&
+	grep "C        | 10009000" bank_C_jobs.format_string &&
+	grep "C        | 1009000" bank_C_jobs.format_string &&
+	grep "C        | 19000"  bank_C_jobs.format_string
+'
+
+# We can pass multiple filters to refine the search both by queue and by bank.
+test_expect_success 'filter jobs by queue and by bank' '
+	flux account jobs ${username} \
+		--bank=C --queue=gold \
+		-o "{BANK:<8} | {QUEUE:<6} | {PRIORITY:<10}" \
+		> multiple_filters.out &&
+	grep "BANK     | QUEUE  | PRIORITY" multiple_filters.out &&
+	grep "C        | gold   | 10009000" multiple_filters.out
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} &&
+	flux cancel ${job2} &&
+	flux cancel ${job3} &&
+	flux cancel ${job4} &&
+	flux cancel ${job5}
+'
+
+test_expect_success 'remove queues from the flux-accounting DB' '
+	flux account edit-user ${username} --queues=-1 &&
+	flux account delete-queue bronze &&
+	flux account delete-queue silver &&
+	flux account delete-queue gold &&
+	flux account-priority-update -p ${DB_PATH}
+'
+
+# job 6 priority calculation:
+# priority = (bank C priority * bank weight)
+#            + (NO queue priority * queue weight)
+#            + (user fairshare * fairshare weight)
+# priority = (1 * 1000) + (0 * 10000) + (0.08 * 100000)
+# priority = 1000 + 0 + 8000
+# priority = 9000
+test_expect_success 'submit a job to one of the queues' '
+	job6=$(flux submit -S bank=C --queue=gold sleep 60) &&
+	flux job wait-event -vt 5 -f json ${job6} priority \
+		| jq '.context.priority' > job6.priority &&
+	grep "9000" job6.priority
+'
+
+# We should still be able to filter jobs by queue even if queues are not
+# configured in flux-accounting.
+test_expect_success 'filter jobs by gold queue' '
+	flux account jobs ${username} --bank=C --queue=gold > no_configured_queues.out &&
+	grep "${job6}" no_configured_queues.out | grep 9000
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

There is no way to see a convenient breakdown of how various job priorities for an association are calculated. Since there are multiple factors with different weights, it might be helpful to list this breakdown on the command line instead of making someone consult documentation and calculate the priorities themselves.

---

This PR (built on top of #673) adds a new command called `jobs`, which takes one argument (`username`) and lists a breakdown of all of their jobs' priorities:

```console
JOBID          USER     BANK    BANKPRIO  BANKFACT  QUEUE   QPRIO  QFACT  FAIRSHARE FSFACTOR  URGENCY URGFACT PRIORITY
foEvbno        moussa1  A       100.0     1000      bronze  1      10000  0.99      100000    16      1000    209000  
fqyZGwh        moussa1  B       10.0      1000      bronze  1      10000  0.5       100000    16      1000    70000   
ftiBx6b        moussa1  C       1.0       1000      bronze  1      10000  0.08      100000    16      1000    19000
``` 

This command accepts optional arguments (`--bank` and `--queue`) to filter jobs that are running under a certain bank, queue, or both. It also accepts an `-o/--format` argument in case you want to customize the output.

Tests are added walking through editing certain factors and submitting different jobs to different banks and queues to give different examples of how job priorities are calculated.

A new page is added to the flux-accounting documentation going into more detail about how job priorities are calculated. Since I've added this page, I've moved some of the explanation out of the flux-accounting guide and instead referenced this new page.