### PR TITLE
`update-usage`: remove `SELECT` query on `jobs` table for every association

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -13,6 +13,7 @@ import time
 import math
 import logging
 import sqlite3
+from collections import defaultdict
 
 from fluxacct.accounting import jobs_table_subcommands as j
 
@@ -122,23 +123,13 @@ def calc_usage_factor(
     pdhl,
     user,
     bank,
-    default_bank,
     end_hl,
-    last_j_ts,
     usage_factors,
+    user_jobs,
 ):
 
     # hl_period represents the number of seconds that represent one usage bin
     hl_period = pdhl * 604800
-
-    # get jobs that have completed since the last seen completed job
-    user_jobs = j.filter_jobs_by_association(
-        conn,
-        bank,
-        default_bank,
-        user=user,
-        after_start_time=last_j_ts,
-    )
 
     last_t_inactive = 0.0
     usg_current = 0.0
@@ -287,6 +278,23 @@ def update_job_usage(acct_conn, pdhl=1):
     cur.execute(s_assoc)
     result = cur.fetchall()
 
+    # fetch new jobs for every association based on their last completed job
+    s_new_jobs = """
+        SELECT r.userid,r.id,r.t_submit,r.t_run,r.t_inactive,r.ranks,r.R,r.jobspec,
+        r.project,r.bank,r.requested_duration,r.actual_duration
+        FROM jobs r LEFT JOIN job_usage_factor_table j
+        ON r.userid = j.userid AND r.bank = j.bank WHERE r.t_run > j.last_job_timestamp
+    """
+    cur.execute(s_new_jobs)
+    new_jobs = cur.fetchall()
+    new_job_records = j.convert_to_obj(new_jobs)
+    # convert new jobs to a dictionary where they key is a tuple of the user ID and bank
+    # associated with the job
+    association_jobs = defaultdict(list)
+    for job in new_job_records:
+        key = (job.userid, job.bank)
+        association_jobs[key].append(job)
+
     # update the job usage for every user in the association_table
     for row in result:
         # add all of the job_usage_factor_period_* columns to dictionary
@@ -299,10 +307,9 @@ def update_job_usage(acct_conn, pdhl=1):
             pdhl=pdhl,
             user=row["username"],
             bank=row["bank"],
-            default_bank=row["default_bank"],
             end_hl=end_hl,
-            last_j_ts=row["last_job_timestamp"],
             usage_factors=usage_factors,
+            user_jobs=association_jobs[(row["userid"], row["bank"])],
         )
 
     # find the root bank in the flux-accounting database

--- a/t/scripts/query.py
+++ b/t/scripts/query.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        dburi = "file:" + args.dbpath[0] + "?mode=ro"
+        dburi = "file:" + args.dbpath[0] + "?mode=rw"
         con = sqlite3.connect(dburi, uri=True)
     except sqlite3.Error as e:
         print(e)
@@ -42,6 +42,7 @@ if __name__ == "__main__":
 
     try:
         cursor.execute(args.query[0])
+        con.commit()
     except sqlite3.Error as e:
         print(e)
         sys.exit(1)

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -20,6 +20,13 @@ select_job_records() {
 		${QUERYCMD} -t 100 ${dbpath} "${query}"
 }
 
+# update job records with bank name
+update_job_records_with_bank_name() {
+		local dbpath=$1
+		query="UPDATE jobs SET bank='$2'"
+		${QUERYCMD} -t 100 ${dbpath} "${query}"
+}
+
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db
 '
@@ -100,7 +107,8 @@ test_expect_success 'submit some sleep 1 jobs under one user' '
 '
 
 test_expect_success 'run fetch-job-records script' '
-	flux account-fetch-job-records -p ${DB_PATH}
+	flux account-fetch-job-records -p ${DB_PATH} &&
+	update_job_records_with_bank_name ${DB_PATH} account1
 '
 
 test_expect_success 'run update-usage and update-fshare commands' '


### PR DESCRIPTION
#### Problem

The `calc_usage_factor()` issues a `SELECT` query on the `"jobs"` table for *every* user in the `association_table`. If there are lots and lots of associations in the table (and subsequently, lots and lots of job records in the `"jobs"` table), these read operations become very expensive and drastically slow down the performance of the job usage update.

---

This PR moves and adjusts the `SELECT` query out of the `calc_usage_factor()` function and put it before the `for-loop` is started to update the job usage values for all of the associations. It adjusts the `SELECT` query to run just *once* instead of for every association by performing a `LEFT JOIN` on the `jobs` table and creating joint rows for associations and any new
jobs they may have ran since their last seen job. These rows are then sorted into a `defaultdict()` where the key is a tuple of userID and bank and the value is a list of `JobRecord` objects associated with that userID and bank.

Finally, it adjusts the function definition of `calc_usage_factor()` to accept a list of those `JobRecord` objects so that `calc_usage_factor()` does not need to issue a `SELECT` query on the `"jobs"` table. It removes the `"default_bank"` and `"last_j_ts"` arguments from function definition since they are no longer needed.

The performance update is pretty significantly increased with this change. In my local testing, a job usage update of the flux-accounting database on tuolumne (which used to take over 10 minutes) now takes a little under 20 seconds.

The unit tests in `t1006_job_archive_py.` are adjusted to account for the change in how the `calc_usage_factor()` function is called and `t1011-job-archive-interface.t` is also updated to annotate some jobs that did not have bank attributes previously associated with them (since this test does not load the multi-factor priority jobtap plugin).