### PR TITLE
NEWS: add release notes for `v0.54.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+flux-accounting version 0.54.0 - 2025-12-02
+-------------------------------------------
+
+#### Fixes
+
+* `fetch-job-records`: add proper logging (#784)
+
+* plugin: set load order of active jobs during initialization (#785)
+
+#### Features
+
+* plugin: add ability to initialize plugin with database information on load
+(#781)
+
+#### Testsuite
+
+* test: add `el9` image to CI (#782)
+
 flux-accounting version 0.53.0 - 2025-11-04
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for `v0.54.0`.

---

This PR adds some release notes for `v0.54.0`. I've included #785 in case that can be landed by next week's release. Once this lands, I'll create an annotated tag with the following:

```console
git tag -a v0.54.0 -m "Tag v0.54.0" && git push upstream v0.54.0
```