### PR TITLE
python: explicitly close `Cursor` objects after use in user commands

### DIFF
--- a/src/bindings/python/fluxacct/accounting/util.py
+++ b/src/bindings/python/fluxacct/accounting/util.py
@@ -11,6 +11,8 @@
 ###############################################################
 import pwd
 import logging
+import functools
+import contextlib
 
 from flux.util import parse_datetime
 import fluxacct.accounting
@@ -86,3 +88,19 @@ def config_logging(verbosity, logger):
     logger.setLevel(log_level)
     # also set level on fluxacct package
     logging.getLogger(fluxacct.__name__).setLevel(log_level)
+
+
+def with_cursor(func):
+    """
+    Decorator that automatically manages a Cursor object's lifecycle.
+
+    The decorated function should take the Cursor object as its first parameter
+    after the Connection object.
+    """
+
+    @functools.wraps(func)
+    def wrapper(conn, *args, **kwargs):
+        with contextlib.closing(conn.cursor()) as cur:
+            return func(conn, cur, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
#### Problem

`Cursor` objects are not explicitly closed in a number of the functions that are called that read from/write to the SQLite database. While not totally necessary (`Cursor` objects *should* be cleaned up by Python's garbage collectors), if there are lots of parallel processes that are reading and writing to the database (such as the flux-accounting service and the `priority-update` script), these `Cursor` objects can keep transactions alive and potentially lead to a database lock. It also would provide better code clarity if these functions actually explicitly cleaned up the use of these objects when the function completes.

---

This PR introduces the use of a context manager for the `Cursor` objects created in the Python bindings that interact with the flux-accounting database.