### PR TITLE
plugin: check `held_jobs` vector before calling `check_and_release_held_jobs ()`

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -776,10 +776,12 @@ static void reprior_cb (flux_t *h,
         auto &banks = entry.second;
 
         for (auto &bank_entry : banks) {
-            if (check_and_release_held_jobs (p, &bank_entry.second) < 0) {
-                flux_log_error (h,
-                                "reprior_cb: error checking and releasing "
-                                "held jobs for user(s)");
+            if (!bank_entry.second.held_jobs.empty ()) {
+                if (check_and_release_held_jobs (p, &bank_entry.second) < 0) {
+                    flux_log_error (h,
+                                    "reprior_cb: error checking and releasing "
+                                    "held jobs for user(s)");
+                }
             }
         }
     }


### PR DESCRIPTION
#### Problem

The `for`-loop in `reprior_cb ()` calls `check_and_release_held_jobs ()` for every association in the `users` map regardless of the length of their `held_jobs` vector (the object that stores all of the held jobs for an association in the plugin). If the list is empty, then the call to the helper function will fail and the following message will be logged to the Flux broker:

`reprior_cb: error checking and releasing held jobs for user(s): No such file or directory`

---

This PR just adds a check to see if the held_jobs vector is has at least one job in it before calling `check_and_release_held_jobs ()`.