### PR TITLE
testsuite: set log-stderr-level on command line

### DIFF
--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -9,9 +9,7 @@ SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -10,9 +10,7 @@ SMALL_NO_TIE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_no_tie.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -10,9 +10,7 @@ SMALL_TIE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_tie.json
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -10,9 +10,7 @@ SMALL_TIE_ALL=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/small_tie_all.jso
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -9,9 +9,7 @@ SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1006-update-fshare.t
+++ b/t/t1006-update-fshare.t
@@ -10,9 +10,7 @@ UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'trying to run update-fshare with bad DBPATH should return an error' '
 	test_must_fail flux account-update-fshare -p foo.db > failure.out 2>&1 &&

--- a/t/t1007-flux-account-users.t
+++ b/t/t1007-flux-account-users.t
@@ -8,9 +8,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/flux_account
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1008-mf-priority-update.t
+++ b/t/t1008-mf-priority-update.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1009-pop-db.t
+++ b/t/t1009-pop-db.t
@@ -8,9 +8,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/pop_db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -9,9 +9,7 @@ QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
 NO_JOBS=${SHARNESS_TEST_SRCDIR}/expected/job_usage/no_jobs.expected
 
 export FLUX_CONF_DIR=$(pwd)
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 # select job records from flux-accounting DB
 select_job_records() {

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -8,9 +8,7 @@ SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -12,9 +12,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -6,9 +6,7 @@ test_description='Test cancelling active jobs with a late user/bank info load'
 MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1015-mf-priority-urgency.t
+++ b/t/t1015-mf-priority-urgency.t
@@ -9,9 +9,7 @@ SEND_PAYLOAD=${SHARNESS_TEST_SRCDIR}/scripts/send_payload.py
 SAME_FAIRSHARE=${SHARNESS_TEST_SRCDIR}/expected/sample_payloads/same_fairshare.json
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1016-export-db.t
+++ b/t/t1016-export-db.t
@@ -9,9 +9,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/pop_db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTestv1.db create-db

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -13,9 +13,7 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create a flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTestv1.db create-db

--- a/t/t1018-mf-priority-disable-entry.t
+++ b/t/t1018-mf-priority-disable-entry.t
@@ -7,9 +7,7 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1019-mf-priority-info-fetch.t
+++ b/t/t1019-mf-priority-info-fetch.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1020-mf-priority-issue262.t
+++ b/t/t1020-mf-priority-issue262.t
@@ -10,9 +10,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/plugin_state
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1021-mf-priority-issue332.t
+++ b/t/t1021-mf-priority-issue332.t
@@ -13,9 +13,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/plugin_state
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1022-mf-priority-issue346.t
+++ b/t/t1022-mf-priority-issue346.t
@@ -12,9 +12,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -8,9 +8,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/flux_account
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1024-flux-account-queues.t
+++ b/t/t1024-flux-account-queues.t
@@ -8,9 +8,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/flux_account
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1025-flux-account-projects.t
+++ b/t/t1025-flux-account-projects.t
@@ -8,9 +8,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/flux_account
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1026-flux-account-perms.t
+++ b/t/t1026-flux-account-perms.t
@@ -8,9 +8,7 @@ EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/flux_account
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1027-mf-priority-issue376.t
+++ b/t/t1027-mf-priority-issue376.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1028-mf-priority-issue385.t
+++ b/t/t1028-mf-priority-issue385.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1029-mf-priority-default-bank.t
+++ b/t/t1029-mf-priority-default-bank.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1030-mf-priority-update-queue.t
+++ b/t/t1030-mf-priority-update-queue.t
@@ -12,9 +12,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1031-mf-priority-issue406.t
+++ b/t/t1031-mf-priority-issue406.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1032-mf-priority-update-bank.t
+++ b/t/t1032-mf-priority-update-bank.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1033-mf-priority-update-job.t
+++ b/t/t1033-mf-priority-update-job.t
@@ -12,9 +12,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1034-mf-priority-config.t
+++ b/t/t1034-mf-priority-config.t
@@ -12,9 +12,7 @@ mkdir -p config
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1035-flux-account-scrub-old-jobs.t
+++ b/t/t1035-flux-account-scrub-old-jobs.t
@@ -9,9 +9,7 @@ INSERT_JOBS="flux python ${SHARNESS_TEST_SRCDIR}/scripts/insert_jobs.py"
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # get job records from jobs table
 # arg1 - database path

--- a/t/t1036-hierarchy-small-no-tie-db.t
+++ b/t/t1036-hierarchy-small-no-tie-db.t
@@ -10,9 +10,7 @@ UPDATE_USAGE=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create small_no_tie flux-accounting DB' '
 	flux account -p ${SMALL_NO_TIE} create-db

--- a/t/t1037-hierarchy-small-tie-db.t
+++ b/t/t1037-hierarchy-small-tie-db.t
@@ -10,9 +10,7 @@ UPDATE_USAGE=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create small_no_tie flux-accounting DB' '
 	flux account -p ${SMALL_TIE} create-db

--- a/t/t1038-hierarchy-small-tie-all-db.t
+++ b/t/t1038-hierarchy-small-tie-all-db.t
@@ -10,9 +10,7 @@ UPDATE_USAGE=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create small_no_tie flux-accounting DB' '
 	flux account -p ${SMALL_TIE_ALL} create-db

--- a/t/t1039-issue476.t
+++ b/t/t1039-issue476.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1040-mf-priority-projects.t
+++ b/t/t1040-mf-priority-projects.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1041-view-jobs-by-project.t
+++ b/t/t1041-view-jobs-by-project.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1042-issue508.t
+++ b/t/t1042-issue508.t
@@ -9,9 +9,7 @@ mkdir -p conf.d
 ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB, start flux-accounting service' '
 	flux account -p ${ACCOUNTING_DB} create-db &&

--- a/t/t1043-view-jobs-by-bank.t
+++ b/t/t1043-view-jobs-by-bank.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1044-mf-priority-resource-limits.t
+++ b/t/t1044-mf-priority-resource-limits.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 4 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1045-issue478.t
+++ b/t/t1045-issue478.t
@@ -9,9 +9,7 @@ mkdir -p conf.d
 ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB, start flux-accounting service' '
 	flux account -p ${ACCOUNTING_DB} create-db &&

--- a/t/t1046-issue565.t
+++ b/t/t1046-issue565.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1047-issue564.t
+++ b/t/t1047-issue564.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'load multi-factor priority plugin' '
 	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}

--- a/t/t1048-issue575.t
+++ b/t/t1048-issue575.t
@@ -7,9 +7,7 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1049-issue580.t
+++ b/t/t1049-issue580.t
@@ -9,9 +9,7 @@ UPDATE_USAGE=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create small_no_tie flux-accounting DB' '
 	flux account -p ${TEST_DB} create-db

--- a/t/t1050-mf-priority-update-on-reload.t
+++ b/t/t1050-mf-priority-update-on-reload.t
@@ -7,9 +7,7 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1051-list-users.t
+++ b/t/t1051-list-users.t
@@ -7,9 +7,7 @@ FLUX_ACCOUNTING_DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p ${FLUX_ACCOUNTING_DB} create-db

--- a/t/t1052-mf-priority-queue-limits.t
+++ b/t/t1052-mf-priority-queue-limits.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1053-issue631.t
+++ b/t/t1053-issue631.t
@@ -10,9 +10,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p ${DB_PATH} create-db

--- a/t/t1054-mf-priority-bank-priorities.t
+++ b/t/t1054-mf-priority-bank-priorities.t
@@ -12,9 +12,7 @@ mkdir -p config
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1055-flux-account-priorities.t
+++ b/t/t1055-flux-account-priorities.t
@@ -10,9 +10,7 @@ mkdir -p config
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1056-mf-priority-urgency-factor.t
+++ b/t/t1056-mf-priority-urgency-factor.t
@@ -11,9 +11,7 @@ mkdir -p config
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1057-flux-account-jobs.t
+++ b/t/t1057-flux-account-jobs.t
@@ -10,9 +10,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 mkdir -p config
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1058-flux-account-visuals.t
+++ b/t/t1058-flux-account-visuals.t
@@ -10,9 +10,7 @@ UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 mkdir -p config
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1059-issue685.t
+++ b/t/t1059-issue685.t
@@ -10,9 +10,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 mkdir -p config
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1060-mf-priority-queue-usage.t
+++ b/t/t1060-mf-priority-queue-usage.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 mkdir -p config
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1061-flux-account-edit-all-users.t
+++ b/t/t1061-flux-account-edit-all-users.t
@@ -9,9 +9,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 mkdir -p config
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p ${DB_PATH} create-db

--- a/t/t1062-mf-priority-queue-resource-limits.t
+++ b/t/t1062-mf-priority-queue-resource-limits.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 mkdir -p config
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1063-issue709.t
+++ b/t/t1063-issue709.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 4 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1064-store-job-duration.t
+++ b/t/t1064-store-job-duration.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 4 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1065-view-jobs-by-duration.t
+++ b/t/t1065-view-jobs-by-duration.t
@@ -12,9 +12,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 # update job records with actual duration
 update_actual_duration() {

--- a/t/t1066-view-bank-concise.t
+++ b/t/t1066-view-bank-concise.t
@@ -8,9 +8,7 @@ UPDATE_USAGE_COL=${SHARNESS_TEST_SRCDIR}/scripts/update_usage_column.py
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p $(pwd)/FluxAccountingTest.db create-db

--- a/t/t1067-mf-priority-issue733.t
+++ b/t/t1067-mf-priority-issue733.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1068-mf-priority-queues-projects-query.t
+++ b/t/t1068-mf-priority-queues-projects-query.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1069-duration-delta.t
+++ b/t/t1069-duration-delta.t
@@ -12,9 +12,7 @@ DB_PATH=$(pwd)/FluxAccountingTest.db
 QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 # update job records with actual_duration
 update_actual_duration() {

--- a/t/t1070-issue749.t
+++ b/t/t1070-issue749.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1071-issue754.t
+++ b/t/t1071-issue754.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1072-sync-uids.t
+++ b/t/t1072-sync-uids.t
@@ -9,9 +9,7 @@ mkdir -p config
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 # create a script to update and get userids from job_usage_factor_table
 cat > db_helper.py <<'PYTHON_EOF'

--- a/t/t1073-mf-priority-init-basic.t
+++ b/t/t1073-mf-priority-init-basic.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1074-mf-priority-init-depend.t
+++ b/t/t1074-mf-priority-init-depend.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1075-custom-usage-reporting.t
+++ b/t/t1075-custom-usage-reporting.t
@@ -12,9 +12,7 @@ DB=$(pwd)/FluxAccountingTest.db
 INSERT_JOBS="flux python ${SHARNESS_TEST_SRCDIR}/scripts/t1075/insert_jobs_to_db.py"
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1076-cmds-short-options.t
+++ b/t/t1076-cmds-short-options.t
@@ -9,9 +9,7 @@ mkdir -p conf.d
 DB_PATH=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/conf.d
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/conf.d -Slog-stderr-level=1
 
 test_expect_success 'create flux-accounting DB' '
 	flux account -p ${DB_PATH} create-db

--- a/t/t1077-max-sched-jobs-basic.t
+++ b/t/t1077-max-sched-jobs-basic.t
@@ -9,9 +9,7 @@ mkdir -p config
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1078-mf-priority-sched-dependencies.t
+++ b/t/t1078-mf-priority-sched-dependencies.t
@@ -11,9 +11,7 @@ SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB=$(pwd)/FluxAccountingTest.db
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 4 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF

--- a/t/t1079-issue809.t
+++ b/t/t1079-issue809.t
@@ -10,9 +10,7 @@ DB=$(pwd)/FluxAccountingTest.db
 QUERYCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/query.py"
 
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF


### PR DESCRIPTION
Problem: the log-stderr-level attribute is adjusted with flux-setattr(1) in several tests, but that interface may change as proposed in flux-framework/flux-core#7370.

Set it on the broker command line instead, by adding -Slog-stderr-level=N to test_under_flux.