### PR TITLE
flux-accounting service: use `DB_SCHEMA_VERSION` constant instead of hard-coded value

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -64,7 +64,8 @@ def check_db_version(conn):
     db_version = cur.fetchone()[0]
     if db_version < fluxacct.accounting.DB_SCHEMA_VERSION:
         print(
-            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+            "flux-accounting database out of date; please update DB with "
+            "'flux account-update-db' before running commands"
         )
         sys.exit(1)
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -58,8 +58,7 @@ def background():
 
 
 def check_db_version(conn):
-    # check version of database; if not up to date, output message
-    # and exit
+    # check version of database; if not up to date, output message and exit
     cur = conn.cursor()
     cur.execute("PRAGMA user_version")
     db_version = cur.fetchone()[0]

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -63,7 +63,7 @@ def check_db_version(conn):
     cur = conn.cursor()
     cur.execute("PRAGMA user_version")
     db_version = cur.fetchone()[0]
-    if db_version < 20:
+    if db_version < fluxacct.accounting.DB_SCHEMA_VERSION:
         print(
             "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
         )


### PR DESCRIPTION
#### Problem

The flux-accounting service hard-codes the schema version of the flux-accounting DB when checking to see if the DB is out-of-date and needs to be updated. However, there is a constant that exists that will remain up to date event when the schema version number is updated.

---

This PR updates the flux-accounting service to use `fluxacct.accounting.DB_SCHEMA_VERSION` in place of a hard-coded
schema version number when checking whether the database needs to be updated.

I've also snuck in a couple of minor formatting commits.