### PR TITLE
doc: update `man(1)` page with new args for `jobs` command

### DIFF
--- a/doc/man1/flux-account-jobs.rst
+++ b/doc/man1/flux-account-jobs.rst
@@ -47,3 +47,13 @@ priority calculations. Jobs can be filtered by bank or by queue.
     Only show jobs that have become inactive since WHEN. A seconds-since-epoch
     timestamp or a human-readable timestamp (e.g. ``"2025-05-20 08:00:00"``)
     can be passed.
+
+.. option:: -j/--jobids=[JOBIDS]
+
+    Return the priority calculation for one or more job IDs.
+
+.. option:: -v/--verbose
+
+    Output a detailed breakdown of how the priority was calculated for each
+    job, showing how each factor relates to one another to come up with the
+    final priority displayed in the ``PRIORITY`` column.


### PR DESCRIPTION
#### Problem

Problem: The `man(1)` page for the `jobs` command does not list the newly-added `-j/--jobids` and `-v/--verbose` optional arguments, which were added in #777.

---

This PR updates the `man(1)` page with the new optional arguments for the `jobs` command. I've also added a small commit to update some of the optional arguments in this `man(1)` page that were missing values where required.