### PR TITLE
update-usage: move one-time SQL query out of `for`-loop, combine per-association queries

### DIFF
--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -235,6 +235,7 @@ class TestAccountingCLI(unittest.TestCase):
             user=user,
             bank=bank,
             default_bank=bank,
+            end_hl=9900000,
         )
         self.assertEqual(usage_factor, 17044.0)
 
@@ -260,6 +261,7 @@ class TestAccountingCLI(unittest.TestCase):
             user=user,
             bank=bank,
             default_bank=bank,
+            end_hl=9900000,
         )
         self.assertEqual(usage_factor, 8500.0)
 
@@ -277,6 +279,7 @@ class TestAccountingCLI(unittest.TestCase):
             user="1003",
             bank="D",
             default_bank="D",
+            end_hl=0,
         )
 
         cur.execute(s_ts)
@@ -345,6 +348,7 @@ class TestAccountingCLI(unittest.TestCase):
             user=user,
             bank=bank,
             default_bank=bank,
+            end_hl=0,
         )
         self.assertEqual(usage_factor, 4366.0)
 
@@ -361,6 +365,7 @@ class TestAccountingCLI(unittest.TestCase):
             user=user,
             bank=bank,
             default_bank=bank,
+            end_hl=0,
         )
 
         self.assertEqual(usage_factor, 3215.5)

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -236,6 +236,7 @@ class TestAccountingCLI(unittest.TestCase):
             bank=bank,
             default_bank=bank,
             end_hl=9900000,
+            last_j_ts=0,
         )
         self.assertEqual(usage_factor, 17044.0)
 
@@ -262,6 +263,7 @@ class TestAccountingCLI(unittest.TestCase):
             bank=bank,
             default_bank=bank,
             end_hl=9900000,
+            last_j_ts=0,
         )
         self.assertEqual(usage_factor, 8500.0)
 
@@ -280,6 +282,7 @@ class TestAccountingCLI(unittest.TestCase):
             bank="D",
             default_bank="D",
             end_hl=0,
+            last_j_ts=0,
         )
 
         cur.execute(s_ts)
@@ -342,6 +345,11 @@ class TestAccountingCLI(unittest.TestCase):
             print(integrity_error)
 
         # re-calculate usage factor for user1001
+        cur.execute(
+            "SELECT last_job_timestamp FROM job_usage_factor_table "
+            "WHERE username='1001' AND bank='C'"
+        )
+        ts = cur.fetchone()[0]
         usage_factor = jobs.calc_usage_factor(
             acct_conn,
             pdhl=1,
@@ -349,6 +357,7 @@ class TestAccountingCLI(unittest.TestCase):
             bank=bank,
             default_bank=bank,
             end_hl=0,
+            last_j_ts=ts,
         )
         self.assertEqual(usage_factor, 4366.0)
 
@@ -358,6 +367,11 @@ class TestAccountingCLI(unittest.TestCase):
     def test_16_recalculate_usage_after_half_life_period(self):
         user = "1001"
         bank = "C"
+        cur.execute(
+            "SELECT last_job_timestamp FROM job_usage_factor_table "
+            "WHERE username='1001' AND bank='C'"
+        )
+        ts = cur.fetchone()[0]
 
         usage_factor = jobs.calc_usage_factor(
             acct_conn,
@@ -366,6 +380,7 @@ class TestAccountingCLI(unittest.TestCase):
             bank=bank,
             default_bank=bank,
             end_hl=0,
+            last_j_ts=ts,
         )
 
         self.assertEqual(usage_factor, 3215.5)


### PR DESCRIPTION
#### Problem

The `calc_usage_factor()` function issues a query to fetch the timestamp of the end of the current half-life period for the _cluster_, but it does this for every association, when it really only needs to perform this query once.

The function also issues a `SELECT` query to fetch a timestamp for every association in order to determine how to filter the `jobs` table to fetch new jobs for each association. However, the parameters used to get this timestamp (username and bank) are already used before calling the `calc_usage_factor()` function for every association. So, there is opportunity to combine these two queries.

---

This PR moves the query to fetch the timestamp of the end of the current half-life period for the cluster to _before_ entering the `for`-loop to calculate the new job usage values for every association.

It also combines the queries:

1) fetching every association from the `association_table`
2) fetching the last seen timestamp for every association in the `association_table`

into just one query by using a `LEFT JOIN` **before** iterating through each association and calculating their new job usage value.

The unit tests in `t1006_job_archive.py` have been adjusted to account for the new parameters expected in the functions responsible for calculating job usage values for associations.