### PR TITLE
plugin: reject jobs that exceed an association's or queue's max resources limits

### DIFF
--- a/src/plugins/job.cpp
+++ b/src/plugins/job.cpp
@@ -18,6 +18,11 @@ int Job::count_resources (json_t *jobspec)
         
     nnodes = counts.nnodes;
     ncores = counts.nslots * counts.slot_size;
+    if (ncores > 0 && nnodes == 0) {
+        // the job specified cores but no nodes, so we need to set nnodes == 1
+        // here
+        nnodes = 1;
+    }
     return 0;
 }
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1128,10 +1128,6 @@ static int depend_cb (flux_plugin_t *p,
                                          "resources for job");
             return -1;
         }
-        if (job.ncores > 0 && job.nnodes == 0)
-            // the job specified cores but no nodes, so we need to set
-            // nnodes == 1 here
-            job.nnodes = 1;
         // look up the association's current number of running jobs in this
         // queue; if it cannot be found in the map, an entry in the Association
         // object will be initialized with a current running jobs count of 0

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -65,6 +65,7 @@ TESTSCRIPTS = \
 	t1060-mf-priority-queue-usage.t \
 	t1061-flux-account-edit-all-users.t \
 	t1062-mf-priority-queue-resource-limits.t \
+	t1063-issue709.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1063-issue709.t
+++ b/t/t1063-issue709.t
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+test_description='test validating job size compared to max resources limits'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association, configure its max resources limits' '
+	flux account add-user \
+		--username=user1 --userid=50001 --bank=A \
+		--max-nodes=1 --max-cores=2
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job with a size greater than max_nodes limit' '
+	test_must_fail flux python ${SUBMIT_AS} 50001 -N2 sleep 5 > max_nodes.out 2>&1 &&
+	test_debug "cat max_nodes.out" &&
+	grep \
+		"job size (2 node(s), 2 core(s)) is greater than max resources limits
+		 configured for association (1 node(s), 2 core(s))" max_nodes.out
+'
+
+test_expect_success 'submit a job with a size greater than max_cores limit' '
+	test_must_fail flux python ${SUBMIT_AS} 50001 -n64 sleep 5 > max_cores.out 2>&1 &&
+	test_debug "cat max_cores.out" &&
+	grep \
+		"job size (1 node(s), 64 core(s)) is greater than max resources limits
+		 configured for association (1 node(s), 2 core(s))" max_cores.out
+'
+
+test_expect_success 'add a queue to the DB' '
+	flux account add-queue bronze --max-nodes-per-assoc=1
+'
+
+test_expect_success 'edit association to belong to the queue' '
+	flux account edit-user user1 --queues=bronze
+'
+
+test_expect_success 'configure flux with that queue' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.bronze]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'update plugin with new flux-accounting data' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job with a size greater than max_nodes_per_association limit on queue' '
+	test_must_fail flux python ${SUBMIT_AS} 50001 \
+		--queue=bronze -N2 sleep 5 > max_resources_queue.out 2>&1 &&
+	test_debug "cat max_resources_queue.out" &&
+	grep \
+		"job size (2 node(s)) is greater than max resources limit configured
+		 for queue (1 node(s))" max_resources_queue.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The priority plugin does not reject jobs in `job.validate` if it exceeds a max resources limit  either per-association or per-queue, and instead will hold the job in `DEPEND`, even though the job is not waiting for a currently running job to finish running. It instead should reject the job during validation with a message saying that the job size is greater than the limit defined per-association or per-queue.

---

This PR adds a check in `job.validate` to compare the size of the job to both the association's `max_nodes` or `max_cores` limits and the queue's `max_nodes_per_association` limit, and if the job would exceed any of these limits, the job is rejected.

Some tests that reproduced the original issue are added to ensure that a job is rejected in `job.validate` instead of held if it exceeds the configured limits.

Fixes #709