### PR TITLE
t: make Python test DB names unique

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -80,7 +80,7 @@ def create_db(
     try:
         # open connection to database
         LOGGER.info("Creating Flux Accounting DB")
-        conn = sqlite3.connect("file:" + filepath + "?mode:rwc", uri=True)
+        conn = sqlite3.connect("file:" + filepath + "?mode=rwc", uri=True)
         LOGGER.info("Created Flux Accounting DB successfully")
     except sqlite3.OperationalError as exception:
         LOGGER.error(exception)

--- a/t/python/t1001_db.py
+++ b/t/python/t1001_db.py
@@ -27,7 +27,7 @@ class TestDB(unittest.TestCase):
         global conn
         global cur
         try:
-            conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
+            conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True, timeout=60)
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
         except sqlite3.OperationalError:

--- a/t/python/t1001_db.py
+++ b/t/python/t1001_db.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import sys
+import time
 
 from fluxacct.accounting import create_db as c
 
@@ -21,11 +22,12 @@ class TestDB(unittest.TestCase):
     # create database
     @classmethod
     def setUpClass(self):
-        c.create_db("FluxAccounting.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
         try:
-            conn = sqlite3.connect("file:FluxAccounting.db?mode=rw", uri=True)
+            conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
         except sqlite3.OperationalError:
@@ -34,7 +36,7 @@ class TestDB(unittest.TestCase):
 
     # create database and make sure it exists
     def test_00_test_create_db(self):
-        assert os.path.exists("FluxAccounting.db")
+        assert os.path.exists(self.dbname)
 
     # make sure association table exists
     def test_01_tables_exist(self):
@@ -163,7 +165,7 @@ class TestDB(unittest.TestCase):
     # remove database file
     @classmethod
     def tearDownClass(self):
-        os.remove("FluxAccounting.db")
+        os.remove(self.dbname)
         os.remove("flux_accounting_test_1.db")
         os.remove("flux_accounting_test_2.db")
 

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import io
+import time
 import sys
 
 from unittest import mock
@@ -28,10 +29,11 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create example accounting database
-        c.create_db("TestUserSubcommands.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global acct_conn
         try:
-            acct_conn = sqlite3.connect("file:TestUserSubcommands.db?mode=rw", uri=True)
+            acct_conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
             acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:
@@ -361,7 +363,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         acct_conn.close()
-        os.remove("TestUserSubcommands.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -33,7 +33,9 @@ class TestAccountingCLI(unittest.TestCase):
         c.create_db(self.dbname)
         global acct_conn
         try:
-            acct_conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
+            acct_conn = sqlite3.connect(
+                f"file:{self.dbname}?mode=rw", uri=True, timeout=60
+            )
             acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:

--- a/t/python/t1003_bank_cmds.py
+++ b/t/python/t1003_bank_cmds.py
@@ -12,6 +12,7 @@
 import unittest
 import sys
 import os
+import time
 import sqlite3
 
 from fluxacct.accounting import bank_subcommands as b
@@ -22,11 +23,12 @@ class TestAccountingCLI(unittest.TestCase):
     # create test flux-accounting database
     @classmethod
     def setUpClass(self):
-        c.create_db("TestBankSubcommands.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global acct_conn
         global cur
         try:
-            acct_conn = sqlite3.connect("file:TestBankSubcommands.db?mode=rw", uri=True)
+            acct_conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
             acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:
@@ -175,7 +177,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         acct_conn.close()
-        os.remove("TestBankSubcommands.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1003_bank_cmds.py
+++ b/t/python/t1003_bank_cmds.py
@@ -28,7 +28,9 @@ class TestAccountingCLI(unittest.TestCase):
         global acct_conn
         global cur
         try:
-            acct_conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
+            acct_conn = sqlite3.connect(
+                f"file:{self.dbname}?mode=rw", uri=True, timeout=60
+            )
             acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:

--- a/t/python/t1004_queue_cmds.py
+++ b/t/python/t1004_queue_cmds.py
@@ -27,7 +27,7 @@ class TestAccountingCLI(unittest.TestCase):
         global acct_conn
         global cur
 
-        acct_conn = sqlite3.connect(self.dbname)
+        acct_conn = sqlite3.connect(self.dbname, timeout=60)
         acct_conn.row_factory = sqlite3.Row
         cur = acct_conn.cursor()
 

--- a/t/python/t1004_queue_cmds.py
+++ b/t/python/t1004_queue_cmds.py
@@ -12,6 +12,7 @@
 import unittest
 import os
 import sqlite3
+import time
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import queue_subcommands as q
@@ -21,11 +22,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("TestQueueSubcommands.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global acct_conn
         global cur
 
-        acct_conn = sqlite3.connect("TestQueueSubcommands.db")
+        acct_conn = sqlite3.connect(self.dbname)
         acct_conn.row_factory = sqlite3.Row
         cur = acct_conn.cursor()
 
@@ -98,7 +100,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         acct_conn.close()
-        os.remove("TestQueueSubcommands.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1005_project_cmds.py
+++ b/t/python/t1005_project_cmds.py
@@ -29,7 +29,7 @@ class TestAccountingCLI(unittest.TestCase):
         global acct_conn
         global cur
 
-        acct_conn = sqlite3.connect(self.dbname)
+        acct_conn = sqlite3.connect(self.dbname, timeout=60)
         acct_conn.row_factory = sqlite3.Row
         cur = acct_conn.cursor()
 

--- a/t/python/t1005_project_cmds.py
+++ b/t/python/t1005_project_cmds.py
@@ -12,6 +12,7 @@
 import unittest
 import os
 import sqlite3
+import time
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import user_subcommands as u
@@ -23,11 +24,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("TestProjectSubcommands.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global acct_conn
         global cur
 
-        acct_conn = sqlite3.connect("TestProjectSubcommands.db")
+        acct_conn = sqlite3.connect(self.dbname)
         acct_conn.row_factory = sqlite3.Row
         cur = acct_conn.cursor()
 
@@ -128,7 +130,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         acct_conn.close()
-        os.remove("TestProjectSubcommands.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -68,7 +68,9 @@ class TestAccountingCLI(unittest.TestCase):
         self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
         c.create_db(self.dbname)
         try:
-            acct_conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
+            acct_conn = sqlite3.connect(
+                f"file:{self.dbname}?mode=rw", uri=True, timeout=60
+            )
             acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -65,9 +65,10 @@ class TestAccountingCLI(unittest.TestCase):
         global user_jobs
 
         # create example job-archive database, output file
-        c.create_db("FluxAccountingUsers.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         try:
-            acct_conn = sqlite3.connect("file:FluxAccountingUsers.db?mode=rw", uri=True)
+            acct_conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
             acct_conn.row_factory = sqlite3.Row
             cur = acct_conn.cursor()
         except sqlite3.OperationalError:
@@ -527,7 +528,7 @@ class TestAccountingCLI(unittest.TestCase):
     # remove database and log file
     @classmethod
     def tearDownClass(self):
-        os.remove("FluxAccountingUsers.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1007_formatter.py
+++ b/t/python/t1007_formatter.py
@@ -12,6 +12,7 @@
 import unittest
 import os
 import sqlite3
+import time
 
 import fluxacct.accounting
 from fluxacct.accounting import create_db as c
@@ -24,11 +25,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("TestFormatter.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("TestFormatter.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -122,7 +124,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("TestFormatter.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1007_formatter.py
+++ b/t/python/t1007_formatter.py
@@ -30,7 +30,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1008_banks_output.py
+++ b/t/python/t1008_banks_output.py
@@ -30,7 +30,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1008_banks_output.py
+++ b/t/python/t1008_banks_output.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import textwrap
+import time
 
 import fluxacct.accounting
 from fluxacct.accounting import create_db as c
@@ -24,11 +25,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("test_view_banks.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("test_view_banks.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -311,7 +313,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("test_view_banks.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1009_users_output.py
+++ b/t/python/t1009_users_output.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import textwrap
+import time
 
 import fluxacct.accounting
 from fluxacct.accounting import create_db as c
@@ -25,11 +26,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("test_view_associations.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("test_view_associations.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -94,7 +96,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("test_view_associations.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1009_users_output.py
+++ b/t/python/t1009_users_output.py
@@ -31,7 +31,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1010_issue631.py
+++ b/t/python/t1010_issue631.py
@@ -33,7 +33,7 @@ class TestAccountingCLI(unittest.TestCase):
         global select_historical_usage
         global select_current_usage
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1010_issue631.py
+++ b/t/python/t1010_issue631.py
@@ -12,6 +12,7 @@
 import unittest
 import os
 import sqlite3
+import time
 
 from unittest import mock
 
@@ -25,13 +26,14 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("FluxAccountingTestIssue631.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
         global select_historical_usage
         global select_current_usage
 
-        conn = sqlite3.connect("FluxAccountingTestIssue631.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -296,7 +298,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("FluxAccountingTestIssue631.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1011_priorities.py
+++ b/t/python/t1011_priorities.py
@@ -28,7 +28,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1011_priorities.py
+++ b/t/python/t1011_priorities.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import textwrap
+import time
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import priorities as prio
@@ -22,11 +23,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("FluxAccountingPriorities.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("FluxAccountingPriorities.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -87,7 +89,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("FluxAccountingPriorities.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1012_visuals.py
+++ b/t/python/t1012_visuals.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import re
+import time
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import user_subcommands as u
@@ -24,11 +25,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test flux-accounting database
-        c.create_db("FluxAccountingVisuals.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("FluxAccountingVisuals.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -108,7 +110,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("FluxAccountingVisuals.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1012_visuals.py
+++ b/t/python/t1012_visuals.py
@@ -30,7 +30,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1013_issue802.py
+++ b/t/python/t1013_issue802.py
@@ -67,7 +67,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
         c.create_db(self.dbname)
         try:
-            conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
+            conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True, timeout=60)
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
         except sqlite3.OperationalError:

--- a/t/python/t1013_issue802.py
+++ b/t/python/t1013_issue802.py
@@ -64,9 +64,10 @@ class TestAccountingCLI(unittest.TestCase):
         global user_jobs
 
         # create example job-archive database, output file
-        c.create_db("FluxAccountingTest.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         try:
-            conn = sqlite3.connect("file:FluxAccountingTest.db?mode=rw", uri=True)
+            conn = sqlite3.connect(f"file:{self.dbname}?mode=rw", uri=True)
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
         except sqlite3.OperationalError:
@@ -216,7 +217,7 @@ class TestAccountingCLI(unittest.TestCase):
     # remove database and log file
     @classmethod
     def tearDownClass(self):
-        os.remove("FluxAccountingTest.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1014_clear_usage.py
+++ b/t/python/t1014_clear_usage.py
@@ -33,7 +33,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/python/t1014_clear_usage.py
+++ b/t/python/t1014_clear_usage.py
@@ -28,11 +28,12 @@ class TestAccountingCLI(unittest.TestCase):
     @mock.patch("time.time", mock.MagicMock(return_value=10000001))
     def setUpClass(self):
         # create test accounting database
-        c.create_db("FluxAccountingTest.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("FluxAccountingTest.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -169,7 +170,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("FluxAccountingTest.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1015_issue815.py
+++ b/t/python/t1015_issue815.py
@@ -12,6 +12,7 @@
 import unittest
 import os
 import sqlite3
+import time
 
 from unittest import mock
 
@@ -25,11 +26,12 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # create test accounting database
-        c.create_db("FluxAccountingTest.db")
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
         global conn
         global cur
 
-        conn = sqlite3.connect("FluxAccountingTest.db")
+        conn = sqlite3.connect(self.dbname)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 
@@ -233,7 +235,7 @@ class TestAccountingCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         conn.close()
-        os.remove("FluxAccountingTest.db")
+        os.remove(self.dbname)
 
 
 def suite():

--- a/t/python/t1015_issue815.py
+++ b/t/python/t1015_issue815.py
@@ -31,7 +31,7 @@ class TestAccountingCLI(unittest.TestCase):
         global conn
         global cur
 
-        conn = sqlite3.connect(self.dbname)
+        conn = sqlite3.connect(self.dbname, timeout=60)
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
 

--- a/t/t1080-clear-usage.t
+++ b/t/t1080-clear-usage.t
@@ -10,9 +10,7 @@ MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
 SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
 DB=$(pwd)/FluxAccountingTest.db
 
-test_under_flux 16 job -o,--config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 16 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
 
 test_expect_success 'allow guest access to testexec' '
 	flux config load <<-EOF


### PR DESCRIPTION
#### Problem

Many of the unit tests in the `t/python/` directory share the same database name, which can cause errors in the unit tests if they are running at the same time and in the same directory, since they would essentially be trying to create and connect to the same database, when they really should each be testing against their own DB.

---

This PR makes the test database names for each of the unit tests in `t/python/` unique. I've also snuck in a minor commit to set the `log-stderr-level` attribute to match the rest of sharness tests that were fixed in #812.