### PR TITLE
bindings: add `db_version()` function, use it across scripts that check DB version

### DIFF
--- a/src/bindings/python/fluxacct/accounting/sql_util.py
+++ b/src/bindings/python/fluxacct/accounting/sql_util.py
@@ -24,3 +24,16 @@ def validate_columns(columns, valid_columns):
     invalid_columns = [column for column in columns if column not in valid_columns]
     if invalid_columns:
         raise ValueError(f"invalid fields: {', '.join(invalid_columns)}")
+
+
+def db_version(conn):
+    """
+    Return the DB schema version of the flux-accounting database.
+
+    Args:
+        conn: The SQLite Connection object.
+    """
+    cur = conn.cursor()
+    cur.execute("PRAGMA user_version")
+
+    return cur.fetchone()[0]

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -20,6 +20,7 @@ import pwd
 import flux
 
 import fluxacct.accounting
+from fluxacct.accounting import sql_util as sql
 
 
 def set_db_loc(args):
@@ -44,12 +45,8 @@ def est_sqlite_conn(path):
         print(f"Exception: {exc}")
         sys.exit(1)
 
-    # check version of database; if not up to date, output message
-    # and exit
-    cur = conn.cursor()
-    cur.execute("PRAGMA user_version")
-    db_version = cur.fetchone()[0]
-    if db_version < fluxacct.accounting.DB_SCHEMA_VERSION:
+    # check version of database; if not up to date, output message and exit
+    if sql.db_version(conn) < fluxacct.accounting.DB_SCHEMA_VERSION:
         print(
             """flux-accounting database out of date; updating DB with """
             """'flux account-update-db' before sending information to plugin"""

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -28,6 +28,7 @@ from fluxacct.accounting import jobs_table_subcommands as j
 from fluxacct.accounting import db_info_subcommands as d
 from fluxacct.accounting import priorities as prio
 from fluxacct.accounting import visuals as vis
+from fluxacct.accounting import sql_util as sql
 
 
 def establish_sqlite_connection(path):
@@ -55,19 +56,6 @@ def background():
     if pid > 0:
         # exit first parent
         sys.exit(0)
-
-
-def check_db_version(conn):
-    # check version of database; if not up to date, output message and exit
-    cur = conn.cursor()
-    cur.execute("PRAGMA user_version")
-    db_version = cur.fetchone()[0]
-    if db_version < fluxacct.accounting.DB_SCHEMA_VERSION:
-        print(
-            "flux-accounting database out of date; please update DB with "
-            "'flux account-update-db' before running commands"
-        )
-        sys.exit(1)
 
 
 # pylint: disable=broad-except, too-many-public-methods
@@ -750,14 +738,11 @@ def main():
     db_path = args.path if args.path else fluxacct.accounting.DB_PATH
     conn = establish_sqlite_connection(db_path)
 
-    # check version of database; if not up to date, output message
-    # and exit
-    cur = conn.cursor()
-    cur.execute("PRAGMA user_version")
-    db_version = cur.fetchone()[0]
-    if db_version < fluxacct.accounting.DB_SCHEMA_VERSION:
+    # check version of database; if not up to date, output message and exit
+    if sql.db_version(conn) < fluxacct.accounting.DB_SCHEMA_VERSION:
         LOGGER.error(
-            "flux-accounting database out of date; please update DB with 'flux account-update-db' before running commands"
+            "flux-accounting database out of date; please update DB with "
+            "'flux account-update-db' before running commands"
         )
         sys.exit(1)
 


### PR DESCRIPTION
#### Problem

The `flux-account-priority-update.py` and `flux-account-service.py` files each have their own check of the DB schema version of the flux-accounting database. Thus, there is opportunity to create a function that can be imported and used across the flux-accounting scripts.

In the case of `flux-account-service.py`, the `check_db_version()` function it had defined is not even being used. 🤦

---

This PR creates a function which will just return the schema version number of the flux-accounting DB, and uses this function both in `flux-account-priority-update.py` and `flux-account-service.py`.