### PR TITLE
NEWS: add release notes for `v0.48.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,56 @@
+flux-accounting version 0.48.0 - 2025-08-01
+-------------------------------------------
+
+#### Features
+
+* database: add `max_nodes` column to `queue_table` (#695)
+
+* priority-update: send `max_nodes_per_assoc` to plugin, add
+`max_nodes_per_assoc` attribute to `Queue` class (#702)
+
+* plugin: add `QueueUsage` class to track an association's node usage per-queue
+(#703)
+
+* command: add `edit-all-users` command (#700)
+
+* plugin: add enforcement of a per-queue max nodes limit (#704)
+
+* bindings: add `db_version()` function, use it across scripts that check DB
+version (#684)
+
+* `view-user`: add `-J/--job-usage` optional arg (#706)
+
+#### Fixes
+
+* update-usage: move one-time SQL query out of `for`-loop, combine
+per-association queries (#680)
+
+* `add-user`: remove extra `.commit()` when `INSERT`-ing values into
+`association_table` (#681)
+
+* plugin: remove unused function arguments from `priority_calculation ()`
+(#687)
+
+* `jobs`: use fair-share at priority calculation instead of association's
+current fair-share (#686)
+
+* flux-accounting service: use `DB_SCHEMA_VERSION` constant instead of
+hard-coded value (#683)
+
+* plugin: shorten line that is greater than 80 characters (#696)
+
+* `bindings/`: remove job-usage documentation (#705)
+
+* `BankFormatter`: reduce duplicate traversal code (#676)
+
+#### Documentation
+
+* doc: add note about case sensitivity for names (#698)
+
+* doc: update `man(1)` page for `edit-user` (#701)
+
+* doc: add flux-accounting "Module Structure" page (#707)
+
 flux-accounting version 0.47.0 - 2025-06-30
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.48.0`.

---

This PR adds some release notes. Once this lands, I'll create an annotated tag with the following:

```console
git tag -a v0.48.0 -m "Tag v0.48.0" && git push upstream v0.48.0
```