### PR TITLE
NEWS: add release notes for `v0.47.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,40 @@
+flux-accounting version 0.47.0 - 2025-06-30
+-------------------------------------------
+
+#### Features
+
+* plugin: enforce max resource limits per-association (#562)
+
+* database: add new table to store priority factors and their weights (#665)
+
+* plugin: unpack priority factor weights from database (#670)
+
+* plugin: add weight for `urgency` factor, update docs with new equation (#673)
+
+* commands: add new `jobs` command to view priority breakdowns of jobs (#674)
+
+* database: add graph commands for displaying job usage values for
+associations, banks (#677)
+
+#### Fixes
+
+* flux-accounting service: use `.get()` instead of direct key access (#653)
+
+* update-usage: remove extra `.commit()` from helper function (#675)
+
+* job-usage update: move update out of flux-accounting service and into own
+script (#657)
+
+#### Documentation
+
+* doc: add `man(1)` pages for priority factor commands (#672)
+
+* doc: add new "Limits" page (#667)
+
+* doc: add `man(1)` page for `view-job-records` (#669)
+
+* doc: update top-level flux-account man page with project command links (#668)
+
 flux-accounting version 0.46.0 - 2025-06-02
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.47.0`.

---

This PR adds some release notes for `v0.47.0`. Posting this a little earlier (but planning on release date being next Monday) because next week is a short week. Once this lands, I'll push an annotated tag with the following:

```
git tag -a v0.47.0 -m "Tag v0.47.0" && git push upstream v0.47.0
```