### PR TITLE
plugin: add `QueueUsage` class to track an association's node usage per-queue

### DIFF
--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -66,6 +66,13 @@ public:
     int max_nodes_per_assoc = 2147483647;
 };
 
+// a class to track an association's usage in a particular queue
+class QueueUsage {
+public:
+    int cur_run_jobs = 0; // number of running jobs in queue
+    int cur_nodes = 0;    // number of nodes across all running jobs in queue
+};
+
 // all attributes are per-user/bank
 class Association {
 public:
@@ -87,8 +94,8 @@ public:
     int max_cores;                     // max num cores across all running jobs
     int cur_nodes;                     // current number of used nodes
     int cur_cores;                     // current number of used cores
-    std::unordered_map<std::string, int>
-      queue_usage;                     // track num of running jobs per queue
+    std::unordered_map<std::string, QueueUsage>
+      queue_usage;                     // the association's usage per-queue
 
     // methods
     json_t* to_json () const;    // convert object to JSON string

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1195,7 +1195,7 @@ static int run_cb (flux_plugin_t *p,
     if (queue != NULL)
         // a queue was passed-in; increment counter of the number of
         // queue-specific running jobs for this association
-        b->queue_usage[std::string (queue)]++;
+        b->queue_usage[std::string (queue)].cur_run_jobs++;
 
     // increment the user's current running jobs count
     b->cur_run_jobs++;
@@ -1497,9 +1497,9 @@ static int inactive_cb (flux_plugin_t *p,
 
     // if a queue cannot be found, just set it to ""
     queue_str = queue ? queue : "";
-    if (b->queue_usage[queue_str] > 0)
+    if (b->queue_usage[queue_str].cur_run_jobs > 0)
         // decrement num of running jobs the association has in queue
-        b->queue_usage[queue_str]--;
+        b->queue_usage[queue_str].cur_run_jobs--;
 
     if (!b->held_jobs.empty ()) {
         // the Association has at least one held Job; begin looping through

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -268,7 +268,7 @@ static void test_under_queue_max_running_jobs_true ()
 {
     Association a = users[1001]["bank_A"];
     Queue bronze = queues["bronze"];
-    ok ((a.queue_usage["bronze"] < bronze.max_running_jobs) == true,
+    ok ((a.queue_usage["bronze"].cur_run_jobs < bronze.max_running_jobs) == true,
         "association is under the max running jobs limit for the queue");
 }
 
@@ -279,8 +279,8 @@ static void test_under_queue_max_running_jobs_false ()
     Queue bronze = queues["bronze"];
     // simulate the Association being at their queue max running jobs limit
     bronze.max_running_jobs = 5;
-    a.queue_usage["bronze"] = 5;
-    ok ((a.queue_usage["bronze"] < bronze.max_running_jobs) == false,
+    a.queue_usage["bronze"].cur_run_jobs = 5;
+    ok ((a.queue_usage["bronze"].cur_run_jobs < bronze.max_running_jobs) == false,
         "association is at their max running jobs limit for the queue");
 }
 

--- a/src/plugins/test/dependencies_test03.cpp
+++ b/src/plugins/test/dependencies_test03.cpp
@@ -150,7 +150,7 @@ void max_run_jobs_per_queue_and_per_association ()
     Association *a = &users[50001]["bank_A"];
     a->cur_run_jobs = 1;
     a->cur_active_jobs = 2;
-    a->queue_usage["gold"] = 1; // one running job in gold queue
+    a->queue_usage["gold"].cur_run_jobs = 1; // one running job in gold queue
 
     // add held Job to Association object
     Job job;
@@ -193,7 +193,7 @@ void under_max_run_jobs_per_association_and_per_queue_true ()
     Association *a = &users[50001]["bank_A"];
     a->cur_run_jobs = 0;
     a->cur_active_jobs = 1;
-    a->queue_usage["gold"] = 0;
+    a->queue_usage["gold"].cur_run_jobs = 0;
     Job held_job = a->held_jobs.front ();
 
     ok (a->under_max_run_jobs () == true,
@@ -241,7 +241,7 @@ void max_run_jobs_per_queue ()
     a->max_run_jobs = 10;
     a->cur_run_jobs = 1;
     a->cur_active_jobs = 2;
-    a->queue_usage["gold"] = 1;
+    a->queue_usage["gold"].cur_run_jobs = 1;
 
     // add held Job to Association object
     Job job;
@@ -277,7 +277,7 @@ void under_max_run_jobs_per_queue_true ()
     Association *a = &users[50001]["bank_A"];
     a->cur_run_jobs = 0;
     a->cur_active_jobs = 1;
-    a->queue_usage["gold"] = 0;
+    a->queue_usage["gold"].cur_run_jobs = 0;
     Job held_job = a->held_jobs.front ();
 
     ok (a->under_max_run_jobs () == true,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -62,6 +62,7 @@ TESTSCRIPTS = \
 	t1057-flux-account-jobs.t \
 	t1058-flux-account-visuals.t \
 	t1059-issue685.t \
+	t1060-mf-priority-queue-usage.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1052-mf-priority-queue-limits.t
+++ b/t/t1052-mf-priority-queue-limits.t
@@ -94,7 +94,7 @@ test_expect_success 'running jobs count for the queues are incremented once jobs
 	flux jobtap query mf_priority.so > silver.json &&
 	jq -e ".mf_priority_map[] | \
 		select(.userid == 5001) | \
-		.banks[0].queue_usage.silver == 2" <silver.json
+		.banks[0].queue_usage[\"silver\"].cur_run_jobs == 2" <silver.json
 '
 
 test_expect_success 'a third job to the silver queue results in a dependency-add' '
@@ -141,7 +141,7 @@ test_expect_success 'running jobs count for the queues are decremented once jobs
 	flux jobtap query mf_priority.so > query.json &&
 	jq -e ".mf_priority_map[] | \
 		select(.userid == 5001) | \
-		.banks[0].queue_usage.silver == 0" <query.json &&
+		.banks[0].queue_usage[\"silver\"].cur_run_jobs == 0" <query.json &&
 	jq -e ".mf_priority_map[] | \
 		select(.userid == 5001) | \
 		.banks[0].cur_run_jobs == 0" <query.json &&

--- a/t/t1060-mf-priority-queue-usage.t
+++ b/t/t1060-mf-priority-queue-usage.t
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+test_description='test tracking per-queue resource usage'
+
+. `dirname $0`/sharness.sh
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+DB_PATH=$(pwd)/FluxAccountingTest.db
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze &&
+	flux account add-queue silver
+'
+
+test_expect_success 'configure flux with those queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user --username=user1 \
+		--userid=50001 \
+		--bank=A \
+		--queues=bronze,silver
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+# The association's usage will be 1 node total in just the bronze queue.
+test_expect_success 'submit a 1-node job to bronze queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc
+'
+
+test_expect_success 'check resource counts for association' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		select(.userid == 50001) |
+		.banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'cancel job' '
+	flux cancel ${job1}
+'
+
+# The association's usage will be 2 nodes total in just the bronze queue.
+test_expect_success 'submit 2 1-node jobs to bronze queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job2} alloc
+'
+
+test_expect_success 'check resource counts for association' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 2" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} &&
+	flux cancel ${job2}
+'
+
+# The association's usage will be 5 nodes total in both the bronze and silver
+# queue; 1 node in the bronze queue, and 4 in the silver queue.
+test_expect_success 'submit 2 different-sized jobs to multiple queues' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 --queue=silver -N4 sleep 60) &&
+	flux job wait-event -vt 5 ${job2} alloc
+'
+
+test_expect_success 'check resource counts in bronze queue for association' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 5" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'check resource counts in silver queue for association' '
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"silver\"].cur_nodes == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"silver\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} &&
+	flux cancel ${job2}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The `queue_usage` attribute of the `Association` class currently _only_ keeps track of the queue an association is running their jobs under and how many running jobs they have under that particular queue. However, there is also a need to know how many resources (i.e. nodes) an association has across all of their running jobs under that queue, which the plugin does not currently keep track of.

---

This PR changes the `queue_usage` attribute of the `Association` class to instead be a map where the key remains the same (a string containing the name of the queue) but with a value of a new `QueueUsage` class, a class that tracks both an association's number of currently running jobs as well as their total node usage across all of their running jobs in that queue. Node usage per-queue is now tracked among an association's set of running jobs. Note that _no_ limit enforcement based on an association's per-queue node usage is added in this PR, but will be added in a future PR.

The plugin is updated to change the way the current number of running jobs per-queue is accessed to use the new class. The `to_json ()` method for `Association` objects is also updated to pack all of the `QueueUsage` class attributes into a JSON object when constructing JSON output for each association.

Tests are added to check different scenarios of an association submitting different-sized jobs to one and/or multiple queues and ensuring that resource counts are correct.

Fixes #691
Fixes #692