### PR TITLE
repo: add `LICENSE`, `NEWS.md` to release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,9 @@ EXTRA_DIST= \
 	config/tap-driver.sh \
 	config/tap-driver.py \
 	DISCLAIMER.LLNS \
-	README.md
+	README.md \
+	LICENSE \
+	NEWS.md
 
 CODE_COVERAGE_IGNORE_PATTERN = \
     "*/common/libtap/*" \


### PR DESCRIPTION
#### Problem

As mentioned in #811, the `LICENSE` and `NEWS.md` files are not currently included in release tarballs.

---

This PR adds them by listing both files in `EXTRA_DIST` in the top-level `Makefile.am`.

Fixes #811