### PR TITLE
`view-user`: add `-J/--job-usage` optional arg

### DIFF
--- a/doc/components/job-usage-calculation.rst
+++ b/doc/components/job-usage-calculation.rst
@@ -83,3 +83,21 @@ The past usage factors have the decay factor applied to them:
 
 :math:`U_{user1002}`'s job usage value now becomes :math:`16089.0`, which takes
 into account both their most recent *and* historical job usage.
+
+
+Viewing Breakdowns of Historical Job Usage
+==========================================
+
+Since an association's historical job usage (i.e. the value reported in the
+``job_usage`` column) is comprised of potentially multiple usage factors that
+make up an association's job usage value, it would be useful to see how this
+value is calculated. The ``view-user`` command offers a ``-j/--job-usage``
+optional argument, which will return all of the association's job usage columns
+that make up their historical job usage value:
+
+.. code-block:: console
+
+    $ flux account view-user --parsable -j moussa
+    username | userid | bank     | usage_factor_period_0 | usage_factor_period_1 | usage_factor_period_2 | usage_factor_period_3
+    ---------+--------+----------+-----------------------+-----------------------+-----------------------+----------------------
+    moussa   | 12345  | A        | 100.0                 | 243.5                 | 8.7                   | 0.0  

--- a/doc/man1/flux-account-view-user.rst
+++ b/doc/man1/flux-account-view-user.rst
@@ -35,3 +35,11 @@ well as customizing which fields are returned.
 .. option:: -o/--format
 
     Specify output format using Python's string format syntax.
+
+.. option:: -j/--job-usage
+
+    List all of the past job usage factors that make up an association's
+    historical job usage value.
+
+    .. note::
+        This optional argument cannot be combined with ``--fields``.

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -153,6 +153,7 @@ class AccountingService:
                 else None,
                 msg.payload.get("list_banks"),
                 msg.payload.get("format"),
+                msg.payload.get("job_usage"),
             )
 
             payload = {"view_user": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -49,17 +49,6 @@ def add_view_user_arg(subparsers):
         metavar="PARSABLE",
     )
     subparser_view_user.add_argument(
-        "--fields",
-        type=str,
-        help="list of fields to include in JSON output",
-        default=None,
-        metavar=(
-            "CREATION_TIME,MOD_TIME,ACTIVE,USERNAME,USERID,BANK,DEFAULT_BANK,"
-            "SHARES,JOB_USAGE,FAIRSHARE,MAX_RUNNING_JOBS,MAX_ACTIVE_JOBS,MAX_NODES,"
-            "MAX_CORES,QUEUES,PROJECTS,DEFAULT_PROJECT"
-        ),
-    )
-    subparser_view_user.add_argument(
         "--list-banks",
         action="store_const",
         const=True,
@@ -73,6 +62,25 @@ def add_view_user_arg(subparsers):
         default="",
         help="Specify output format using Python's string format syntax.",
         metavar="FORMAT",
+    )
+    group = subparser_view_user.add_mutually_exclusive_group()
+    group.add_argument(
+        "--fields",
+        type=str,
+        help="list of fields to include in JSON output",
+        default=None,
+        metavar=(
+            "CREATION_TIME,MOD_TIME,ACTIVE,USERNAME,USERID,BANK,DEFAULT_BANK,"
+            "SHARES,JOB_USAGE,FAIRSHARE,MAX_RUNNING_JOBS,MAX_ACTIVE_JOBS,MAX_NODES,"
+            "MAX_CORES,QUEUES,PROJECTS,DEFAULT_PROJECT"
+        ),
+    )
+    group.add_argument(
+        "-J",
+        "--job-usage",
+        action="store_const",
+        const=True,
+        help="display breakdown of an association's historical job usage",
     )
 
 

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -322,7 +322,6 @@ class TestAccountingCLI(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             u.edit_all_users(acct_conn, foo="bar")
 
-        print(str(err.exception))
         self.assertIn("unrecognized argument(s) passed: ['foo']", str(err.exception))
 
     # remove database and log file

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -324,6 +324,37 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertIn("unrecognized argument(s) passed: ['foo']", str(err.exception))
 
+    # set job_usage to True to get breakdown of job usage
+    def test_20_view_user_job_usage_no_usage(self):
+        result = u.view_user(acct_conn, user="test_user5", job_usage=True)
+
+        self.assertIn("username", result)
+        self.assertIn("bank", result)
+        self.assertIn("last_job_timestamp", result)
+        self.assertIn("usage_factor_period_0", result)
+        self.assertIn("usage_factor_period_1", result)
+        self.assertIn("usage_factor_period_2", result)
+        self.assertIn("usage_factor_period_3", result)
+        self.assertIn("test_user5", result)
+        self.assertIn("A", result)
+        self.assertIn("0.0", result)
+
+    # edit the job usage columns and make suer they are populated in result
+    def test_21_view_user_job_usage_usage(self):
+        cur = acct_conn.cursor()
+        cur.execute(
+            "UPDATE job_usage_factor_table SET usage_factor_period_0=1.23 "
+            "WHERE username='test_user5'"
+        )
+        cur.execute(
+            "UPDATE job_usage_factor_table SET usage_factor_period_1=4.56 "
+            "WHERE username='test_user5'"
+        )
+        acct_conn.commit()
+        result = u.view_user(acct_conn, user="test_user5", job_usage=True)
+        self.assertIn("1.23", result)
+        self.assertIn("4.56", result)
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -161,6 +161,21 @@ test_expect_success 'call view-job-records -o with an invalid field' '
 	grep "Unknown format field: foo" invalid_field.out
 '
 
+# ensure that job usage factors are displayed with -j/--job-usage;
+# make sure that both rows have job usage values of at least 4 in the
+# most recent job usage factor column
+test_expect_success 'call view-user -J/--job-usage' '
+	flux account view-user -J ${username} > job_usage_breakdown.json &&
+	test_debug "jq -S . <job_usage_breakdown.json" &&
+	jq -e ".[0].usage_factor_period_0 >= 4" job_usage_breakdown.json &&
+	jq -e ".[1].usage_factor_period_0 >= 4" job_usage_breakdown.json
+'
+
+test_expect_success 'pass both -J and --fields; ensure ValueError is raised' '
+	test_must_fail flux account view-user --fields=username -J ${username} > bad_args.error 2>&1 &&
+	grep "argument \-J/\-\-job-usage: not allowed with argument \-\-fields" bad_args.error
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

An association's job usage value is made up of multiple job usage values (i.e. it is the sum of both current and older job usage factors that are stored in `job_usage_factor_table`), but this data is not viewable on the command line.

---

This PR adds a new optional argument to the view-user command: `-J/--job-usage`, which will return all the data stored for an association in `job_usage_factor_table`. Docs are updated with a description of the optional argument itself as well as an example of how to use it.