### PR TITLE
plugin: don't initialize "queues" map when checking limits

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -219,6 +219,13 @@ void split_string_and_push_back (const char *list,
 }
 
 
+bool has_text (const char *s) {
+    if (!s) return false;
+    while (*s && std::isspace (static_cast<unsigned char> (*s))) ++s;
+    return *s != '\0';
+};
+
+
 int get_queue_info (char *queue,
                     const std::vector<std::string> &permissible_queues,
                     const std::map<std::string, Queue> &queues)

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -332,11 +332,22 @@ bool Association::under_max_resources (const Job &job)
     return under_max_resources;
 }
 
-bool Association::under_queue_max_resources (const Job &job,
-                                             const Queue &queue)
+bool Association::under_queue_max_resources (
+                                    const Job &job,
+                                    const std::string &queue,
+                                    const std::map<std::string, Queue> &queues)
 {
-    bool under_max_nodes = (queue_usage[queue.name].cur_nodes + job.nnodes)
-                           <= queue.max_nodes_per_assoc;
+    auto qit = queues.find (queue);
+    if (qit == queues.end ())
+        // queue is unknown to flux-accounting; skip check
+        return true;
+    const int queue_max_nodes_per_assoc = qit->second.max_nodes_per_assoc;
 
-    return under_max_nodes;
+    // look up current per-queue node usage for the association
+    int cur_nodes_in_queue = 0;
+    auto uit = queue_usage.find (queue);
+    if (uit != queue_usage.end ())
+        cur_nodes_in_queue = uit->second.cur_nodes;
+
+    return (cur_nodes_in_queue + job.nnodes) <= queue_max_nodes_per_assoc;
 }

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -118,7 +118,10 @@ public:
     bool under_queue_max_run_jobs (const std::string &queue,
                                    std::map<std::string, Queue> queues);
     bool under_max_resources (const Job &job);
-    bool under_queue_max_resources (const Job &job, const Queue &queue);
+    bool under_queue_max_resources (
+                                  const Job &job,
+                                  const std::string &queue,
+                                  const std::map<std::string, Queue> &queues);
 };
 
 class Bank {

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -143,6 +143,9 @@ json_t* convert_map_to_json (std::map<int, std::map<std::string, Association>>
 void split_string_and_push_back (const char *list,
                                  std::vector<std::string> &vec);
 
+// helper to test if a C-string is non-null and non-whitespace
+bool has_text (const char *s);
+
 // validate a potentially passed-in queue by an association and return the
 // integer priority associated with the queue
 int get_queue_info (char *queue,

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -316,7 +316,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
         }
         // is the association under the max nodes limit for the queue the
         // held job is submitted under?
-        if (b->under_queue_max_resources (held_job, queues[held_job.queue]) &&
+        if (b->under_queue_max_resources (held_job, held_job.queue, queues) &&
             held_job.contains_dep (D_QUEUE_MRES)) {
             if (flux_jobtap_dependency_remove (p,
                                                held_job.id,
@@ -1218,7 +1218,7 @@ static int depend_cb (flux_plugin_t *p,
                 goto error;
             job.add_dep (D_QUEUE_MRJ);
         }
-        if (!b->under_queue_max_resources (job, queues[queue_str])) {
+        if (!b->under_queue_max_resources (job, queue_str, queues)) {
             // association is already at their max nodes limit across their
             // running jobs in this queue; add a dependency
             if (flux_jobtap_dependency_add (p, id, D_QUEUE_MRES) < 0)

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -535,10 +535,12 @@ static void rec_update_cb (flux_t *h,
 
         // split queues comma-delimited string and add it to b->queues vector
         b->queues.clear ();
-        split_string_and_push_back (assoc_queues, b->queues);
+        if (has_text (assoc_queues))
+            split_string_and_push_back (assoc_queues, b->queues);
         // do the same thing for the association's projects
         b->projects.clear ();
-        split_string_and_push_back (assoc_projects, b->projects);
+        if (has_text (assoc_projects))
+            split_string_and_push_back (assoc_projects, b->projects);
 
         users_def_bank[uid] = def_bank;
     }

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -241,8 +241,9 @@ static int increment_resources (Association *b,
     b->cur_cores = b->cur_cores + (counts.nslots * counts.slot_size);
 
     // increment cur_nodes for queue
-    b->queue_usage[queue].cur_nodes = b->queue_usage[queue].cur_nodes +
-                                      counts.nnodes;
+    if (!queue.empty ())
+        b->queue_usage[queue].cur_nodes = b->queue_usage[queue].cur_nodes +
+                                          counts.nnodes;
 
     return 0;
 }
@@ -269,8 +270,9 @@ static int decrement_resources (Association *b,
     b->cur_cores = b->cur_cores - (counts.nslots * counts.slot_size);
 
     // decrement cur_nodes for queue
-    b->queue_usage[queue].cur_nodes = b->queue_usage[queue].cur_nodes -
-                                      counts.nnodes;
+    if (!queue.empty ())
+        b->queue_usage[queue].cur_nodes = b->queue_usage[queue].cur_nodes -
+                                          counts.nnodes;
 
     return 0;
 }
@@ -1605,9 +1607,11 @@ static int inactive_cb (flux_plugin_t *p,
         }
     }
 
-    if (b->queue_usage[queue_str].cur_run_jobs > 0)
-        // decrement num of running jobs the association has in queue
-        b->queue_usage[queue_str].cur_run_jobs--;
+    if (!queue_str.empty ()) {
+        if (b->queue_usage[queue_str].cur_run_jobs > 0)
+            // decrement num of running jobs the association has in queue
+            b->queue_usage[queue_str].cur_run_jobs--;
+    }
 
     if (!b->held_jobs.empty ()) {
         // the Association has at least one held Job; begin looping through

--- a/src/plugins/test/queue_limits_test05.cpp
+++ b/src/plugins/test/queue_limits_test05.cpp
@@ -77,7 +77,7 @@ void association_under_queue_max_nodes_limit_true ()
 
     ok (a->queue_usage["bronze"].cur_nodes == 0,
         "association has no occupied nodes under bronze queue");
-    ok (a->under_queue_max_resources (job, queues["bronze"]) == true,
+    ok (a->under_queue_max_resources (job, "bronze", queues) == true,
         "association is under queue's max_nodes limit");
 
     // assume job passes all checks and has moved to RUN state
@@ -108,7 +108,7 @@ void association_under_queue_max_nodes_limit_false ()
         "association has one held job due to per-queue max_resources limit");
     ok (job.deps.size () == 1,
         "held job has one dependency added to it");
-    ok (a->under_queue_max_resources (job, queues["bronze"]) == false,
+    ok (a->under_queue_max_resources (job, "bronze", queues) == false,
         "association is not under queue's max_nodes limit");
 }
 
@@ -126,7 +126,7 @@ void association_release_held_job_true ()
     a->queue_usage["bronze"].cur_nodes = 0;
     Job held_job = a->held_jobs.front ();
 
-    ok (a->under_queue_max_resources (held_job, queues["bronze"]) == true,
+    ok (a->under_queue_max_resources (held_job, "bronze", queues) == true,
         "association is now under queue's max_nodes limit");
     
     held_job.remove_dep (D_QUEUE_MRES);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -69,6 +69,7 @@ TESTSCRIPTS = \
 	t1064-store-job-duration.t \
 	t1065-view-jobs-by-duration.t \
 	t1066-view-bank-concise.t \
+	t1067-mf-priority-issue733.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1067-mf-priority-issue733.t
+++ b/t/t1067-mf-priority-issue733.t
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+test_description='test priority plugin validating jobs with no configured queues'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root bankA 1
+'
+
+test_expect_success 'add an association' '
+	flux account add-user --username=user1 --userid=50001 --bank=bankA
+'
+
+# In this set of tests, no queues are configured for flux-accounting, which
+# means the priority plugin should not do any sort of queue validation or limit
+# checks for the association when submitting their jobs.
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'make sure association has no current usage under queue' '
+	flux jobtap query mf_priority.so > query.json &&
+	cat query.json | jq &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queues | length == 0" <query.json
+'
+
+test_expect_success 'configure flux with queues' '
+	cat >conf.d/queues.toml <<-EOT &&
+	[queues.batch]
+	[queues.debug]
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'job submitted under default queue gets alloc event' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -n1 sleep 60) &&
+	flux job wait-event -vt 3 ${job1} alloc
+'
+
+test_expect_success 'second job submitted under default queue also gets alloc event' '
+	job2=$(flux python ${SUBMIT_AS} 50001 -n1 sleep 60) &&
+	flux job wait-event -vt 3 ${job2} alloc
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} &&
+	flux cancel ${job2}
+'
+
+test_expect_success 'make sure association has no current usage under queue' '
+	flux jobtap query mf_priority.so > query.json &&
+	cat query.json | jq &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queues | length == 0" <query.json
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As mentioned in #733, when checking to see if an association is under a queue's max resources limit for a particular job, the "queues" map gets initialized with a `Queue` object unintentionally (especially if queues are not configured in the flux-accounting DB), and subsequently submitted jobs get rejected with a `"Queue not valid for user"` error message.

---

This PR reworks the `under_queue_max_resources ()` method to perform a safer lookup of the "queues" map with the passed-in queue instead of passing the queue directly in the map (which will initialize the map if the queue does not already exist). It adjusts the calls to this method to account for the change in which parameters are passed to `under_queue_max_resources ()`. I've added a simple test file to ensure that configured queues in Flux (particularly with a default queue) do not reject submitted jobs from associations when there are no queues configured in flux-accounting.

I've also added some minor cleanups to drop initialization of some of the `Association` class' queue attributes with empty strings in the case where queues are not configured in flux-accounting.

Fixes #733 