### PR TITLE
plugin: fix valgrind "Conditional jump or move depends on uninitialized value(s)" error

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -294,8 +294,8 @@ static int decrement_resources (Association *b,
  */
 static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
 {
-    std::string dependency;
-    flux_jobid_t held_job_id;
+    std::string dependency = "";
+    flux_jobid_t held_job_id = 0;
     // the Association has at least one held Job; begin looping through
     // held Jobs and see if they satisfy the requirements to be released
     auto it = b->held_jobs.begin ();


### PR DESCRIPTION
#### Problem

valgrind complains with a `"Conditional jump or move depends on uninitialized value(s)"` error message because the "dependency" and "held_job_id" variables are uninitialized at the top of `check_and_release_held_jobs ()`.

---

This PR just initializes both variables. I've also included a small commit to set `held_job_id` in one of the `if-` checks where it was mistakenly not set.