### PR TITLE
plugin: shorten line that is greater than 80 characters

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1211,7 +1211,7 @@ static int run_cb (flux_plugin_t *p,
                                          FLUX_JOBTAP_CURRENT_JOB,
                                          "mf_priority",
                                          0,
-                                         "job.state.run: failed to increment " \
+                                         "job.state.run: failed to increment "
                                          "resource count");
             return -1;
         }


### PR DESCRIPTION
#### Problem

There is a line in the callback for job.state.run that is longer than 80 characters, which does not follow the coding guidelines outlined in [RFC 7](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_7.html).

---

This PR just shortens the line to be at less than 80 characters.