### PR TITLE
NEWS: add release notes for `v0.51.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+flux-accounting version 0.51.0 - 2025-09-03
+-------------------------------------------
+
+#### Fixes
+
+* plugin: don't initialize "queues" map when checking limits (#734)
+
 flux-accounting version 0.50.0 - 2025-09-02
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.51.0`.

---

This PR adds some release notes for `v0.51.0`, which contains the fix proposed in #734. Once this has landed, I will create an annotated tag with the following:

```console
git tag -a v0.51.0 -m "Tag v0.51.0" && git push upstream v0.51.0
```