### PR TITLE
bindings: close `Cursor` objects when function exits

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -114,7 +114,7 @@ def add_bank(conn, cur, bank, shares, parent_bank="", priority=0.0):
 
     # insert the bank values into the database
     try:
-        conn.execute(
+        cur.execute(
             """
             INSERT INTO bank_table (
                 bank,
@@ -273,7 +273,7 @@ def edit_bank(
                 params[field],
                 bank,
             )
-            conn.execute(update_stmt, tup)
+            cur.execute(update_stmt, tup)
 
     # commit changes
     conn.commit()

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -14,6 +14,7 @@ import sqlite3
 import fluxacct.accounting
 from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import sql_util as sql
+from fluxacct.accounting.util import with_cursor
 
 ###############################################################
 #                                                             #
@@ -44,8 +45,8 @@ def project_is_active(cur, project):
 ###############################################################
 
 
-def view_project(conn, project, parsable=False, format_string=None):
-    cur = conn.cursor()
+@with_cursor
+def view_project(conn, cur, project, parsable=False, format_string=None):
     # get the information pertaining to a project in the DB
     cur.execute("SELECT * FROM project_table where project=?", (project,))
 
@@ -58,9 +59,8 @@ def view_project(conn, project, parsable=False, format_string=None):
     return formatter.as_json()
 
 
-def add_project(conn, project):
-    cur = conn.cursor()
-
+@with_cursor
+def add_project(conn, cur, project):
     if project_is_active(cur, project):
         raise sqlite3.IntegrityError(
             f"project {project} already exists in project_table"
@@ -83,13 +83,12 @@ def add_project(conn, project):
         )
 
 
-def delete_project(conn, project):
-    cursor = conn.cursor()
-
+@with_cursor
+def delete_project(conn, cur, project):
     # look for any rows in the association_table that reference this project
     select_stmt = "SELECT * FROM association_table WHERE projects LIKE ?"
-    cursor.execute(select_stmt, ("%" + project + "%",))
-    result = cursor.fetchall()
+    cur.execute(select_stmt, ("%" + project + "%",))
+    result = cur.fetchall()
     warning_stmt = (
         "WARNING: user(s) in the association_table still "
         "reference this project. Make sure to edit user rows to "
@@ -97,7 +96,7 @@ def delete_project(conn, project):
     )
 
     delete_stmt = "DELETE FROM project_table WHERE project=?"
-    cursor.execute(delete_stmt, (project,))
+    cur.execute(delete_stmt, (project,))
 
     conn.commit()
 
@@ -110,7 +109,8 @@ def delete_project(conn, project):
     return 0
 
 
-def list_projects(conn, cols=None, json_fmt=False, format_string=None):
+@with_cursor
+def list_projects(conn, cur, cols=None, json_fmt=False, format_string=None):
     """
     List all of the available projects registered in the project_table.
 
@@ -122,9 +122,6 @@ def list_projects(conn, cols=None, json_fmt=False, format_string=None):
     """
     # use all column names if none are passed in
     cols = cols or fluxacct.accounting.PROJECT_TABLE
-
-    cur = conn.cursor()
-
     sql.validate_columns(cols, fluxacct.accounting.PROJECT_TABLE)
     # construct SELECT statement
     select_stmt = f"SELECT {', '.join(cols)} FROM project_table"

--- a/src/bindings/python/fluxacct/accounting/project_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/project_subcommands.py
@@ -68,7 +68,7 @@ def add_project(conn, cur, project):
 
     try:
         insert_stmt = "INSERT INTO project_table (project) VALUES (?)"
-        conn.execute(
+        cur.execute(
             insert_stmt,
             (project,),
         )

--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -55,7 +55,7 @@ def add_queue(
                         max_nodes_per_assoc
                       ) VALUES (?, ?, ?, ?, ?, ?, ?)
                       """
-        conn.execute(
+        cur.execute(
             insert_stmt,
             (
                 queue,
@@ -145,7 +145,7 @@ def edit_queue(
                     queue,
                 )
 
-            conn.execute(update_stmt, tup)
+            cur.execute(update_stmt, tup)
 
             # commit changes
             conn.commit()


### PR DESCRIPTION
#### Problem

In continuation of #768, `Cursor` objects are not explicitly closed in a number of functions that are called for a lot of the Python commands. Thus, these `Cursor` objects can keep transactions alive, which is a potential cause for a database lock.

---

This PR uses the context manager decorator introduced in #768 as well as the `contextlib.closing()` method to explicitly close `Cursor` objects when functions exit.

It also changes some of the `.execute()` statements to use the `Cursor` object instead of the `Connection` object, which should make it consistent for the rest of the Python bindings.