### PR TITLE
`apply_decay_factor`: change decay application to incremental instead of cumulative

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import time
-import math
 import logging
 import sqlite3
 from collections import defaultdict
@@ -93,8 +92,8 @@ def apply_decay_factor(decay, acct_conn, user, bank, usage_factors):
     usg_past_decay = []
 
     # apply decay factor to past usage periods of a user's jobs
-    for power, usage_factor in enumerate(usage_factors, start=1):
-        usg_past_decay.append(usage_factor * math.pow(decay, power))
+    for usage_factor in usage_factors:
+        usg_past_decay.append(usage_factor * decay)
 
     # update job_usage_factor_table with new values, starting with the second usage
     # period and working back to the oldest usage period since the most recent usage

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -98,7 +98,8 @@ TESTSCRIPTS = \
 	python/t1011_priorities.py \
 	python/t1012_visuals.py \
 	python/t1013_issue802.py \
-	python/t1014_clear_usage.py
+	python/t1014_clear_usage.py \
+	python/t1015_issue815.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -428,7 +428,7 @@ class TestAccountingCLI(unittest.TestCase):
             ],
             user_jobs=job_records,
         )
-        self.assertEqual(usage_factor, 4366.0)
+        self.assertEqual(usage_factor, 4442.0)
 
     # simulate a half-life period further; re-calculate
     # usage for user1001 to make sure its value goes down
@@ -459,7 +459,7 @@ class TestAccountingCLI(unittest.TestCase):
             user_jobs=[],
         )
 
-        self.assertEqual(usage_factor, 3215.5)
+        self.assertEqual(usage_factor, 4334.0)
 
         select_stmt = (
             "SELECT usage_factor_period_0 FROM job_usage_factor_table"
@@ -522,7 +522,7 @@ class TestAccountingCLI(unittest.TestCase):
 
         cur.execute(s_stmt)
         job_usage = cur.fetchone()[0]
-        self.assertEqual(job_usage, 8496.0)
+        self.assertEqual(job_usage, 8518.0)
 
     # remove database and log file
     @classmethod

--- a/t/python/t1015_issue815.py
+++ b/t/python/t1015_issue815.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+
+from unittest import mock
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import job_usage_calculation as j
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        c.create_db("FluxAccountingTest.db")
+        global conn
+        global cur
+
+        conn = sqlite3.connect("FluxAccountingTest.db")
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        # set the end of the current half-life period in database
+        update_stmt = "UPDATE t_half_life_period_table SET end_half_life_period=? WHERE cluster='cluster'"
+        cur.execute(update_stmt, ("10000000",))
+        conn.commit()
+
+        # add banks
+        b.add_bank(conn, "root", 1)
+        b.add_bank(conn, "A", 1, "root")
+
+        # add associations
+        u.add_user(conn, username="user1", bank="A", uid=50001)
+
+        # edit the job usage values for the associations so that:
+        # Bank | Usage
+        # root | 100
+        #   A | 100
+        cur.execute("UPDATE association_table SET job_usage=100 WHERE username='user1'")
+        # manually set current job usage factor all associations in the DB
+        cur.execute(
+            "UPDATE job_usage_factor_table SET usage_factor_period_0=100 WHERE username='user1'"
+        )
+
+        conn.commit()
+
+    # call update_job_usage so that the banks get their job usage value updated
+    @mock.patch("time.time", mock.MagicMock(return_value=10000001))
+    def test_01_call_update_usage(self):
+        j.update_job_usage(conn)
+
+    # check job usage values for every bank
+    def test_02_check_job_usage_value_bank_root(self):
+        cur.execute("SELECT job_usage FROM bank_table WHERE bank='root'")
+        usage = cur.fetchone()[0]
+
+        self.assertEqual(usage, 100)
+
+    def test_03_check_job_usage_value_bank_A(self):
+        cur.execute("SELECT job_usage FROM bank_table WHERE bank='A'")
+        usage = cur.fetchone()[0]
+
+        self.assertEqual(usage, 100)
+
+    # make sure the historical job usage value and all of the job usage period values
+    # are accurate
+    #
+    # before any half-life decay, the usage for user1 should look like:
+    # p0  | p1 | p2 | p3
+    # ------------------
+    # 100 | 0  | 0  | 0
+    def test_04_check_job_usage_value_user1(self):
+        cur.execute("SELECT job_usage FROM association_table WHERE username='user1'")
+        historical_usage = cur.fetchone()[0]
+        self.assertEqual(historical_usage, 100.0)
+
+        cur.execute(
+            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 100.0)
+
+        cur.execute(
+            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_1 = cur.fetchone()[0]
+        self.assertEqual(usage_period_1, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_2 = cur.fetchone()[0]
+        self.assertEqual(usage_period_2, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_3 = cur.fetchone()[0]
+        self.assertEqual(usage_period_3, 0)
+
+    # simulate a half-period further; ensure that the half-life decay is applied properly
+    # across all usage period columns
+    #
+    # after a half-life decay, the usage for user1 should look like:
+    # p0 | p1 | p2 | p3
+    # -----------------
+    # 0  | 50 | 0  | 0
+    @mock.patch("time.time", mock.MagicMock(return_value=(100000000 + (604801 * 1.1))))
+    def test_05_call_update_usage_new_half_life_period(self):
+        j.update_job_usage(conn)
+
+    def test_06_check_job_usage_value_user1_after_first_decay(self):
+        cur.execute("SELECT job_usage FROM association_table WHERE username='user1'")
+        historical_usage = cur.fetchone()[0]
+        self.assertEqual(historical_usage, 50.0)
+
+        cur.execute(
+            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_1 = cur.fetchone()[0]
+        self.assertEqual(usage_period_1, 50.0)
+
+        cur.execute(
+            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_2 = cur.fetchone()[0]
+        self.assertEqual(usage_period_2, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_3 = cur.fetchone()[0]
+        self.assertEqual(usage_period_3, 0)
+
+    # simulate another half-period further
+    #
+    # after another half-life decay, the usage for user1 should look like:
+    # p0 | p1 | p2 | p3
+    # -----------------
+    # 0  | 0  | 25 | 0
+    @mock.patch("time.time", mock.MagicMock(return_value=(100000000 + (604801 * 2.1))))
+    def test_07_call_update_usage_new_half_life_period(self):
+        j.update_job_usage(conn)
+
+    def test_08_check_job_usage_value_user1_after_second_decay(self):
+        cur.execute("SELECT job_usage FROM association_table WHERE username='user1'")
+        historical_usage = cur.fetchone()[0]
+        self.assertEqual(historical_usage, 25.0)
+
+        cur.execute(
+            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_1 = cur.fetchone()[0]
+        self.assertEqual(usage_period_1, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_2 = cur.fetchone()[0]
+        self.assertEqual(usage_period_2, 25.0)
+
+        cur.execute(
+            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_3 = cur.fetchone()[0]
+        self.assertEqual(usage_period_3, 0)
+
+    # simulate another half-period further
+    #
+    # after another half-life decay, the usage for user1 should look like:
+    # p0  | p1 | p2 | p3
+    # --------------------
+    # 0   | 0  | 0  | 12.5
+    @mock.patch("time.time", mock.MagicMock(return_value=(100000000 + (604801 * 3.1))))
+    def test_09_call_update_usage_new_half_life_period(self):
+        j.update_job_usage(conn)
+
+    def test_10_check_job_usage_value_user1_after_third_decay(self):
+        cur.execute("SELECT job_usage FROM association_table WHERE username='user1'")
+        historical_usage = cur.fetchone()[0]
+        self.assertEqual(historical_usage, 12.5)
+
+        cur.execute(
+            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_1 = cur.fetchone()[0]
+        self.assertEqual(usage_period_1, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_2 = cur.fetchone()[0]
+        self.assertEqual(usage_period_2, 0)
+
+        cur.execute(
+            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+        )
+        usage_period_3 = cur.fetchone()[0]
+        self.assertEqual(usage_period_3, 12.5)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove("FluxAccountingTest.db")
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
#### Problem

As mentioned in #815, the `apply_decay_factor()` function applies cumulative decay factors (`0.5^1`, `0.5^2`, `0.5^3`, etc.) to each usage period every time the function runs. However, each period already contains values that have
been decayed in previous cycles. This causes compound decay - for example, a value that should have been decayed by `0.5^3` total was actually being decayed by much more (`0.5^5` or higher).

---

This PR changes the decay application from cumulative to incremental, i.e. just multiplies each value by 0.5 once (representing one half-life period) rather than raising 0.5 to increasing powers.

As a result, some of the expected job usage values in `t1006_job_archive.py` are changed with the new decay application. I've also added some new tests to simulate multiple half-life periods and checks to make sure that **all** job usage period values are updated properly.

Fixes #815