### PR TITLE
database: add graph commands for displaying job usage values for associations, banks

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -35,7 +35,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-list-factors.1 \
 	man1/flux-account-reset-factors.1 \
 	man1/flux-account-jobs.1 \
-	man1/flux-account-view-job-records.1
+	man1/flux-account-view-job-records.1 \
+	man1/flux-account-show-usage.1
 
 RST_FILES  = \
 	$(MAN1_FILES_PRIMARY:.1=.rst)

--- a/doc/man1/flux-account-show-usage.rst
+++ b/doc/man1/flux-account-show-usage.rst
@@ -1,0 +1,42 @@
+.. flux-help-section: flux account
+
+==========================
+flux-account-show-usage(1)
+==========================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **show-usage** TABLE --limit=N
+
+DESCRIPTION
+===========
+
+.. program:: flux account show-usage
+
+:program:`flux account show-usage` will display a bar chart for the top *N*
+associations or the top *N* banks in terms of job usage. A configurable limit
+to limit the rows to only the first *N* can be specified with the ``--limit``
+optional argument.
+
+.. option:: table
+
+    The table to display job usage data from. The current available options are
+    ("associations", "banks").
+
+.. option:: --limit
+
+    The max number of rows to display on the bar graph.
+
+EXAMPLES
+--------
+
+.. code-block:: console
+
+    $ flux account show-usage associations --limit=5
+    user1 / bankA  | ██████████████████████████████████████████████████████████████  8814977.53
+    user2 / bankA  | ██████████████████████████████████████████                      6614967.62
+    user3 / bankB  | ██████████████████████                                          4419446.80
+    user4 / bankC  | █████████████                                                   3395406.50
+    user5 / bankC  | ███████████                                                     3184829.87

--- a/doc/man1/flux-account.rst
+++ b/doc/man1/flux-account.rst
@@ -236,3 +236,13 @@ jobs
 View a breakdown of an association's job priorities.
 
 See :man1:`flux-account-jobs` for more details.
+
+DATA VISUALIZATION
+==================
+
+show-usage
+^^^^^^^^^^
+
+Display a chart of the top associations or banks in terms of job usage.
+
+See :man1:`flux-account-show-usage` for more details.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -220,4 +220,11 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-show-usage",
+        "flux-account-show-usage",
+        "display a chart of the top associations or banks in terms of job usage",
+        [author],
+        1,
+    ),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -545,6 +545,8 @@ MaxRunningJobs
 ParentBank
 UserID
 bankA
+bankB
+bankC
 parsable
 fnYtwBV
 fPeYLgX

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -10,7 +10,8 @@ acctpy_PYTHON = \
 	create_db.py \
 	formatter.py \
 	sql_util.py \
-	priorities.py
+	priorities.py \
+	visuals.py
 
 clean-local:
 	-rm -f *.pyc *.pyo

--- a/src/bindings/python/fluxacct/accounting/visuals.py
+++ b/src/bindings/python/fluxacct/accounting/visuals.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import shutil
+import sys
+
+
+class RenderBarGraph:
+    """A class for displaying a horizontal bar graph."""
+
+    def __init__(self, conn, query, query_params=(), bar_char="█", fallback_char="#"):
+        """
+        Initialize the graph renderer.
+
+        Parameters:
+            conn: A SQLite Connection object.
+            query: The query to the flux-accounting DB to actually fetch the data used
+                in the graph.
+            query_params: Any parameters specified for the SQLite query.
+            bar_char: The primary character to draw the bars (default: block char).
+            fallback_char: A fallback ASCII character if primary char can't be encoded in
+                the terminal.
+        """
+        self.conn = conn
+        self.bar_char = bar_char
+        self.fallback_char = fallback_char
+        self.query = query
+        self.query_params = query_params
+
+    def fetch_rows(self):
+        cur = self.conn.cursor()
+        if self.query_params != ():
+            cur.execute(self.query, self.query_params)
+        else:
+            cur.execute(self.query)
+        return cur.fetchall()
+
+    def make_label(self, row):
+        """Return string label for a row; override in subclasses."""
+        raise NotImplementedError
+
+    def _bar_char(self):
+        """Return the appropriate bar character based on terminal encoding support."""
+        encoding = sys.stdout.encoding or "utf-8"
+        try:
+            self.bar_char.encode(encoding)
+            return self.bar_char
+        except (UnicodeEncodeError, TypeError):
+            return self.fallback_char
+
+    def draw(self):
+        rows = self.fetch_rows()
+        if not rows:
+            return "no data to display"
+
+        labels = [self.make_label(row) for row in rows]
+        # last column will be the numerical value to display
+        values = [row[-1] for row in rows]
+
+        term_width = shutil.get_terminal_size().columns
+        # max width for the labels on y-axis
+        max_label = max(len(lbl) for lbl in labels)
+        reserved = max_label + 10 + max(len(f"{v:.2f}") for v in values)
+        max_bar = max(term_width - reserved, 10)
+        scale = 0 if max(values) == 0 else max_bar / max(values)
+
+        char = self._bar_char()
+        lines = []
+        for lbl, val in zip(labels, values):
+            bar_len = int(val * scale)
+            bar_character = char * bar_len
+            lines.append(f"{lbl:<{max_label}} | {bar_character:<{max_bar}} {val: .2f}")
+        return "\n".join(lines)
+
+
+class AssociationUsageGraph(RenderBarGraph):
+    def __init__(self, conn, limit, bar_char="█", fallback_char="#"):
+        """
+        A subclass of RenderBarGraph to display job_usage data from the
+        association_table. Order the data in descending order by job_usage. Allow for a
+        configurable amount of data to be displayed in the graph.
+
+        Args:
+            conn: The SQLite Connection object.
+            limit: The max number of rows to display on the graph.
+            bar_char: The character used to dsiplay the horizontal bar on the graph.
+            fallback_char: A fallback character used to display the horizontal bar on
+                the graph.
+        """
+        self.conn = conn
+        self.limit = limit
+        self.bar_char = bar_char
+        self.fallback_char = fallback_char
+        # the following attributes are manually set here to query the flux-accounting
+        # DB using the fetch_rows() method in the RenderBarGraph class
+        self.query = (
+            "SELECT username,bank,job_usage FROM association_table "
+            "ORDER BY job_usage DESC LIMIT ?"
+        )
+        self.query_params = (self.limit,)
+        super().__init__(conn, self.query, self.query_params)
+
+    def make_label(self, row):
+        return f"{row['username']} / {row['bank']}"
+
+
+class BankUsageGraph(RenderBarGraph):
+    def __init__(self, conn, limit, bar_char="█", fallback_char="#"):
+        """
+        A subclass of RenderBarGraph to display job_usage data from the
+        bank_table. Order the data in descending order by job_usage. Allow for a
+        configurable amount of data to be displayed in the graph.
+
+        Args:
+            conn: The SQLite Connection object.
+            limit: The max number of rows to display on the graph.
+            bar_char: The character used to dsiplay the horizontal bar on the graph.
+            fallback_char: A fallback character used to display the horizontal bar on
+                the graph.
+        """
+        self.conn = conn
+        self.limit = limit
+        self.bar_char = bar_char
+        self.fallback_char = fallback_char
+        self.query = (
+            "SELECT bank,job_usage FROM bank_table WHERE parent_bank != '' "
+            "ORDER BY job_usage DESC LIMIT ?"
+        )
+        self.query_params = (self.limit,)
+        super().__init__(conn, self.query, self.query_params)
+
+    def make_label(self, row):
+        return row["bank"]
+
+
+def show_usage(conn, table, limit=10):
+    """
+    Create a horizontal bar graph for displaying job usage data for either associations
+    or banks.
+
+    Args:
+        conn: The SQLite Connection object.
+        table: The name of the table to pull job usage data from.
+        limit: The max number of rows to display on the graph.
+    """
+    if table == "associations":
+        return AssociationUsageGraph(conn, limit=limit).draw()
+
+    return BankUsageGraph(conn, limit=limit).draw()

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -27,6 +27,7 @@ from fluxacct.accounting import project_subcommands as p
 from fluxacct.accounting import jobs_table_subcommands as j
 from fluxacct.accounting import db_info_subcommands as d
 from fluxacct.accounting import priorities as prio
+from fluxacct.accounting import visuals as vis
 
 
 def establish_sqlite_connection(path):
@@ -100,6 +101,7 @@ class AccountingService:
             "view_factor",
             "list_factors",
             "jobs",
+            "show_usage",
         ]
 
         privileged_endpoints = [
@@ -677,6 +679,22 @@ class AccountingService:
             handle.respond_error(msg, 0, f"jobs: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(msg, 0, f"jobs: {type(exc).__name__}: {exc}")
+
+    def show_usage(self, handle, watcher, msg, arg):
+        try:
+            val = vis.show_usage(
+                conn=self.conn,
+                table=msg.payload["table"],
+                limit=msg.payload.get("limit"),
+            )
+
+            payload = {"show_usage": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"show-usage: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"show-usage: {type(exc).__name__}: {exc}")
 
 
 LOGGER = logging.getLogger("flux-uri")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -1046,6 +1046,29 @@ def add_jobs_arg(subparsers):
     )
 
 
+def add_show_usage_arg(subparsers):
+    subparsers_visuals = subparsers.add_parser(
+        "show-usage",
+        help="graph job usage values from the flux-accounting database",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparsers_visuals.set_defaults(func="show_usage")
+    subparsers_visuals.add_argument(
+        "table",
+        help="the type of job usage data to visualize ",
+        type=str,
+        choices=["associations", "banks"],
+    )
+    subparsers_visuals.add_argument(
+        "-n",
+        "--limit",
+        help="the number of rows to display on the bar chart",
+        type=int,
+        default=10,
+        metavar="LIMIT",
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_output_file_arg(parser)
@@ -1079,6 +1102,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_list_priority_factors(subparsers)
     add_reset_priority_factors_arg(subparsers)
     add_jobs_arg(subparsers)
+    add_show_usage_arg(subparsers)
 
 
 def set_db_location(args):
@@ -1127,6 +1151,7 @@ def select_accounting_function(args, output_file, parser):
         "list_factors": "accounting.list_factors",
         "reset_factors": "accounting.reset_factors",
         "jobs": "accounting.jobs",
+        "show_usage": "accounting.show_usage",
     }
 
     if args.func in func_map:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -72,7 +72,8 @@ TESTSCRIPTS = \
 	python/t1008_banks_output.py \
 	python/t1009_users_output.py \
 	python/t1010_issue631.py \
-	python/t1011_priorities.py
+	python/t1011_priorities.py \
+	python/t1012_visuals.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -60,6 +60,7 @@ TESTSCRIPTS = \
 	t1055-flux-account-priorities.t \
 	t1056-mf-priority-urgency-factor.t \
 	t1057-flux-account-jobs.t \
+	t1058-flux-account-visuals.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/python/t1012_visuals.py
+++ b/t/python/t1012_visuals.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import re
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import visuals as vis
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test flux-accounting database
+        c.create_db("FluxAccountingVisuals.db")
+        global conn
+        global cur
+
+        conn = sqlite3.connect("FluxAccountingVisuals.db")
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        b.add_bank(conn, bank="root", shares=1)
+        b.add_bank(conn, parent_bank="root", bank="A", shares=1)
+        b.add_bank(conn, parent_bank="root", bank="B", shares=1)
+        b.add_bank(conn, parent_bank="root", bank="C", shares=1)
+
+        u.add_user(conn, username="user1", bank="A")
+        u.add_user(conn, username="user2", bank="A")
+        u.add_user(conn, username="user3", bank="B")
+        u.add_user(conn, username="user4", bank="B")
+        u.add_user(conn, username="user5", bank="C")
+
+        cur.execute("UPDATE association_table SET job_usage=5  WHERE username='user1'")
+        cur.execute("UPDATE association_table SET job_usage=14 WHERE username='user2'")
+        cur.execute("UPDATE association_table SET job_usage=7  WHERE username='user3'")
+        cur.execute("UPDATE association_table SET job_usage=45 WHERE username='user4'")
+        cur.execute("UPDATE association_table SET job_usage=23 WHERE username='user5'")
+
+        cur.execute("UPDATE bank_table SET job_usage=19 WHERE bank='A'")
+        cur.execute("UPDATE bank_table SET job_usage=52 WHERE bank='B'")
+        cur.execute("UPDATE bank_table SET job_usage=23 WHERE bank='C'")
+
+        conn.commit()
+
+    @staticmethod
+    def extract_values(output):
+        """
+        Given the multi-line bar graph output, grab the float at the
+        end of each line and return them as a list of floats.
+        """
+        vals = []
+        for line in output.splitlines():
+            m = re.search(r"([0-9]+\.[0-9]+)\s*$", line)
+            vals.append(float(m.group(1)))
+        return vals
+
+    def test_01_show_usage_associations_default(self):
+        test = vis.show_usage(conn, table="associations")
+        vals = self.extract_values(test)
+        # ensure the order of the y-axis is in reverse order (i.e. largest job usage
+        # value at the top of the graph)
+        self.assertTrue(vals, sorted(vals, reverse=True))
+
+        y_axis = test.splitlines()
+        # check order of y-axis
+        self.assertEqual(y_axis[0].split("|")[0].strip(), "user4 / B")
+        self.assertEqual(y_axis[1].split("|")[0].strip(), "user5 / C")
+        self.assertEqual(y_axis[2].split("|")[0].strip(), "user2 / A")
+        self.assertEqual(y_axis[3].split("|")[0].strip(), "user3 / B")
+        self.assertEqual(y_axis[4].split("|")[0].strip(), "user1 / A")
+
+    def test_02_show_usage_banks_default(self):
+        test = vis.show_usage(conn, table="banks")
+        vals = self.extract_values(test)
+        # ensure the order of the y-axis is in reverse order (i.e. largest job usage
+        # value at the top of the graph)
+        self.assertTrue(vals, sorted(vals, reverse=True))
+
+        y_axis = test.splitlines()
+        # check order of y-axis
+        self.assertEqual(y_axis[0].split("|")[0].strip(), "B")
+        self.assertEqual(y_axis[1].split("|")[0].strip(), "C")
+        self.assertEqual(y_axis[2].split("|")[0].strip(), "A")
+
+    def test_03_show_usage_associations_custom(self):
+        test = vis.show_usage(conn, table="associations", limit=1)
+
+        y_axis = test.splitlines()
+        # make sure only one result is returned
+        self.assertEqual(len(y_axis), 1)
+
+        self.assertEqual(y_axis[0].split("|")[0].strip(), "user4 / B")
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove("FluxAccountingVisuals.db")
+
+
+def suite():
+    unittest.TestSuite()
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t1058-flux-account-visuals.t
+++ b/t/t1058-flux-account-visuals.t
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+test_description='test visualizing flux-accounting numerical data'
+
+. `dirname $0`/sharness.sh
+
+DB_PATH=$(pwd)/FluxAccountingTest.db
+UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'call show-usage with no data' '
+	flux account show-usage associations > no_association_data.out &&
+	grep "no data to display" no_association_data.out &&
+	flux account show-usage banks > no_bank_data.out &&
+	grep "no data to display" no_bank_data.out
+'
+
+test_expect_success 'call show-usage --help' '
+	flux account show-usage --help
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1
+'
+
+test_expect_success 'add some associations' '
+	flux account add-user --username=user1 --bank=A &&
+	flux account add-user --username=user2 --bank=A &&
+	flux account add-user --username=user3 --bank=B &&
+	flux account add-user --username=user4 --bank=B &&
+	flux account add-user --username=user5 --bank=C
+'
+
+test_expect_success 'edit job usage values for every association' '
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user1 5 &&
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user2 14 &&
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user3 7 &&
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user4 45 &&
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user5 23
+'
+
+test_expect_success 'update usage for entire flux-accounting DB hierarchy' '
+	flux account-update-usage -p ${DB_PATH}
+'
+
+test_expect_success 'call show-usage for associations' '
+	flux account show-usage associations > associations.out &&
+	grep "user4" associations.out | grep 45 &&
+	grep "user5" associations.out | grep 23 &&
+	grep "user2" associations.out | grep 14 &&
+	grep "user3" associations.out | grep 7 &&
+	grep "user1" associations.out | grep 5
+'
+
+test_expect_success 'call show-usage for banks' '
+	flux account show-usage banks > banks.out &&
+	grep "B" banks.out | grep 52 &&
+	grep "C" banks.out | grep 23 &&
+	grep "A" banks.out | grep 19
+'
+
+test_expect_success 'call show-usage for associations with --limit' '
+	flux account show-usage associations --limit=1 > associations_limited.out &&
+	grep "user4" associations_limited.out | grep 45 
+'
+
+test_expect_success 'call show-usage for banks with --limit' '
+	flux account show-usage banks --limit=1 > banks_limited.out &&
+	grep "B" banks_limited.out | grep 52
+'
+
+test_expect_success 'call show-usage with a bad table name' '
+	test_must_fail flux account show-usage foo > error.out 2>&1 &&
+	cat error.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Some of the numerical data in flux-accounting, such as job usage, would be cool to be visualized and compared directly on the command line for admins or users who are interested in looking at what users or banks are consuming the most usage. This would be a lot more convenient than calling `list-users` or `list-banks` and manually parsing tables to look at this kind of data.

---

This PR adds a new class to the Python bindings (`RenderBarChart`) that can create a horizontal bar chart using data from the flux-accounting database. To start, there are just two subclasses: classes for displaying the top _n_ associations or top _n_ banks in terms of job usage.

A new command is added to the flux-accounting command suite called `show-usage`, which will render a graph for either associations or banks:

```console
moussa1@docker-desktop:/usr/src$ flux account list-usage associations --limit=5
user1 / guests  | █████████████████████████████████████████████████████████████████████████████  8814977.53
user2 / guests  | █████████████████████████████████████████████████████████                      6614967.62
user3 / wbronze | █████████████████████████████████████                                          4419446.80
user4 / guests  | ████████████████████████████                                                   3395406.50
user5 / guests  | ██████████████████████████                                                     3184829.87
```

The graph is automatically sized to the width of the terminal the person running the command on and will fallback to a `#` character in the case the █ character cannot be rendered. An optional `--limit` argument is also available to limit the number of rows displayed. 