### PR TITLE
doc: fix use of `-J` option in job usage factor example

### DIFF
--- a/doc/components/job-usage-calculation.rst
+++ b/doc/components/job-usage-calculation.rst
@@ -21,7 +21,7 @@ jobs.
 
 The **job usage factor** table stores past job usage factors per association.
 When an association is first added to the **association** table, they are also
-added to to **job usage factor** table.
+added to **job usage factor** table.
 
 The value of **PriorityDecayHalfLife** determines the amount of time that
 represents one "usage period" of jobs. flux-accounting filters out its ``jobs``


### PR DESCRIPTION
#### Problem

The example of showing the different job usage factors for an association uses an incorrect optional argument: it should be `-J`, but the documentation shows `-j`.

---

This PR fixes the example in the documentation.