### PR TITLE
`list-users`: extend command to search for multiple values per filter

### DIFF
--- a/t/t1051-list-users.t
+++ b/t/t1051-list-users.t
@@ -82,6 +82,21 @@ test_expect_success 'call list-users with no optional args to get all associatio
 	jq -e "length == 5" all_users.json 
 '
 
+# We can also pass multiple conditions for each filter.
+test_expect_success 'list users from both bank A and B' '
+	flux account list-users --bank=A,B --json > multiple_banks.json &&
+	jq -e "length == 4" multiple_banks.json
+'
+
+test_expect_success 'list users from multiple queues' '
+	flux account list-users --queues=silver,gold --json > multiple_queues.json &&
+	jq -e "length == 4" multiple_queues.json &&
+	test_must_fail grep "user1" multiple_queues.json &&
+	grep "user2" multiple_queues.json &&
+	grep "user3" multiple_queues.json &&
+	grep "user4" multiple_queues.json
+'
+
 # In the following set of tests, we pass certain filters to only get
 # the associations which fit the criteria of the filters passed in.
 test_expect_success 'filter associations by bank' '


### PR DESCRIPTION
#### Problem

The `list-users` command does not accept multiple values per filter. It would be nice if each filter could accept multiple values,
e.g. list associations that might belong to either bank1 OR bank2 OR bank3.

---

This PR extends the `list_users()` function to accept multiple values per filter by attempting to strip the value passed in for each filter and using the `"IN"` keyword to query `association_table` in the case where more than one value is passed per filter.

An example:

```console
flux account list-users --bank=A,B
creation_time | mod_time   | active | username | userid | bank | default_bank | shares | job_usage | fairshare | max_running_jobs | max_active_jobs | max_nodes  | max_cores  | queues             | projects                        | default_project
--------------+------------+--------+----------+--------+------+--------------+--------+-----------+-----------+------------------+-----------------+------------+------------+--------------------+---------------------------------+----------------
1758123997    | 1758123998 | 1      | user1    | 5011   | A    | A            | 1      | 0.0       | 0.5       | 5                | 7               | 2147483647 | 2147483647 | bronze             | leviathan_wakes,*               | *              
1758123997    | 1758123997 | 1      | user2    | 5012   | A    | A            | 1      | 0.0       | 0.5       | 5                | 7               | 2147483647 | 2147483647 | bronze,silver      | *                               | *              
1758123997    | 1758123998 | 1      | user2    | 5012   | B    | A            | 1      | 0.0       | 0.5       | 5                | 7               | 2147483647 | 2147483647 | bronze,silver      | leviathan_wakes,babylons_gate,* | leviathan_wakes
1758123997    | 1758123998 | 1      | user3    | 5013   | B    | B            | 100    | 0.0       | 0.5       | 5                | 7               | 2147483647 | 2147483647 | bronze,silver,gold | *                               | *              
```

I've also added some basic tests where multiple values are passed in for the filter.