### PR TITLE
bindings: use `FLUX_USERID_UNKNOWN` as default

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -12,6 +12,7 @@
 import sqlite3
 import time
 
+from flux.constants import FLUX_USERID_UNKNOWN
 import fluxacct.accounting
 from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import sql_util as sql
@@ -333,7 +334,7 @@ def add_user(
     cur,
     username,
     bank,
-    uid=65534,
+    uid=FLUX_USERID_UNKNOWN,
     shares=1,
     fairshare=0.5,
     max_running_jobs=5,
@@ -344,7 +345,7 @@ def add_user(
     projects="*",
     default_project=None,
 ):
-    if uid == 65534:
+    if uid == FLUX_USERID_UNKNOWN:
         uid = util.get_uid(username)
 
     # if true, association (user, bank) is already active

--- a/src/bindings/python/fluxacct/accounting/util.py
+++ b/src/bindings/python/fluxacct/accounting/util.py
@@ -14,6 +14,7 @@ import logging
 import functools
 import contextlib
 
+from flux.constants import FLUX_USERID_UNKNOWN
 from flux.util import parse_datetime
 import fluxacct.accounting
 
@@ -29,7 +30,7 @@ def get_uid(username):
     try:
         return pwd.getpwnam(username).pw_uid
     except KeyError:
-        return 65534
+        return FLUX_USERID_UNKNOWN
 
 
 def get_username(userid):

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -13,6 +13,7 @@ import logging
 import subprocess
 
 import flux
+from flux.constants import FLUX_USERID_UNKNOWN
 import fluxacct.accounting
 
 from fluxacct.accounting import create_db as c
@@ -161,7 +162,7 @@ def add_add_user_arg(subparsers):
     subparser_add_user.add_argument(
         "--userid",
         help="userid",
-        default=65534,
+        default=FLUX_USERID_UNKNOWN,
         metavar="USERID",
     )
     subparser_add_user.add_argument(

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -17,6 +17,7 @@ import sys
 
 from unittest import mock
 
+from flux.constants import FLUX_USERID_UNKNOWN
 from fluxacct.accounting import user_subcommands as u
 from fluxacct.accounting import bank_subcommands as b
 from fluxacct.accounting import create_db as c
@@ -251,7 +252,7 @@ class TestAccountingCLI(unittest.TestCase):
         u.add_user(acct_conn, username="test_user5", bank="A")
 
         cur.execute("SELECT userid FROM association_table WHERE username='test_user5'")
-        self.assertEqual(cur.fetchone()[0], 65534)
+        self.assertEqual(cur.fetchone()[0], FLUX_USERID_UNKNOWN)
 
         u.edit_user(acct_conn, username="test_user5", userid="12345")
         cur.execute("SELECT userid FROM association_table WHERE username='test_user5'")

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -19,6 +19,7 @@ from collections import namedtuple
 
 from unittest import mock
 
+from flux.constants import FLUX_USERID_UNKNOWN
 from fluxacct.accounting import job_usage_calculation as jobs
 from fluxacct.accounting import jobs_table_subcommands as j
 from fluxacct.accounting import create_db as c
@@ -45,7 +46,7 @@ def fake_get_uid(uid):
     try:
         return FAKE_ASSOCIATIONS[int(uid)].pw_uid
     except KeyError:
-        return 65534
+        return FLUX_USERID_UNKNOWN
 
 
 def fake_get_username(name):


### PR DESCRIPTION
#### Problem

The Python bindings use `65534` as the default userid for a user when one cannot be found, but this userid is technically valid (it is the userid for the `nobody` user).

---

This PR changes the default behavior to use `flux.constants.FLUX_USERID_UNKNOWN` as the default userid for a user when one cannot be found.