### PR TITLE
update-usage: remove extra `.commit()` from helper function

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -116,6 +116,17 @@ def update_curr_usg_col(acct_conn, usg_h, user, bank):
 
 
 def apply_decay_factor(decay, acct_conn, user=None, bank=None):
+    """
+    Apply a decay factor to an association's job usage period values. Since this helper
+    issues a write to the flux-accounting DB and does not have a .commit() call after the
+    update, this function should be called inside of a SQLite TRANSACTION.
+
+    Args:
+        decay: The decay factor to be applied to every job usage period.
+        acct_conn: The SQLite Connection object.
+        user: The username of the association.
+        bank: The bank name of the association.
+    """
     usg_past = []
     usg_past_decay = []
 
@@ -145,7 +156,6 @@ def apply_decay_factor(decay, acct_conn, user=None, bank=None):
         )
         period += 1
 
-    acct_conn.commit()
     # only return the usage factors up to but not including the oldest one
     # since it no longer affects a user's historical usage factor
     return sum(usg_past_decay[:-1])


### PR DESCRIPTION
#### Problem

The `apply_decay_factor()` helper function has a `.commit()` call at the end of the function, which will write all changes to disk. However, this helper function is called in the middle of a SQLite TRANSACTION, which will already call `.commit()` when the transaction is finished running. Thus, this hinders performance of the `update-usage` command by performing an extra write to disk for every association in the `association_table`.

---

This PR removes the extra `.commit()` from the end of `apply_decay_factor()`.