### PR TITLE
doc: add note about case sensitivity for names

### DIFF
--- a/doc/components/database-administration.rst
+++ b/doc/components/database-administration.rst
@@ -75,6 +75,12 @@ From here, users can be added to these banks to create *associations*, a
 
  $ flux account add-user --username=user_1 --bank=bank_A
 
+.. note::
+    Both usernames and bank names are case sensitive. Make sure that if a name
+    contains a capital letter, it is referenced by its exact case throughout
+    the various flux-accounting components that take these names as a
+    parameter.
+
 If you wish to delete an association or bank from the database, you can run the
 ``flux account delete-user`` or ``flux account delete-bank`` commands. Note
 that this will not actually remove the association's or bank's row from the


### PR DESCRIPTION
#### Problem

As mentioned in #697, there is some confusion about having to reference usernames and bank names by their exact case, i.e. using capital letters for bank names that contain a capital letter, and there is no documentation making this clear for users and/or administrators.

---

This PR adds a note to the Database Administration document about case sensitivity and being careful about including capital letters in usernames or bank names.

Fixes #697