### PR TITLE
NEWS: add release notes for `v0.49.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+flux-accounting version 0.49.0 - 2025-08-04
+-------------------------------------------
+
+#### Fixes
+
+* plugin: reject jobs that exceed an association's or queue's max resources
+limits (#710)
+
 flux-accounting version 0.48.0 - 2025-08-01
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.49.0` that contains the fix for #709.

---

This PR adds some release notes. Once landed, I'll create an annotated tag with the following:

```console
git tag -a v0.49.0 -m "Tag v0.49.0" && git push upstream v0.49.0
```