### PR TITLE
priority-update: add max_sched_jobs field

### DIFF
--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -186,6 +186,7 @@ def send_instance_owner_info():
         "def_project": "*",
         "max_nodes": 1000000,
         "max_cores": 1000000,
+        "max_sched_jobs": fluxacct.accounting.INTEGER_MAX,
     }
 
     flux.Flux().rpc(


### PR DESCRIPTION
#### Problem

The instance owner data that is constructed and sent over in `flux-account-priority-update.py` does not include the `max_sched_jobs` property, which results in an error being logged by the job manager when it cannot find the `max_sched_jobs` property in the JSON payload:

```console
job-manager.err[0]: mf_priority unpack: Object item not found: max_sched_jobs
```

---

This PR just adds the `max_sched_jobs` attribute to the JSON payload that contains instance owner data.

Fixes #822