### PR TITLE
doc: fix bank factor job priority example

### DIFF
--- a/doc/components/job-priorities.rst
+++ b/doc/components/job-priorities.rst
@@ -173,14 +173,14 @@ different priorities:
 .. math::
     P_{job\_C} = (0.5 \times 100000)
       + (0 \times 10000)
-      + (300 \times -5)
+      + (-5 \times 10)
       + (1000 \times (16 - 16))
 
 .. math::
-    P_{job\_C} = 50000 + 0 - 1500 + 0
+    P_{job\_C} = 50000 + 0 - 50 + 0
 
 .. math::
-    P_{job\_C} = 48500
+    P_{job\_C} = 49950
 
 The same principle can be configured to queues, resulting in a multivariate
 equation that considers multiple factors when calculating the priority for a


### PR DESCRIPTION
#### Problem

The example job priority calculation that factors in a bank priority is partially incorrect. The priority for `P_job_C` uses the bank factor for bank A when it should be using its own bank factor for bank C.

---

This PR just fixes the example to use the right factor and weight when showing how the priority for a job submitted under bank C is calculated.