### PR TITLE
`scrub-old-jobs`: add `0` return code on successful runs of `scrub_old_jobs()`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -371,3 +371,5 @@ def scrub_old_jobs(conn, num_weeks=26):
     select_stmt = "DELETE FROM jobs WHERE t_inactive < ?"
     cur.execute(select_stmt, (cutoff_time,))
     conn.commit()
+
+    return 0


### PR DESCRIPTION
#### Problem

The `scrub_old_jobs()` function does not return anything at function end, so the flux-accounting service will return and output `None` in response, which is confusing for a successful call of the function.

---

This PR adds a `0` return code to the end of `scrub_old_jobs()` when the function runs successfully.