### PR TITLE
plugin: add more information returned in output of `flux jobtap query`

### DIFF
--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -351,3 +351,37 @@ bool Association::under_queue_max_resources (
 
     return (cur_nodes_in_queue + job.nnodes) <= queue_max_nodes_per_assoc;
 }
+
+json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
+{
+    json_t *root = json_object ();
+    if (!root)
+        return nullptr;
+
+    for (const auto &kv : queues) {
+        const std::string &key = kv.first;
+        const Queue &q = kv.second;
+
+        json_t *qobj = json_pack (
+                                "{s:s, s:i, s:i, s:i, s:i, s:i, s:i}",
+                                "name", q.name.c_str (),
+                                "min_nodes_per_job", q.min_nodes_per_job,
+                                "max_nodes_per_job", q.max_nodes_per_job,
+                                "max_time_per_job", q.max_time_per_job,
+                                "priority", q.priority,
+                                "max_running_jobs", q.max_running_jobs,
+                                "max_nodes_per_assoc", q.max_nodes_per_assoc);
+        if (!qobj) {
+            json_decref (root);
+            return nullptr;
+        }
+
+        if (json_object_set_new (root, key.c_str (), qobj) < 0) {
+            json_decref (qobj);
+            json_decref (root);
+            return nullptr;
+        }
+    }
+
+    return root;
+}

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -385,3 +385,22 @@ json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
 
     return root;
 }
+
+json_t* convert_projects_to_json (const std::vector<std::string> projects)
+{
+    json_t *known_projects = json_array ();
+    if (!known_projects)
+        return nullptr;
+
+    json_t *temp = nullptr;
+    for (const auto &project : projects) {
+        if (!(temp = json_string (project.c_str ()))
+            || json_array_append_new (known_projects, temp) < 0) {
+            json_decref (temp);
+            json_decref (known_projects);
+            return nullptr;
+        }
+    }
+
+    return known_projects;
+}

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -145,6 +145,9 @@ json_t* convert_map_to_json (std::map<int, std::map<std::string, Association>>
 // convert the queues map to a JSON object to be returned in query_cb ()
 json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues);
 
+// convert the projects vector to a JSON object to be returned in query_cb ()
+json_t* convert_projects_to_json (const std::vector<std::string> projects);
+
 // split a list of items and add them to a vector in an Association object
 void split_string_and_push_back (const char *list,
                                  std::vector<std::string> &vec);

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -142,6 +142,9 @@ Association* get_association (int userid,
 json_t* convert_map_to_json (std::map<int, std::map<std::string, Association>>
                                  &users);
 
+// convert the queues map to a JSON object to be returned in query_cb ()
+json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues);
+
 // split a list of items and add them to a vector in an Association object
 void split_string_and_push_back (const char *list,
                                  std::vector<std::string> &vec);

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -470,6 +470,22 @@ static int query_cb (flux_plugin_t *p,
 
     json_decref (accounting_data);
 
+    json_t *queue_data = convert_queues_to_json (queues);
+
+    if (!queue_data)
+        return -1;
+
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:O}",
+                              "queues",
+                              queue_data) < 0)
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "mf_priority: query_cb: flux_plugin_arg_pack: %s",
+                        flux_plugin_arg_strerror (args));
+
+    json_decref (queue_data);
+
     return 0;
 }
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -486,6 +486,22 @@ static int query_cb (flux_plugin_t *p,
 
     json_decref (queue_data);
 
+    json_t *project_data = convert_projects_to_json (projects);
+
+    if (!project_data)
+        return -1;
+
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:O}",
+                              "projects",
+                              project_data) < 0)
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "mf_priority: query_cb: flux_plugin_arg_pack: %s",
+                        flux_plugin_arg_strerror (args));
+
+    json_decref (project_data);
+
     return 0;
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -70,6 +70,7 @@ TESTSCRIPTS = \
 	t1065-view-jobs-by-duration.t \
 	t1066-view-bank-concise.t \
 	t1067-mf-priority-issue733.t \
+	t1068-mf-priority-queues-projects-query.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1068-mf-priority-queues-projects-query.t
+++ b/t/t1068-mf-priority-queues-projects-query.t
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+test_description='test fetching queue and project information in flux jobtap query'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p conf.d
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 16 job -o,--config-path=$(pwd)/conf.d
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root bankA 1
+'
+
+test_expect_success 'add an association' '
+	flux account add-user --username=user1 --userid=50001 --bank=bankA
+'
+
+test_expect_success 'add some queues' '
+	flux account add-queue bronze --priority=100 &&
+	flux account add-queue silver --priority=200 &&
+	flux account add-queue gold --priority=300
+'
+
+test_expect_success 'add some projects' '
+	flux account add-project project1 &&
+	flux account add-project project2 &&
+	flux account add-project project3 &&
+	flux account add-project project4
+'
+
+test_expect_success 'send flux-accounting data to plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'run flux jobtap query' '
+	flux jobtap query mf_priority.so > query.json &&
+	cat query.json | jq
+'
+
+test_expect_success 'check queue information in output of flux jobtap query' '
+	jq -e ".queues.bronze.priority == 100" <query.json &&
+	jq -e ".queues.silver.priority == 200" <query.json &&
+	jq -e ".queues.gold.priority == 300" <query.json
+'
+
+test_expect_success 'check projects information in output of flux jobtap query' '
+	jq -e ".projects | length == 5" <query.json &&
+	jq -e ".projects[0] == \"*\"" <query.json &&
+	jq -e ".projects[1] == \"project1\"" <query.json &&
+	jq -e ".projects[2] == \"project2\"" <query.json &&
+	jq -e ".projects[3] == \"project3\"" <query.json &&
+	jq -e ".projects[4] == \"project4\"" <query.json
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The information stored in the priority plugin's `queues` map and `projects` vector are not returned in the output of `flux jobtap query`, which makes it difficult to diagnose what queue and/or project information the plugin has on hand without inserting print statements directly within the plugin.

---

This PR adds the information stored in the `queues` map and the `projects` vector to the information returned in the output of `flux jobtap query`. It adds helper functions to construct and pack the objects into JSON objects, similar to how `Association` objects are already constructed for the output of `flux jobtap query`.

I've added some basic tests to check for both queue and project information in the output of `flux jobtap query`.

Fixes #736