### PR TITLE
`update-usage`: add `-v/--verbose` option

### DIFF
--- a/src/bindings/python/fluxacct/accounting/util.py
+++ b/src/bindings/python/fluxacct/accounting/util.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import pwd
+import logging
 
 from flux.util import parse_datetime
 import fluxacct.accounting
@@ -67,3 +68,21 @@ def format_value(val):
     if val == fluxacct.accounting.INTEGER_MAX:
         return "unlimited"
     return val
+
+
+def config_logging(verbosity, logger):
+    """
+    Configure the logging level for a logger.
+
+    Args:
+        verbosity: the level of verbosity to set the logger to.
+        logger: the logger object.
+    """
+    log_level = logging.WARNING
+    if verbosity > 0:
+        log_level = logging.INFO
+    if verbosity > 1:
+        log_level = logging.DEBUG
+    logger.setLevel(log_level)
+    # also set level on fluxacct package
+    logging.getLogger(fluxacct.__name__).setLevel(log_level)

--- a/src/cmd/flux-account-update-usage.py
+++ b/src/cmd/flux-account-update-usage.py
@@ -17,6 +17,7 @@ import os
 
 import fluxacct.accounting
 from fluxacct.accounting import job_usage_calculation as job_usage
+from fluxacct.accounting import util
 
 logging.basicConfig(
     level=logging.INFO,
@@ -70,7 +71,15 @@ def main():
         help="number of weeks for a job's usage contribution to a half-life decay",
         metavar="PRIORITY_DECAY_HALF_LIFE",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase verbosity of output",
+    )
     args = parser.parse_args()
+    util.config_logging(args.verbose, LOGGER)
 
     path = set_db_loc(args)
     conn = est_sqlite_conn(path)

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -180,6 +180,18 @@ test_expect_success 'pass both -J and --fields; ensure ValueError is raised' '
 	grep "argument \-J/\-\-job-usage: not allowed with argument \-\-fields" bad_args.error
 '
 
+test_expect_success 'call update-usage with verbosity enabled and look for INFO-level messages' '
+	flux account-update-usage -p ${DB_PATH} -v > expect_info_logs.out 2>&1 &&
+	grep "INFO: beginning job-usage update" expect_info_logs.out &&
+	grep "INFO: job-usage update for flux-accounting DB now complete" expect_info_logs.out
+'
+
+test_expect_success 'call update-usage with no --log-level; expect no INFO-level messages' '
+	flux account-update-usage -p ${DB_PATH} > no_info_logs.out 2>&1 &&
+	test_must_fail grep "INFO: beginning " no_info_logs.out &&
+	test_must_fail grep "INFO: job-usage " no_info_logs.out
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '


### PR DESCRIPTION
#### Problem

The `flux account-update-usage` script logs _all_ messages (Including `INFO`-level) every time it runs, which can flood log files with information since it runs periodically with `flux cron`.

---

This PR adds an optional argument to `flux account-update-usage` called `--log-level`, which allows the user to enable `INFO`-level logging. Now, by default, only `WARNING`-level messages are logged.

Some basic tests calling `flux account-update-usage` with and without `-v/--verbose` to make sure `INFO`-level messages are correctly suppressed.

Fixes #750 