### PR TITLE
util: add `parse_timestamp()` function

### DIFF
--- a/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
@@ -12,28 +12,9 @@
 import json
 
 from flux.resource import ResourceSet
-from flux.util import parse_datetime
 from flux.job.JobID import JobID
 from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import util
-
-
-def parse_timestamp(timestamp):
-    """
-    Parse an input timestamp for after-start-time or before-end-time, which
-    could be in multiple formats. Try to first parse it as a human-readable
-    format (e.g, "2025-01-27 12:00:00"), or just return as a
-    seconds-since-epoch timestamp if the parsing fails.
-
-    Returns:
-        a seconds-since-epoch timestamp
-    """
-    try:
-        # try to parse as a human-readable timestamp
-        return parse_datetime(str(timestamp)).timestamp()
-    except ValueError:
-        # just return as a seconds-since-epoch timestamp
-        return timestamp
 
 
 class JobRecord:
@@ -253,10 +234,10 @@ def get_jobs(conn, **kwargs):
         params_list.append(params["user"])
     if "after_start_time" in params:
         where_clauses.append("t_run > ?")
-        params_list.append(parse_timestamp(params["after_start_time"]))
+        params_list.append(util.parse_timestamp(params["after_start_time"]))
     if "before_end_time" in params:
         where_clauses.append("t_inactive < ?")
-        params_list.append(parse_timestamp(params["before_end_time"]))
+        params_list.append(util.parse_timestamp(params["before_end_time"]))
     if "jobid" in params:
         # convert jobID passed-in to decimal format
         params["jobid"] = JobID(params["jobid"]).dec

--- a/src/bindings/python/fluxacct/accounting/util.py
+++ b/src/bindings/python/fluxacct/accounting/util.py
@@ -11,6 +11,8 @@
 ###############################################################
 import pwd
 
+from flux.util import parse_datetime
+
 
 def get_uid(username):
     """
@@ -35,3 +37,20 @@ def get_username(userid):
         return pwd.getpwuid(userid).pw_name
     except KeyError:
         return str(userid)
+
+
+def parse_timestamp(timestamp):
+    """
+    Parse a timestamp and convert it to a seconds-since-epoch timestamp. Try to first
+    parse it as a human-readable format (e.g. "2025-01-27 12:00:00"), or just return as a
+    seconds-since-epoch timestamp if the parsing fails.
+
+    Returns:
+        a seconds-since-epoch timestamp
+    """
+    try:
+        # try to parse as a human-readable timestamp
+        return parse_datetime(str(timestamp)).timestamp()
+    except ValueError:
+        # just return as a seconds-since-epoch timestamp
+        return timestamp


### PR DESCRIPTION
#### Problem

The `parse_timestamp()` helper function in `jobs_table_subcommands` could be used to parse timestamps in other functions in the Python bindings and would be useful to have in the `util.py` file.

---

This PR just moves the function out of `jobs_table_subcommands.py` and into `util.py`.