### PR TITLE
`update-fshare`: wrap `UPDATE`s in single transaction, enable `PRAGMA`s to enable concurrency

### DIFF
--- a/src/fairness/writer/data_writer_db.cpp
+++ b/src/fairness/writer/data_writer_db.cpp
@@ -239,22 +239,41 @@ int data_writer_db_t::write_acct_info (
         return -1;
     }
 
-    ud = "UPDATE association_table SET fairshare=? WHERE username=? AND bank=?";
-
-    c_ud = compile_stmt (DB, ud);
-    if (c_ud == nullptr)
-        return -1;
-
-    rc = update_fairshare_values (DB, c_ud, node);
-
-    // destroy prepared statement
-    rc = sqlite3_finalize (c_ud);
+    // take the write lock upfront to fail fast if another writer is active
+    char *errmsg = nullptr;
+    rc = sqlite3_exec (DB, "BEGIN IMMEDIATE;", nullptr, nullptr, &errmsg);
     if (rc != SQLITE_OK) {
-        m_err_msg = "Failed to delete prepared statement";
-
+        m_err_msg = "BEGIN IMMEDIATE failed: "
+                    + std::string (sqlite3_errmsg(DB));
+        sqlite3_close (DB);
         return rc;
     }
 
+    ud = "UPDATE association_table SET fairshare=? WHERE username=? AND bank=?";
+
+    c_ud = compile_stmt (DB, ud);
+    if (c_ud == nullptr) {
+        sqlite3_exec (DB, "ROLLBACK;", nullptr, nullptr, nullptr);
+        sqlite3_close (DB);
+        return -1;
+    }
+
+    rc = update_fairshare_values (DB, c_ud, node);
+    int rc_finalize = sqlite3_finalize (c_ud);
+    if (rc_finalize != SQLITE_OK) {
+        m_err_msg = "Failed to delete prepared statement";
+        rc = (rc == SQLITE_OK || rc == SQLITE_DONE) ? rc_finalize : rc;
+    }
+
+    if (rc == SQLITE_OK || rc == SQLITE_DONE) {
+        if (sqlite3_exec (DB, "COMMIT;", nullptr, nullptr, nullptr)
+            != SQLITE_OK) {
+            m_err_msg = "COMMIT failed: " + std::string (sqlite3_errmsg (DB));
+            rc = SQLITE_ERROR;
+        }
+    } else {
+        sqlite3_exec (DB, "ROLLBACK;", nullptr, nullptr, nullptr);
+    }
     // close DB connection
     sqlite3_close (DB);
 


### PR DESCRIPTION
#### Problem

The `open_db ()` function in `data_writer_db.cpp` opens the flux-accounting DB in with `SQLITE_OPEN_READWRITE` but does not set any busy policy or [Write-Ahead Logging (WAL) mode](https://www.sqlite.org/wal.html), so even a brief overlap between a writer and a reader will return `SQLITE_BUSY`, and the fairshare update will not go through.

Currently, each row `UPDATE` effectively is its own transaction on the database, which can increase the block it has on other operations throughout flux-accounting that might interact with the database.

---

This PR makes a number of relatively minor improvements to `data_writer_db.cpp` to introduce slightly more robustness to the way the fair-share update scripts open connections to the SQLite database as well as saves the actual write to the database to be performed in a single transaction.

It adds a busy timeout to `open_db ()` to wait for the DB in the event it is zlocked at the moment. It sets `PRAGMA`s for enabling write-ahead logging and synchronous modes when writing to the database, as well as sets a `PRAGMA` for storing
temporary tables and indices in memory rather than on desk when updating the fair-share values.

It also wraps the `UPDATE`s to the fairshare values for each association in a single transaction to reduce the potential of a lock, as well as institutes a `ROLLBACK` in the event the transaction fails to restore the database to its state before the transaction began.

