### PR TITLE
github: update crate-ci version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check Spelling
-      uses: crate-ci/typos@bcafd462cb07ef7ba57e34abf458fe20767e808b # v1.19.0
+      uses: crate-ci/typos@v1.35.5
 
   python-format:
     name: python format

--- a/doc/components/fair-share.rst
+++ b/doc/components/fair-share.rst
@@ -30,7 +30,7 @@ initial fair-share value of 0.5 when they are first added to the
 flux-accounting database.
 
 flux-accounting dynamically adjusts fair-share as resources are consumed.
-Historical job usage diminishes in signficance over time, ensuring that
+Historical job usage diminishes in significance over time, ensuring that
 short-term heavy usage does not permanently impact an association's fair-share.
 
 ***********************

--- a/src/bindings/python/fluxacct/accounting/visuals.py
+++ b/src/bindings/python/fluxacct/accounting/visuals.py
@@ -91,7 +91,7 @@ class AssociationUsageGraph(RenderBarGraph):
         Args:
             conn: The SQLite Connection object.
             limit: The max number of rows to display on the graph.
-            bar_char: The character used to dsiplay the horizontal bar on the graph.
+            bar_char: The character used to display the horizontal bar on the graph.
             fallback_char: A fallback character used to display the horizontal bar on
                 the graph.
         """
@@ -122,7 +122,7 @@ class BankUsageGraph(RenderBarGraph):
         Args:
             conn: The SQLite Connection object.
             limit: The max number of rows to display on the graph.
-            bar_char: The character used to dsiplay the horizontal bar on the graph.
+            bar_char: The character used to display the horizontal bar on the graph.
             fallback_char: A fallback character used to display the horizontal bar on
                 the graph.
         """


### PR DESCRIPTION
Problem: The crate-ci typo checker version is quite old.

Update the version to v1.35.5.