### PR TITLE
plugin: add enforcement of a per-queue max nodes limit

### DIFF
--- a/doc/components/limits.rst
+++ b/doc/components/limits.rst
@@ -41,6 +41,10 @@ The soft limits in flux-accounting are composed of:
   The max number of running jobs an association can have in a given queue at
   any given time.
 
+(per-queue) max nodes
+  The max number of nodes an association can have across their running jobs in
+  a givent queue at any given time.
+
 .. note::
     For more details on the difference between an active job and a running job,
     see the `virtual states`_ section of RFC 21.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,8 @@ TESTS = \
 	accounting_test01.t \
 	job_test02.t \
 	dependencies_test03.t \
-	banks_test04.t
+	banks_test04.t \
+	queue_limits_test05.t
 check_PROGRAMS = $(TESTS)
 
 TEST_EXTENSIONS = .t
@@ -137,6 +138,18 @@ banks_test04_t_SOURCES = \
 	plugins/accounting.hpp
 banks_test04_t_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir) $(JANSSON_CFLAGS)
 banks_test04_t_LDADD = \
+	common/libtap/libtap.la \
+	$(JANSSON_LIBS)
+
+queue_limits_test05_t_SOURCES = \
+	plugins/test/queue_limits_test05.cpp \
+	plugins/accounting.cpp \
+	plugins/accounting.hpp \
+	plugins/job.cpp \
+	plugins/job.hpp \
+	plugins/jj.cpp
+queue_limits_test05_t_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir) $(JANSSON_CFLAGS)
+queue_limits_test05_t_LDADD = \
 	common/libtap/libtap.la \
 	$(JANSSON_LIBS)
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -324,3 +324,12 @@ bool Association::under_max_resources (const Job &job)
 
     return under_max_resources;
 }
+
+bool Association::under_queue_max_resources (const Job &job,
+                                             const Queue &queue)
+{
+    bool under_max_nodes = (queue_usage[queue.name].cur_nodes + job.nnodes)
+                           <= queue.max_nodes_per_assoc;
+
+    return under_max_nodes;
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -51,6 +51,7 @@ extern "C" {
 #define D_QUEUE_MRJ  "max-run-jobs-queue"
 #define D_ASSOC_MRJ  "max-running-jobs-user-limit"
 #define D_ASSOC_MRES "max-resources-user-limit"
+#define D_QUEUE_MRES "max-resources-queue"
 
 // min_nodes_per_job, max_nodes_per_job, and max_time_per_job are not
 // currently used or enforced in this plugin, so their values have no
@@ -105,6 +106,7 @@ public:
     bool under_queue_max_run_jobs (const std::string &queue,
                                    std::map<std::string, Queue> queues);
     bool under_max_resources (const Job &job);
+    bool under_queue_max_resources (const Job &job, const Queue &queue);
 };
 
 class Bank {

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -312,6 +312,18 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
             }
             held_job.remove_dep (D_QUEUE_MRJ);
         }
+        // is the association under the max nodes limit for the queue the
+        // held job is submitted under?
+        if (b->under_queue_max_resources (held_job, queues[held_job.queue]) &&
+            held_job.contains_dep (D_QUEUE_MRES)) {
+            if (flux_jobtap_dependency_remove (p,
+                                               held_job.id,
+                                               D_QUEUE_MRES) < 0) {
+                dependency = D_QUEUE_MRES;
+                goto error;
+            }
+            held_job.remove_dep (D_QUEUE_MRES);
+        }
         // is association under their overall max running jobs limit?
         if (b->under_max_run_jobs () && held_job.contains_dep (D_ASSOC_MRJ)) {
             if (flux_jobtap_dependency_remove (p,
@@ -1129,6 +1141,13 @@ static int depend_cb (flux_plugin_t *p,
             if (flux_jobtap_dependency_add (p, id, D_QUEUE_MRJ) < 0)
                 goto error;
             job.add_dep (D_QUEUE_MRJ);
+        }
+        if (!b->under_queue_max_resources (job, queues[queue_str])) {
+            // association is already at their max nodes limit across their
+            // running jobs in this queue; add a dependency
+            if (flux_jobtap_dependency_add (p, id, D_QUEUE_MRES) < 0)
+                goto error;
+            job.add_dep (D_QUEUE_MRES);
         }
         if (!b->under_max_run_jobs ()) {
             // association is already at their max running jobs count; add a

--- a/src/plugins/test/queue_limits_test05.cpp
+++ b/src/plugins/test/queue_limits_test05.cpp
@@ -1,0 +1,162 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <map>
+#include <string>
+
+#include "src/plugins/accounting.hpp"
+#include "src/plugins/job.hpp"
+#include "src/common/libtap/tap.h"
+
+// define a test users map to run tests on
+std::map<int, std::map<std::string, Association>> users;
+// define a test queues map
+std::map<std::string, Queue> queues;
+
+
+/*
+ * add an association
+ */
+void initialize_map (
+    std::map<int, std::map<std::string, Association>> &users)
+{
+    Association user1 {};
+    user1.bank_name = "bank_A";
+    user1.max_run_jobs = 100;
+    user1.max_active_jobs = 150;
+    user1.queues = {"bronze", "silver"};
+
+    users[50001]["bank_A"] = user1;
+}
+
+/*
+ * helper function to add test queues to the queues map
+ */
+void initialize_queues () {
+    queues["bronze"] = {};
+    queues["bronze"].name = "bronze";
+    queues["bronze"].max_running_jobs = 100;
+    queues["bronze"].max_nodes_per_assoc = 1;
+}
+
+void queue_limits_defined ()
+{
+    ok (queues["bronze"].max_nodes_per_assoc == 1,
+        "bronze queue has a max_nodes limit of 1");
+}
+
+/*
+ * Without running any prior jobs, an association is under the
+ * queue's max_nodes limit.
+ */
+void association_under_queue_max_nodes_limit_true ()
+{
+    Association *a = &users[50001]["bank_A"];
+
+    // create a Job object
+    Job job;
+    job.id = 1;
+    job.nnodes = 1;
+    job.queue = "bronze";
+
+    ok (a->queue_usage["bronze"].cur_nodes == 0,
+        "association has no occupied nodes under bronze queue");
+    ok (a->under_queue_max_resources (job, queues["bronze"]) == true,
+        "association is under queue's max_nodes limit");
+
+    // assume job passes all checks and has moved to RUN state
+    a->cur_run_jobs = 1;
+    a->cur_nodes = 1;
+    a->queue_usage["bronze"].cur_run_jobs = 1;
+    a->queue_usage["bronze"].cur_nodes = 1;
+}
+
+/*
+ * Once an association's limit is hit within a particular queue, a
+ * per-queue dependency is added on the job.
+ */
+void association_under_queue_max_nodes_limit_false ()
+{
+    Association *a = &users[50001]["bank_A"];
+
+    // assume Job object above is still running; create a Job object that is
+    // also under the "bronze" queue (so it will have a dependency added to it)
+    Job job;
+    job.id = 2;
+    job.nnodes = 1;
+    job.queue = "bronze";
+    job.add_dep (D_QUEUE_MRES);
+    a->held_jobs.emplace_back (job);
+
+    ok (a->held_jobs.size () == 1,
+        "association has one held job due to per-queue max_resources limit");
+    ok (job.deps.size () == 1,
+        "held job has one dependency added to it");
+    ok (a->under_queue_max_resources (job, queues["bronze"]) == false,
+        "association is not under queue's max_nodes limit");
+}
+
+/*
+ * Once the first job finishes running and current job and resource counters
+ * are decremented, the check for the held job will pass, the dependency will
+ * be removed, and the job can proceed to RUN state.
+ */
+void association_release_held_job_true ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_run_jobs = 0;
+    a->cur_nodes = 0;
+    a->queue_usage["bronze"].cur_run_jobs = 0;
+    a->queue_usage["bronze"].cur_nodes = 0;
+    Job held_job = a->held_jobs.front ();
+
+    ok (a->under_queue_max_resources (held_job, queues["bronze"]) == true,
+        "association is now under queue's max_nodes limit");
+    
+    held_job.remove_dep (D_QUEUE_MRES);
+    ok (held_job.deps.size () == 0,
+        "held job no longer has any dependencies added to it");
+    
+    // erase held job from association's held_jobs vector
+    a->held_jobs.clear ();
+    ok (a->held_jobs.size () == 0,
+        "association has no more held jobs");
+}
+
+int main (int argc, char* argv[])
+{
+    // add an association
+    initialize_map (users);
+    // add queues to the test queues map
+    initialize_queues ();
+
+    queue_limits_defined ();
+    association_under_queue_max_nodes_limit_true ();
+    association_under_queue_max_nodes_limit_false ();
+    association_release_held_job_true ();
+
+    // indicate we are done testing
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -64,6 +64,7 @@ TESTSCRIPTS = \
 	t1059-issue685.t \
 	t1060-mf-priority-queue-usage.t \
 	t1061-flux-account-edit-all-users.t \
+	t1062-mf-priority-queue-resource-limits.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1062-mf-priority-queue-resource-limits.t
+++ b/t/t1062-mf-priority-queue-resource-limits.t
@@ -1,0 +1,428 @@
+#!/bin/bash
+
+test_description='test enforcing per-queue resource limits'
+
+. `dirname $0`/sharness.sh
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+DB_PATH=$(pwd)/FluxAccountingTest.db
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+
+mkdir -p config
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add some queues to the DB' '
+	flux account add-queue bronze --max-nodes-per-assoc=1 &&
+	flux account add-queue silver --max-nodes-per-assoc=2 &&
+	flux account add-queue gold --max-nodes-per-assoc=3
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user --username=user1 \
+		--userid=50001 \
+		--bank=A \
+		--max-running-jobs=2 \
+		--max-active-jobs=100 \
+		--max-nodes=10 \
+		--max-cores=100 \
+		--queues=bronze,silver,gold
+'
+
+test_expect_success 'configure flux with those queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.bronze]
+	[queues.silver]
+	[queues.gold]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'send flux-accounting information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+# Scenario 1: An association submits a 1-node job to the bronze queue, which
+# has a max_nodes limit of 1. A second-submitted job to the bronze queue will
+# be held with a queue-specific max resources dependency. 
+test_expect_success 'submit a job to bronze queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc
+'
+
+test_expect_success 'check resource counts for association in bronze queue' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'hold second job due to per-queue max nodes limit' '
+	job2=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-queue" \
+		${job2} dependency-add &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json
+'
+
+test_expect_success 'second job gets released when first job completes' '
+	flux cancel ${job1} &&
+	flux job wait-event -vt 5 ${job2} alloc &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+test_expect_success 'cancel second job' '
+	flux cancel ${job2}
+'
+
+# Scenario 2: An association submits a 1-node job to the bronze queue, which
+# has a max_nodes limit of 1. The association's properties are also edited to
+# have a max_nodes limit of 1. A second-submitted job to the bronze queue will
+# be held with BOTH a queue-specific max_nodes_per_assoc dependency AND a
+# per-association max resources dependency.
+test_expect_success 'edit association max_nodes limit to 1' '
+	flux account edit-user user1 --max-nodes=1
+'
+
+test_expect_success 'send flux-accounting information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job to bronze queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc
+'
+
+test_expect_success 'check resource counts for association' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'hold second job due to queue and association limits' '
+	job2=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-queue" \
+		${job2} dependency-add &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-user-limit" \
+		${job2} dependency-add &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json
+'
+
+test_expect_success 'second job gets released when first job completes' '
+	flux cancel ${job1} &&
+	flux job wait-event -vt 5 ${job2} alloc &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+test_expect_success 'cancel second job' '
+	flux cancel ${job2}
+'
+
+# Scenario 3: An association submits a 1-node job to the bronze queue, which
+# has a max_nodes limit of 1 AND a max_running_jobs limit of 1. A
+# second-submitted job to the bronze queue will be held with the following
+# dependencies:
+#   - queue-specific max_nodes_per_assoc
+#   - queue-specific max_running_jobs
+#   - association-specific max_nodes
+test_expect_success 'edit queue max_running_jobs limit to 1' '
+	flux account edit-queue bronze --max-running-jobs=1
+'
+
+test_expect_success 'send flux-accounting information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job to bronze queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc
+'
+
+test_expect_success 'check resource counts for association' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'second job is held due to multiple limits being hit' '
+	job2=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-queue" \
+		${job2} dependency-add &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-user-limit" \
+		${job2} dependency-add &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-run-jobs-queue" \
+		${job2} dependency-add &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json
+'
+
+test_expect_success 'second job gets released when first job completes' '
+	flux cancel ${job1} &&
+	flux job wait-event -vt 5 ${job2} alloc &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs |
+		 length == 0" <query.json
+'
+
+test_expect_success 'cancel second job' '
+	flux cancel ${job2}
+'
+
+# Scenario 4: An association submits a 1-node job to the bronze queue, which
+# has a max_nodes limit of 1 AND a max_running_jobs limit of 1. The
+# association's properties are also edited to have a max running jobs limit of
+# 1. A second-submitted job to the bronze queue will be held with the following
+# dependencies:
+#   - queue-specific max_nodes
+#   - queue-specific max_running_jobs
+#   - association-specific max_nodes
+#   - association-specific max_running_jobs
+test_expect_success 'edit association max_running_jobs limit to 1' '
+	flux account edit-user user1 --max-running-jobs=1
+'
+
+test_expect_success 'send flux-accounting information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job to bronze queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 ${job1} alloc
+'
+
+test_expect_success 'check resource counts for association' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json
+'
+
+test_expect_success 'second job is held due to multiple limits being hit' '
+	job2=$(flux python ${SUBMIT_AS} 50001 --queue=bronze -N1 sleep 60) &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-queue" \
+		${job2} dependency-add &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-resources-user-limit" \
+		${job2} dependency-add &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-run-jobs-queue" \
+		${job2} dependency-add &&
+	flux job wait-event -vt 5 \
+		--match-context=description="max-running-jobs-user-limit" \
+		${job2} dependency-add &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json
+'
+
+test_expect_success 'second job gets released when first job completes' '
+	flux cancel ${job1} &&
+	flux job wait-event -vt 5 ${job2} alloc &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_nodes == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage[\"bronze\"].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+test_expect_success 'cancel second job' '
+	flux cancel ${job2}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The plugin needs a way to enforce a per-queue max nodes limit when an association is using up a lot of nodes across their running jobs under a particular queue.

---

This PR adds limit enforcement on the max number of nodes an association can have across all of their running jobs in a particular queue. It adds a method to the `Association` class to check if their submitted job would put them _over_ the queue's max nodes limit, and if it does, a dependency is added to the job until a currently running job in that queue completes.

Unit tests are added for checking the new `under_queue_max_resources ()` method and sharness tests are added for simulating different scenarios where an association hits the per-queue max nodes limit as well as any other potential limits at the same time.

Fixes #693