### PR TITLE
NEWS: add release notes for `v0.50.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,50 @@
+flux-accounting version 0.50.0 - 2025-09-02
+-------------------------------------------
+
+#### Fixes
+
+* plugin: improve error message context in job.validate (#712)
+
+* cmd: remove `--output-file` argument (#716)
+
+* formatter: remove `HierarchyFormatter` class (#717)
+
+* `update-fshare`: wrap `UPDATE`s in single transaction, enable `PRAGMA`s to
+enable concurrency (#720)
+
+* `scrub-old-jobs`: add `0` return code on successful runs of
+`scrub_old_jobs()` (#721)
+
+* `update-usage`: condense `SELECT` query to fetch recent job usage factor, use
+row names, drop unused function arg (#722)
+
+* `update-usage`: remove extra `SELECT` query in favor of retrieving past job
+usage information beforehand (#723)
+
+* `update-usage`: remove `SELECT` query on `jobs` table for every association
+(#725)
+
+* `update-usage`: add `.rollback()` in case of error (#726)
+
+* github: update crate-ci version (#727)
+
+#### Features
+
+* `jobs`: add duration fields to `jobs` table, return both requested and actual
+duration in `view-job-records` (#718)
+
+* `view-job-records`: add filters for requested duration and actual duration in
+`jobs` table (#719)
+
+* `view-bank`: add `-c/--concise` option (#730)
+
+* python: add general utility file for duplicate function definitions, general
+helper functions (#731)
+
+#### Testsuite
+
+* testsuite: don't load deprecated barrier module (#724)
+
 flux-accounting version 0.49.0 - 2025-08-04
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.50.0`.

---

This PR adds some release notes. Once this has landed, I'll go ahead and create an annotated tag with the following:

```console
git tag -a v0.50.0 -m "Tag v0.50.0" && git push upstream v0.50.0
```