### PR TITLE
command: add `edit-all-users` command

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -36,7 +36,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-reset-factors.1 \
 	man1/flux-account-jobs.1 \
 	man1/flux-account-view-job-records.1 \
-	man1/flux-account-show-usage.1
+	man1/flux-account-show-usage.1 \
+	man1/flux-account-edit-all-users.1
 
 RST_FILES  = \
 	$(MAN1_FILES_PRIMARY:.1=.rst)

--- a/doc/man1/flux-account-edit-all-users.rst
+++ b/doc/man1/flux-account-edit-all-users.rst
@@ -1,0 +1,76 @@
+.. flux-help-section: flux account
+
+==============================
+flux-account-edit-all-users(1)
+==============================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **edit-all-users** [OPTIONS]
+
+DESCRIPTION
+===========
+
+.. program:: flux account edit-all-users
+
+:program:`flux account edit-all-users` allows for the modification of certain
+fields for *every* association in ``association_table``. The list of modifiable
+fields are as follows:
+
+.. option:: --bank
+
+    The bank that the user belongs to.
+
+.. option:: --default-bank
+
+    The default bank that the user belongs to.
+
+.. option:: --shares
+
+    The amount of available resources their organization considers they should
+    be entitled to use relative to other competing users.
+
+.. option:: --fairshare
+
+    The ratio between the amount of resources an association is allocated
+    versus the amount actually consumed.
+
+.. option:: --max-running-jobs
+
+    The max number of running jobs the association can have at any given time.
+
+.. option:: --max-active-jobs
+
+    The max number of both pending and running jobs the association can have at
+    any given time.
+
+.. option:: --max-nodes
+
+    The max number of nodes an association can have across all of their running
+    jobs.
+
+.. option:: --max-cores
+
+    The max number of cores an association can have across all of their running
+    jobs.
+
+.. option:: --queues
+
+    A comma-separated list of all of the queues an association can run jobs
+    under.
+
+.. option:: --projects
+
+    A comma-separated list of all of the projects an association can run jobs
+    under.
+
+.. option:: --default-project
+
+    The default project the association will submit jobs under when they do not
+    specify a project.
+
+Most of the attributes able to be modified can be reset to their default value
+by passing ``-1`` as the value for the field. Multiple fields can be edited at
+the same time by passing them on the command line.

--- a/doc/man1/flux-account.rst
+++ b/doc/man1/flux-account.rst
@@ -76,6 +76,13 @@ Modify an attribute for an association in the flux-accounting database.
 
 See :man1:`flux-account-edit-user` for more details.
 
+edit-all-users
+^^^^^^^^^^^^^^
+
+Modify an attribute for every association in the flux-accounting database.
+
+See :man1:`flux-account-edit-all-users` for more details.
+
 BANK ADMINISTRATION
 ===================
 

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -227,4 +227,11 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-edit-all-users",
+        "flux-account-edit-all-users",
+        "edit a column for every association in association_table",
+        [author],
+        1,
+    ),
 ]

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -581,3 +581,85 @@ def edit_user(conn, username, bank=None, **kwargs):
     conn.commit()
 
     return 0
+
+
+def edit_all_users(conn, **kwargs):
+    """
+    Edit an attribute for every row in association_table.
+
+    Args:
+        conn: A SQLite Connection object.
+        bank: The bank that the user belongs to.
+        default_bank: The default bank that the user belongs to.
+        shares: The amount of available resources their organization considers the user
+            should be entitled to use relative to other competing users.
+        fairshare: The ratio between the amount of resources an association is
+            allocated versus the amount actually consumed.
+        max_running_jobs: The max number of running jobs the association can have at any
+            given time.
+        max_active_jobs: The max number of both pending and running jobs the association
+            can have at any given time.
+        max_nodes: The man number of nodes an association can have across all of their
+            running jobs.
+        max_cores: The max number of cores an association can have across all of their
+            running jobs.
+        queues: A comma-separated list of all of the queues an association can run jobs
+            under.
+        projects: A comma-separated list of all of the projects an association can run jobs
+            under.
+        default_project: The association's default project.
+    """
+    cur = conn.cursor()
+    editable_fields = {
+        "bank",
+        "default_bank",
+        "shares",
+        "fairshare",
+        "max_running_jobs",
+        "max_active_jobs",
+        "max_nodes",
+        "max_cores",
+        "queues",
+        "projects",
+        "default_project",
+    }
+
+    updates = {
+        field: value
+        for field, value in kwargs.items()
+        if value is not None and field in editable_fields
+    }
+
+    if not updates:
+        raise ValueError("no fields provided for update")
+
+    reset_statements = []
+    reset_values = []
+
+    for field, value in updates.items():
+        if str(value) == "-1":
+            if field == "default_bank":
+                raise ValueError(
+                    "default bank cannot be reset with -1; please specify a value"
+                )
+            if field in {"queues", "projects"}:
+                reset_statements.append(f"{field}=''")
+            else:
+                reset_statements.append(f"{field}=NULL")
+        else:
+            if field == "queues":
+                validate_queue(conn, value)
+            elif field == "projects":
+                updates[field] = validate_project(conn, value)
+            reset_statements.append(f"{field}=?")
+            reset_values.append(updates[field])
+
+    # combine everything into a single UPDATE statement
+    if reset_statements:
+        stmt = f"UPDATE association_table SET {', '.join(reset_statements)}"
+        cur.execute(stmt, reset_values)
+        # update mod_time
+        cur.execute("UPDATE association_table SET mod_time=?", (int(time.time()),))
+        conn.commit()
+
+    return 0

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -122,6 +122,7 @@ class AccountingService:
             "shutdown_service",
             "edit_factor",
             "reset_factors",
+            "edit_all_users",
         ]
 
         for name in general_endpoints:
@@ -695,6 +696,33 @@ class AccountingService:
             handle.respond_error(msg, 0, f"show-usage: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(msg, 0, f"show-usage: {type(exc).__name__}: {exc}")
+
+    def edit_all_users(self, handle, watcher, msg, arg):
+        try:
+            val = u.edit_all_users(
+                conn=self.conn,
+                bank=msg.payload.get("bank"),
+                default_bank=msg.payload.get("default_bank"),
+                shares=msg.payload.get("shares"),
+                fairshare=msg.payload.get("fairshare"),
+                max_running_jobs=msg.payload.get("max_running_jobs"),
+                max_active_jobs=msg.payload.get("max_active_jobs"),
+                max_nodes=msg.payload.get("max_nodes"),
+                max_cores=msg.payload.get("max_cores"),
+                queues=msg.payload.get("queues"),
+                projects=msg.payload.get("projects"),
+                default_project=msg.payload.get("default_project"),
+            )
+
+            payload = {"edit_all_users": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(
+                msg, 0, f"edit-all-users: missing key in payload: {exc}"
+            )
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"edit-all-users: {type(exc).__name__}: {exc}")
 
 
 LOGGER = logging.getLogger("flux-uri")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -340,6 +340,81 @@ def add_edit_user_arg(subparsers):
     )
 
 
+def add_edit_all_users_arg(subparsers):
+    subparser_edit_all_users = subparsers.add_parser(
+        "edit-all-users",
+        help="edit an attribute for every row in association_table",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_edit_all_users.set_defaults(func="edit_all_users")
+    subparser_edit_all_users.add_argument(
+        "--bank",
+        help="bank to charge jobs against",
+        default=None,
+        metavar="BANK",
+    )
+    subparser_edit_all_users.add_argument(
+        "--default-bank",
+        help="default bank",
+        default=None,
+        metavar="DEFAULT_BANK",
+    )
+    subparser_edit_all_users.add_argument(
+        "--shares",
+        help="shares",
+        default=None,
+        metavar="SHARES",
+    )
+    subparser_edit_all_users.add_argument(
+        "--fairshare",
+        help="fairshare",
+        default=None,
+        metavar="SHARES",
+    )
+    subparser_edit_all_users.add_argument(
+        "--max-running-jobs",
+        help="max number of jobs that can be running at the same time",
+        default=None,
+        metavar="MAX_RUNNING_JOBS",
+    )
+    subparser_edit_all_users.add_argument(
+        "--max-active-jobs",
+        help="max number of both pending and running jobs",
+        default=None,
+        metavar="max_active_jobs",
+    )
+    subparser_edit_all_users.add_argument(
+        "--max-nodes",
+        help="max number of nodes a user can have across all of their running jobs",
+        default=None,
+        metavar="MAX_NODES",
+    )
+    subparser_edit_all_users.add_argument(
+        "--max-cores",
+        help="max number of cores a user can have across all of their running jobs",
+        default=None,
+        metavar="MAX_CORES",
+    )
+    subparser_edit_all_users.add_argument(
+        "--queues",
+        help="queues the user is allowed to run jobs in",
+        default=None,
+        metavar="QUEUES",
+    )
+    subparser_edit_all_users.add_argument(
+        "--projects",
+        help="projects the user is allowed to submit jobs under",
+        default=None,
+        metavar="PROJECTS",
+    )
+    subparser_edit_all_users.add_argument(
+        "--default-project",
+        help="default projects the user submits jobs under when no project is specified",
+        default=None,
+        metavar="DEFAULT_PROJECT",
+    )
+
+
 def add_view_job_records_arg(subparsers):
     subparser_view_job_records = subparsers.add_parser(
         "view-job-records",
@@ -1103,6 +1178,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_reset_priority_factors_arg(subparsers)
     add_jobs_arg(subparsers)
     add_show_usage_arg(subparsers)
+    add_edit_all_users_arg(subparsers)
 
 
 def set_db_location(args):
@@ -1152,6 +1228,7 @@ def select_accounting_function(args, output_file, parser):
         "reset_factors": "accounting.reset_factors",
         "jobs": "accounting.jobs",
         "show_usage": "accounting.show_usage",
+        "edit_all_users": "accounting.edit_all_users",
     }
 
     if args.func in func_map:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -62,6 +62,7 @@ TESTSCRIPTS = \
 	t1057-flux-account-jobs.t \
 	t1058-flux-account-visuals.t \
 	t1059-issue685.t \
+	t1060-flux-account-edit-all-users.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1060-flux-account-edit-all-users.t
+++ b/t/t1060-flux-account-edit-all-users.t
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+test_description='test the edit-all-users command'
+
+. `dirname $0`/sharness.sh
+
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1
+'
+
+test_expect_success 'add a queue' '
+	flux account add-queue bronze
+'
+
+test_expect_success 'add a project' '
+	flux account add-project physics
+'
+
+test_expect_success 'add some associations' '
+	flux account add-user --username=user1 --bank=A &&
+	flux account add-user --username=user2 --bank=A &&
+	flux account add-user --username=user3 --bank=A
+'
+
+test_expect_success 'list all associations' '
+	flux account list-users -o "{username:<8} | {bank:<8}" > users.default &&
+	grep "username | bank" users.default &&
+	grep "user1    | A" users.default &&
+	grep "user2    | A" users.default &&
+	grep "user3    | A" users.default
+'
+
+test_expect_success 'call edit-all-users with no args passed; make sure ValueError is raised' '
+	test_must_fail flux account edit-all-users > no_args.error 2>&1 &&
+	grep "edit-all-users: ValueError: no fields provided for update" no_args.error
+'
+
+test_expect_success 'edit the bank for every association' '
+	flux account edit-all-users --bank=B &&
+	flux account list-users -o "{username:<8} | {bank:<8}" > new_bank.test &&
+	grep "username | bank" new_bank.test &&
+	grep "user1    | B" new_bank.test &&
+	grep "user2    | B" new_bank.test &&
+	grep "user3    | B" new_bank.test
+'
+
+test_expect_success 'edit the default bank for every association' '
+	flux account edit-all-users --default-bank=B &&
+	flux account list-users -o "{username:<8} | {default_bank:<8}" > new_default_bank.test &&
+	grep "username | default_bank" new_default_bank.test &&
+	grep "user1    | B" new_default_bank.test &&
+	grep "user2    | B" new_default_bank.test &&
+	grep "user3    | B" new_default_bank.test
+'
+
+test_expect_success 'edit the shares for every association' '
+	flux account edit-all-users --shares=100 &&
+	flux account list-users -o "{username:<8} | {shares:<8}" > new_shares.test &&
+	grep "username | shares" new_shares.test &&
+	grep "user1    | 100" new_shares.test &&
+	grep "user2    | 100" new_shares.test &&
+	grep "user3    | 100" new_shares.test
+'
+
+test_expect_success 'edit the fair-share for every association' '
+	flux account edit-all-users --fairshare=0.75 &&
+	flux account list-users -o "{username:<8} | {fairshare:<8}" > new_fairshare.test &&
+	grep "username | fairshare" new_fairshare.test &&
+	grep "user1    | 0.75" new_fairshare.test &&
+	grep "user2    | 0.75" new_fairshare.test &&
+	grep "user3    | 0.75" new_fairshare.test
+'
+
+test_expect_success 'edit the max-running-jobs for every association' '
+	flux account edit-all-users --max-running-jobs=100 &&
+	flux account list-users -o "{username:<8} | {max_running_jobs:<8}" > new_max_run_jobs.test &&
+	grep "username | max_running_jobs" new_max_run_jobs.test &&
+	grep "user1    | 100" new_max_run_jobs.test &&
+	grep "user2    | 100" new_max_run_jobs.test &&
+	grep "user3    | 100" new_max_run_jobs.test
+'
+
+test_expect_success 'edit the max-active-jobs for every association' '
+	flux account edit-all-users --max-active-jobs=200 &&
+	flux account list-users -o "{username:<8} | {max_active_jobs:<8}" > new_max_active_jobs.test &&
+	grep "username | max_active_jobs" new_max_active_jobs.test &&
+	grep "user1    | 200" new_max_active_jobs.test &&
+	grep "user2    | 200" new_max_active_jobs.test &&
+	grep "user3    | 200" new_max_active_jobs.test
+'
+
+test_expect_success 'edit the max-nodes for every association' '
+	flux account edit-all-users --max-nodes=100 &&
+	flux account list-users -o "{username:<8} | {max_nodes:<8}" > new_max_nodes.test &&
+	grep "username | max_nodes" new_max_nodes.test &&
+	grep "user1    | 100" new_max_nodes.test &&
+	grep "user2    | 100" new_max_nodes.test &&
+	grep "user3    | 100" new_max_nodes.test
+'
+
+test_expect_success 'edit the max-cores for every association' '
+	flux account edit-all-users --max-cores=1000 &&
+	flux account list-users -o "{username:<8} | {max_cores:<8}" > new_max_cores.test &&
+	grep "username | max_cores" new_max_cores.test &&
+	grep "user1    | 1000" new_max_cores.test &&
+	grep "user2    | 1000" new_max_cores.test &&
+	grep "user3    | 1000" new_max_cores.test
+'
+
+test_expect_success 'edit the queues for every association' '
+	flux account edit-all-users --queues="bronze" &&
+	flux account list-users -o "{username:<8} | {queues:<8}" > new_queues.test &&
+	grep "username | queues" new_queues.test &&
+	grep "user1    | bronze" new_queues.test &&
+	grep "user2    | bronze" new_queues.test &&
+	grep "user3    | bronze" new_queues.test
+'
+
+test_expect_success 'edit the projects for every association' '
+	flux account edit-all-users --projects="physics" &&
+	flux account list-users -o "{username:<8} | {projects:<8}" > new_projects.test &&
+	grep "username | projects" new_projects.test &&
+	grep "user1    | physics" new_projects.test &&
+	grep "user2    | physics" new_projects.test &&
+	grep "user3    | physics" new_projects.test
+'
+
+test_expect_success 'edit the default project for every association' '
+	flux account edit-all-users --default-project="physics" &&
+	flux account list-users -o "{username:<8} | {default_project:<8}" > new_default_project.test &&
+	grep "username | default_project" new_default_project.test &&
+	grep "user1    | physics" new_default_project.test &&
+	grep "user2    | physics" new_default_project.test &&
+	grep "user3    | physics" new_default_project.test
+'
+
+test_expect_success 'edit multiple fields at once for every association' '
+	flux account edit-all-users --bank=A --max-nodes=123 &&
+	flux account list-users -o "{username:<8} | {bank:<8} | {max_nodes:<8}" > multiple_fields.test &&
+	grep "username | bank     | max_nodes" multiple_fields.test &&
+	grep "user1    | A        | 123" multiple_fields.test &&
+	grep "user2    | A        | 123" multiple_fields.test &&
+	grep "user3    | A        | 123" multiple_fields.test
+'
+
+test_expect_success 'reset a field for every association' '
+	flux account edit-all-users --max-cores=-1 &&
+	flux account list-users -o "{username:<8} | {max_cores:<8}" > reset_max_cores.test &&
+	grep "username | max_cores" reset_max_cores.test &&
+	grep "user1    | 2147483647" reset_max_cores.test &&
+	grep "user2    | 2147483647" reset_max_cores.test &&
+	grep "user3    | 2147483647" reset_max_cores.test
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

There is no way to efficiently edit a column (or attribute) for every association in `association_table`. This might come in handy in the case that an admin wants to update something for every association, such as increasing the `max_active_jobs` limit for every association.

---

This PR adds a new command to the flux-accounting command suite called `edit-all-users`, which takes optional arguments for a number of columns in `association_table` and executes an `UPDATE` statement for every association in the table at once.

Sharness tests and documentation for the command are also added.