### PR TITLE
`add-user`: remove extra `.commit()` when `INSERT`-ing values into `association_table`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -406,8 +406,6 @@ def add_user(
             default_project,
         ),
     )
-    # commit changes
-    conn.commit()
     # insert the user values into job_usage_factor_table
     conn.execute(
         """
@@ -420,6 +418,7 @@ def add_user(
             bank,
         ),
     )
+    # commit changes
     conn.commit()
 
     return 0


### PR DESCRIPTION
#### Problem

There is a `.commit()` call in the `add_user()` function that is not needed since there is a `.commit()` call a few lines later.

---

This PR removes the extra `.commit()` call.