### PR TITLE
`view-bank`: add `-c/--concise` option

### DIFF
--- a/doc/man1/flux-account-view-bank.rst
+++ b/doc/man1/flux-account-view-bank.rst
@@ -43,3 +43,8 @@ database hierarchy.
 .. option:: -o/--format
 
     Specify output format using Python's string format syntax.
+
+.. option:: -c/--concise
+
+    Only list associations under this bank that have contributed to the bank's
+    current job usage value.

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -136,7 +136,14 @@ def add_bank(conn, bank, shares, parent_bank="", priority=0.0):
 
 
 def view_bank(
-    conn, bank, tree=False, users=False, parsable=False, cols=None, format_string=""
+    conn,
+    bank,
+    tree=False,
+    users=False,
+    parsable=False,
+    cols=None,
+    format_string="",
+    concise=False,
 ):
     if tree and cols is not None:
         # tree format cannot be combined with custom formatting, so raise an Exception
@@ -162,10 +169,10 @@ def view_bank(
         return formatter.as_format_string(format_string)
     if tree:
         if parsable:
-            return formatter.as_parsable_tree(bank)
-        return formatter.as_tree()
+            return formatter.as_parsable_tree(bank, concise)
+        return formatter.as_tree(concise)
     if users:
-        return formatter.with_users(bank)
+        return formatter.with_users(bank, concise)
     return formatter.as_json()
 
 

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -281,6 +281,7 @@ class AccountingService:
                 if msg.payload.get("fields")
                 else None,
                 msg.payload.get("format"),
+                msg.payload.get("concise"),
             )
 
             payload = {"view_bank": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -592,6 +592,13 @@ def add_view_bank_arg(subparsers):
         help="Specify output format using Python's string format syntax.",
         metavar="FORMAT",
     )
+    subparser_view_bank.add_argument(
+        "-c",
+        "--concise",
+        action="store_const",
+        const=True,
+        help="only list associations that have a job usage value > 0",
+    )
 
 
 def add_delete_bank_arg(subparsers):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -68,6 +68,7 @@ TESTSCRIPTS = \
 	t1063-issue709.t \
 	t1064-store-job-duration.t \
 	t1065-view-jobs-by-duration.t \
+	t1066-view-bank-concise.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1066-view-bank-concise.t
+++ b/t/t1066-view-bank-concise.t
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+test_description='test calling view-bank with --concise'
+
+. `dirname $0`/sharness.sh
+DB_PATH=$(pwd)/FluxAccountingTest.db
+UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1
+'
+
+test_expect_success 'add some associations' '
+	flux account add-user --username=user1 --userid=50011 --bank=A &&
+	flux account add-user --username=user2 --userid=50012 --bank=A &&
+	flux account add-user --username=user3 --userid=50013 --bank=B &&
+	flux account add-user --username=user4 --userid=50014 --bank=B
+'
+
+test_expect_success 'call view-bank on the root bank without --concise' '
+	flux account view-bank -t root > hierarchy_default.test &&
+	grep "user1" hierarchy_default.test &&
+	grep "user2" hierarchy_default.test &&
+	grep "user3" hierarchy_default.test &&
+	grep "user4" hierarchy_default.test
+'
+
+test_expect_success 'call view-bank on the root bank with --concise' '
+	flux account view-bank -t -c root > hierarchy_concise_v1.test &&
+	test_must_fail grep "user1" hierarchy_concise_v1.test &&
+	test_must_fail grep "user2" hierarchy_concise_v1.test &&
+	test_must_fail grep "user3" hierarchy_concise_v1.test &&
+	test_must_fail grep "user4" hierarchy_concise_v1.test
+'
+
+test_expect_success 'edit the job_usage column for two of the associations' '
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user1 100 &&
+	flux python ${UPDATE_USAGE_COL} ${DB_PATH} user4 50
+'
+
+test_expect_success 'call view-bank on the root bank with --concise' '
+	flux account view-bank -t -c root > hierarchy_concise_v2.test &&
+	grep "user1" hierarchy_concise_v2.test &&
+	grep "user4" hierarchy_concise_v2.test &&
+	test_must_fail grep "user2" hierarchy_concise_v2.test &&
+	test_must_fail grep "user3" hierarchy_concise_v2.test
+'
+
+test_expect_success 'call view-bank on the root bank with --concise and --parsable' '
+	flux account view-bank -t -P -c root > hierarchy_concise_parsable.test &&
+	grep "user1" hierarchy_concise_v2.test &&
+	grep "user4" hierarchy_concise_v2.test &&
+	test_must_fail grep "user2" hierarchy_concise_v2.test &&
+	test_must_fail grep "user3" hierarchy_concise_v2.test
+'
+
+test_expect_success 'call view-bank on the root bank with --concise and --users' '
+	flux account view-bank --users -c A > hierarchy_concise_parsable.test &&
+	cat hierarchy_concise_parsable.test &&
+	grep "user1" hierarchy_concise_v2.test &&
+	test_must_fail grep "user2" hierarchy_concise_v2.test
+'
+
+test_expect_success 'remove flux-accounting DB' '
+	rm $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

When viewing the job usage breakdown for a particular bank in the flux-accounting DB, it can get easily cluttered with many associations who don't actually have any job usage contributing to the bank's total job usage value. It would be nice if the `view-bank` command had a filter to only show associations who contributed to the bank's total job usage value.

---

This PR adds a new `-c/--concise` option to the `view-bank` command, which will only list associations under that bank which have a job usage value greater than 0.

This will reduce output that could potentially has a lot of noise, like the following:

```console
$ flux account view-bank -t root
Bank                            Username           RawShares            RawUsage           Fairshare
root                                                       1               150.0
 A                                                         1               100.0
  A                                user1                   1               100.0                 0.5
  A                                user2                   1                 0.0                 0.5
  A                                user5                   1                 0.0                 0.5
  A                                user6                   1                 0.0                 0.5
  A                                user7                   1                 0.0                 0.5
  A                                user8                   1                 0.0                 0.5
  A                                user9                   1                 0.0                 0.5
  A                               user10                   1                 0.0                 0.5
 B                                                         1                50.0
  B                                user3                   1                 0.0                 0.5
  B                                user4                   1                50.0                 0.5
```

to just:

```console
$ flux account view-bank -t -c root
Bank                            Username           RawShares            RawUsage           Fairshare
root                                                       1               150.0
 A                                                         1               100.0
  A                                user1                   1               100.0                 0.5
 B                                                         1                50.0
  B                                user4                   1                50.0                 0.5
```

Some basic tests are added which go through calling `view-bank` with and without passing the `-c/--concise` option.