### PR TITLE
cmd: remove `--output-file` argument

### DIFF
--- a/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import pwd
-import csv
 import json
 
 from flux.resource import ResourceSet
@@ -86,42 +85,6 @@ class JobRecord:
     @property
     def queued(self):
         return self.t_run - self.t_submit
-
-
-def write_records_to_file(job_records, output_file):
-    with open(output_file, "w", newline="") as csvfile:
-        spamwriter = csv.writer(
-            csvfile, delimiter="|", escapechar="'", quoting=csv.QUOTE_NONE
-        )
-        spamwriter.writerow(
-            (
-                "UserID",
-                "Username",
-                "JobID",
-                "T_Submit",
-                "T_Run",
-                "T_Inactive",
-                "Nodes",
-                "R",
-                "Project",
-                "Bank",
-            )
-        )
-        for record in job_records:
-            spamwriter.writerow(
-                (
-                    str(record.userid),
-                    str(record.username),
-                    str(record.jobid),
-                    str(record.t_submit),
-                    str(record.t_run),
-                    str(record.t_inactive),
-                    str(record.nnodes),
-                    str(record.resources),
-                    str(record.project),
-                    str(record.bank),
-                )
-            )
 
 
 def convert_to_str(job_records, fmt_string=None):
@@ -289,15 +252,10 @@ def get_jobs(conn, **kwargs):
     return job_records
 
 
-def view_jobs(conn, output_file, fields, **kwargs):
+def view_jobs(conn, fields, **kwargs):
     # look up jobs in jobs table
     job_records = convert_to_obj(get_jobs(conn, **kwargs))
     # convert query result to a readable string
     job_records_str = convert_to_str(job_records, fields)
-
-    if output_file is None:
-        return job_records_str
-
-    write_records_to_file(job_records, output_file)
 
     return job_records_str

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -366,7 +366,6 @@ class AccountingService:
         try:
             val = j.view_jobs(
                 self.conn,
-                msg.payload.get("output_file"),
                 msg.payload.get("format"),
                 jobid=msg.payload.get("jobid"),
                 user=msg.payload.get("user"),

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -24,15 +24,6 @@ def add_path_arg(parser):
     )
 
 
-def add_output_file_arg(parser):
-    parser.add_argument(
-        "-o",
-        "--output-file",
-        dest="output_file",
-        help="specify location of output file",
-    )
-
-
 def add_view_user_arg(subparsers):
     subparser_view_user = subparsers.add_parser(
         "view-user",
@@ -1176,7 +1167,6 @@ def add_show_usage_arg(subparsers):
 
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
-    add_output_file_arg(parser)
     add_view_user_arg(subparsers)
     add_list_users_arg(subparsers)
     add_add_user_arg(subparsers)
@@ -1217,14 +1207,7 @@ def set_db_location(args):
     return path
 
 
-def set_output_file(args):
-    # set path for output file
-    output_file = args.output_file if args.output_file else None
-
-    return output_file
-
-
-def select_accounting_function(args, output_file, parser):
+def select_accounting_function(args, parser):
     data = vars(args)
 
     # map each command to the corresponding accounting RPC call
@@ -1329,9 +1312,7 @@ def main():
             sys.exit(1)
         sys.exit(0)
 
-    output_file = set_output_file(args)
-
-    select_accounting_function(args, output_file, parser)
+    select_accounting_function(args, parser)
 
 
 if __name__ == "__main__":

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -103,10 +103,6 @@ test_expect_success 'run fetch-job-records script' '
 	flux account-fetch-job-records -p ${DB_PATH}
 '
 
-test_expect_success 'view job records for a user and direct it to a file' '
-	flux account -p ${DB_PATH} --output-file $(pwd)/test.txt view-job-records --user $username
-'
-
 test_expect_success 'run update-usage and update-fshare commands' '
 	flux account-update-usage -p ${DB_PATH} &&
 	flux account-update-fshare -p ${DB_PATH}


### PR DESCRIPTION
#### Problem

The flux-accounting command suite offers an `--output-file` argument to direct output of any of the commands to a file, but output can already be redirected to a file with the `>` character.

---

This PR removes the `--output-file` argument from the flux-accounting command suite (which was really only used by the `view-job-records` command). It also removes the `write_records_to_file ()` function from the `jobs_table_subcommands` file. Finally, it removes the one test in `t1011-job-archive-interface.t` that checks redirecting output to a file with the `--output-file` argument.