### PR TITLE
test: add `el9` image to CI

### DIFF
--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -1,0 +1,17 @@
+FROM fluxrm/flux-core:el9
+
+ARG USER=flux
+ARG UID=1000
+
+# Add configured user to image with sudo access:
+#
+RUN \
+ if test "$USER" != "flux"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -148,6 +148,13 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# el9
+matrix.add_build(
+    name="el9 - py3.9",
+    image="el9",
+    docker_tag=True,
+)
+
 # jammy
 matrix.add_build(
     name="jammy - py3.6",


### PR DESCRIPTION
#### Problem

The flux-accounting project does not have `el9` in its matrix of images built when running through CI.

---

This PR adds it.