### PR TITLE
`add-bank`/`add-user`: add check for existing DB structure when trying to add a bank or association

### DIFF
--- a/doc/components/database-administration.rst
+++ b/doc/components/database-administration.rst
@@ -59,6 +59,13 @@ there is one root bank which all other banks and associations descend from:
 Multiple levels of banks can be defined under this root bank. Users can belong
 to more than one bank and will have at most one default bank.
 
+.. warning::
+    You are not allowed to have both an association and a bank under the same
+    parent bank, as this conflicts with how fair-share and job usage are
+    calculated. Trying to add a sub-bank to a parent bank which already has
+    associations (or vice versa: trying to add an association to a bank which
+    already has at least one sub-bank) will result in an error.
+
 To add a bank to the database, you can use the ``flux account add-bank``
 command. Each ``add-bank`` call requires a bank name, their allocated shares,
 and a parent bank name (if it is not the root bank):

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -102,6 +102,15 @@ def add_bank(conn, cur, bank, shares, parent_bank="", priority=0.0):
     except ValueError as bad_parent_bank:
         raise ValueError(f"parent bank {bad_parent_bank} not found in bank table")
 
+    # check that there exist no associations currently under the parent bank
+    cur.execute("SELECT * FROM association_table WHERE bank=?", (parent_bank,))
+    associations = cur.fetchall()
+    if len(associations) > 0:
+        # there is at least one association already under the parent bank; raise an error
+        raise ValueError(
+            "banks cannot be added to a bank that currently has associations in it"
+        )
+
     # check if bank already exists and is active in bank_table; if so, raise
     # a sqlite3.IntegrityError
     if bank_is_active(cur, bank, parent_bank):

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -356,6 +356,16 @@ def add_user(
             f"association {username},{bank} already active in association_table"
         )
 
+    # check that there exist no sub-banks under this bank
+    cur.execute("SELECT * FROM bank_table WHERE parent_bank=?", (bank,))
+    parent_bank = cur.fetchall()
+    if len(parent_bank) > 0:
+        # the bank that the association is trying to be added to also has at least one
+        # sub-bank in it; raise an error
+        raise ValueError(
+            "associations cannot be added to the same parent bank as a sub-bank"
+        )
+
     # if true, association already exists in table but is not
     # active, so re-activate the association and return
     if check_if_user_disabled(conn, cur, username, bank):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -81,6 +81,7 @@ TESTSCRIPTS = \
 	t1076-cmds-short-options.t \
 	t1077-max-sched-jobs-basic.t \
 	t1078-mf-priority-sched-dependencies.t \
+	t1079-issue809.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -125,7 +125,7 @@ for db in ${SHARNESS_TEST_SRCDIR}/expected/test_dbs/*; do
 		test_expect_success 'add a bank: '$(basename $db) \
 			"flux account add-bank --parent-bank=root G 1"
 		test_expect_success 'add a user: '$(basename $db) \
-			"flux account add-user --username=fluxuser --bank=root"
+			"flux account add-user --username=fluxuser --bank=G"
 		test_expect_success 'check validity of DB: '$(basename $db) \
 			"flux python ${DB_INTEGRITY_CHECK} $tmp_db > result.out && grep 'ok' result.out"
 		test_expect_success 'shutdown flux-accounting service' \

--- a/t/t1079-issue809.t
+++ b/t/t1079-issue809.t
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+test_description='make sure an error is raised when creating an invalid bank hierarchy structure'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+DB=$(pwd)/FluxAccountingTest.db
+QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+test_expect_success 'add banks' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association' '
+	flux account add-user --username=user1 --userid=50001 --bank=A
+'
+
+# Associations can only be added to banks that do not have any sub-banks under
+# them. Since the 'root' bank has a sub-bank under it (bank 'A'), this will
+# fail.
+test_expect_success 'adding an association under the same parent bank as a sub-bank fails' '
+	test_must_fail flux account add-user --username=user1 --userid=50001 --bank=root > error_assoc.out 2>&1 &&
+	grep "associations cannot be added to the same parent bank as a sub-bank" error_assoc.out
+'
+
+# Banks (particularly, sub-banks) can only be added under a parent that does
+# not already have associations in it. Since bank 'A' has one association in
+# it, this will fail.
+test_expect_success 'adding a bank under the same parent bank that has associations in it fails' '
+	test_must_fail flux account add-bank --parent-bank=A B 1 > error_bank.out 2>&1 &&
+	grep "banks cannot be added to a bank that currently has associations in it" error_bank.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As noted in #809, flux-accounting requires a bank hierarchy structure in which sub-banks cannot be added to a parent bank that already has associations in it (and vice versa; associations cannot be added to a bank that
already has sub-banks in it), but there is no check for this hierarchy structure when calling `add-bank` or `add-user`.

---

This PR adds a check in `add_bank()` and `add_user()` that the bank or association being added is valid and complies with the hierarchy structure for flux-accounting; if not, it raises an error. Existing tests that did _not_ follow this structure have also been adjusted to comply and are adjusted in the first commit. Documentation has also been updated to leave a warning to readers about the assumptions of the structure of banks and associations in flux-accounting.

Fixes #809