### PR TITLE
testsuite: stop using flux job cancelall

### DIFF
--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -68,6 +68,6 @@ fi
 
 test $RANK -ne 0 || flux admin cleanup-push <<-EOT
 	flux queue stop --all
-	flux job cancelall -f --states RUN
+	flux cancel --all --states RUN
 	flux queue idle
 EOT


### PR DESCRIPTION
Problem: flux job cancelall is deprecated but flux accounting is still using an old rc1-job in the test suite that uses it.

Update rc1-job.