### PR TITLE
t1043: add `wait-event` for jobs after cancelling

### DIFF
--- a/t/t1043-view-jobs-by-bank.t
+++ b/t/t1043-view-jobs-by-bank.t
@@ -51,7 +51,9 @@ test_expect_success 'submit 2 jobs under bank A' '
 	job2=$(flux python ${SUBMIT_AS} 5001 hostname) &&
 	flux job wait-event -f json ${job2} priority &&
 	flux cancel ${job1} &&
-	flux cancel ${job2}
+	flux cancel ${job2} &&
+	flux job wait-event -vt 3 ${job1} clean &&
+	flux job wait-event -vt 3 ${job2} clean
 '
 
 test_expect_success 'submit 2 jobs under bank B' '
@@ -60,13 +62,16 @@ test_expect_success 'submit 2 jobs under bank B' '
 	job2=$(flux python ${SUBMIT_AS} 5002 hostname) &&
 	flux job wait-event -f json ${job2} priority &&
 	flux cancel ${job1} &&
-	flux cancel ${job2}
+	flux cancel ${job2} &&
+	flux job wait-event -vt 3 ${job1} clean &&
+	flux job wait-event -vt 3 ${job2} clean
 '
 
 test_expect_success 'submit jobs under a secondary bank' '
 	job1=$(flux python ${SUBMIT_AS} 5001 --setattr=system.bank=bankB hostname) &&
 	flux job wait-event -f json ${job1} priority &&
-	flux cancel ${job1}
+	flux cancel ${job1} &&
+	flux job wait-event -vt 3 ${job1} clean
 '
 
 test_expect_success 'run fetch-job-records script' '

--- a/t/t1043-view-jobs-by-bank.t
+++ b/t/t1043-view-jobs-by-bank.t
@@ -47,26 +47,26 @@ test_expect_success 'send flux-accounting DB information to the plugin' '
 
 test_expect_success 'submit 2 jobs under bank A' '
 	job1=$(flux python ${SUBMIT_AS} 5001 hostname) &&
-	flux job wait-event -f json $job1 priority &&
+	flux job wait-event -f json ${job1} priority &&
 	job2=$(flux python ${SUBMIT_AS} 5001 hostname) &&
-	flux job wait-event -f json $job2 priority &&
-	flux cancel $job1 &&
-	flux cancel $job2
+	flux job wait-event -f json ${job2} priority &&
+	flux cancel ${job1} &&
+	flux cancel ${job2}
 '
 
 test_expect_success 'submit 2 jobs under bank B' '
 	job1=$(flux python ${SUBMIT_AS} 5002 hostname) &&
-	flux job wait-event -f json $job1 priority &&
+	flux job wait-event -f json ${job1} priority &&
 	job2=$(flux python ${SUBMIT_AS} 5002 hostname) &&
-	flux job wait-event -f json $job2 priority &&
-	flux cancel $job1 &&
-	flux cancel $job2
+	flux job wait-event -f json ${job2} priority &&
+	flux cancel ${job1} &&
+	flux cancel ${job2}
 '
 
 test_expect_success 'submit jobs under a secondary bank' '
 	job1=$(flux python ${SUBMIT_AS} 5001 --setattr=system.bank=bankB hostname) &&
-	flux job wait-event -f json $job1 priority &&
-	flux cancel $job1
+	flux job wait-event -f json ${job1} priority &&
+	flux cancel ${job1}
 '
 
 test_expect_success 'run fetch-job-records script' '


### PR DESCRIPTION
#### Problem

The jobs submitted and cancelled in `t1043-view-jobs-by-bank.t` are attempted to be fetched and inserted in the flux-accounting DB's `jobs` table, but the jobs are not waited to be cleaned up before calling that script that fetches and inserts it into the flux-accounting DB.

---

This PR adds a `wait-event` call for each job that is submitted and cancelled before calling `flux account-fetch-job-records` to fetch and `INSERT` those jobs. I've also added a minor cleanup commit to wrap the variables in `t1043-view-jobs-by-bank.t` in curly braces to make it consistent with the rest of the testsuite.