### PR TITLE
plugin: minor improvements to logic, variable initialization

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1478,10 +1478,12 @@ static int run_cb (flux_plugin_t *p,
     b->cur_sched_jobs--;
     // check to see if any jobs held due to max_sched_jobs limit can now
     // have their dependency removed
-    if (check_and_release_held_jobs (p, b) < 0) {
-        flux_log_error (h,
-                        "job.state.run: error checking and releasing "
-                        "held jobs for association");
+    if (!b->held_jobs.empty ()) {
+        if (check_and_release_held_jobs (p, b) < 0) {
+            flux_log_error (h,
+                            "job.state.run: error checking and releasing held "
+                            "jobs for association");
+        }
     }
 
     return 0;

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -377,6 +377,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
             // move onto the next Job
             ++it;
     }
+    return 0;
 error:
     flux_jobtap_raise_exception (p,
                                  held_job_id,

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -348,6 +348,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
                                                held_job.id,
                                                D_ASSOC_MSJ) < 0) {
                 dependency = D_ASSOC_MSJ;
+                held_job_id = held_job.id;
                 goto error;
             }
             held_job.remove_dep (D_ASSOC_MSJ);


### PR DESCRIPTION
#### Problem

There are few minor issues in the priority plugin:

- In `check_and_release_held_jobs ()`, `held_job_id` is not set in the case where removing the `max_sched_jobs` dependency fails, which is inconsistent with the other checks throughout this function.
- The `goto error` block is unconditionally executed at the end of `check_and_release_held_jobs ()` because there is no `return` statement before the label, even on success. This incorrectly populates the journal with error messages, even if the function succeeds.
- In `run_cb ()`, the `held_jobs` attribute for an Association object is not checked to see if it is empty before calling `check_and_release_held_jobs ()`.

---

This PR includes minor fixes for all three problems listed above.