### PR TITLE
NEWS: add release notes for `v0.52.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,36 @@
+flux-accounting version 0.52.0 - 2025-09-30
+-------------------------------------------
+
+#### Fixes
+
+* `view-user`/`edit-user`: use `"unlimited"` to display and set `max_nodes` and
+`max_cores` to their default values (#751)
+
+* `update-usage`: add `-v/--verbose` option (#753)
+
+##### Features
+
+* plugin: add more information returned in output of `flux jobtap query` (#737)
+
+* util: add `parse_timestamp()` function (#740)
+
+* `jobs` command: add more options to filter jobs by (#741)
+
+* `view-job-records`: add filter for duration delta of jobs (#742)
+
+* `list-users`: extend command to search for multiple values per filter (#745)
+
+#### Documentation
+
+* doc: expand example job priority calculation (#747)
+
+#### Testsuite
+
+* testsuite: stop using `flux job cancelall` (#743)
+
+* t1043: add `wait-event` for jobs after cancelling (#746)
+
+
 flux-accounting version 0.51.0 - 2025-09-03
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.52.0`.

---

This PR adds some release notes. Once this lands, I'll create an annotated tag with the following:

```console
git tag -a v0.51.0 -m "Tag v0.52.0" && git push upstream v0.52.0
```

I'll wait to merge this one until #752 and #755 have landed and I can add them to this set of release notes.