### PR TITLE
`view-job-records`: change default job ID format to f58

### DIFF
--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -362,6 +362,14 @@ class JobsFormatter(flux.util.OutputFormat):
         "requested_duration": "requested_duration",
         "actual_duration": "actual_duration",
         "duration_delta": "duration_delta",
+        "jobid.dec": "jobid.dec",
+        "jobid.hex": "jobid.hex",
+        "jobid.dothex": "jobid.dothex",
+        "jobid.kvs": "jobid.kvs",
+        "jobid.words": "jobid.words",
+        "jobid.emoji": "jobid.emoji",
+        "jobid.f58plain": "jobid.f58plain",
+        "jobid.f58": "jobid.f58",
     }
 
     def __init__(self, fmt, headings=None):

--- a/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
@@ -73,7 +73,7 @@ def convert_to_str(job_records, fmt_string=None):
         fmt_string = (
             "{jobid:<15} | {username:<8} | {userid:<8} | {t_submit:<15.2f} | "
             + "{t_run:<15.2f} | {t_inactive:<15.2f} | {nnodes:<8} | {project:<8} | "
-            + "{bank:<8} | {requested_duration:<18.2f} | {actual_duration:<15.2f} "
+            + "{bank:<8} | {requested_duration:<18.2f} | {actual_duration:<15.2f} | "
             + "{duration_delta:<18.2f}"
         )
     output = fmt.JobsFormatter(fmt_string)

--- a/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
@@ -36,10 +36,11 @@ class JobRecord:
         bank,
         requested_duration,
         actual_duration,
+        jobid_format="f58",
     ):
         self.userid = userid
         self.username = util.get_username(userid)
-        self.jobid = jobid
+        self.jobid = util.JobIDFormat(jobid, jobid_format=jobid_format)
         self.t_submit = t_submit
         self.t_run = t_run
         self.t_inactive = t_inactive
@@ -82,7 +83,7 @@ def convert_to_str(job_records, fmt_string=None):
     return job_record_str
 
 
-def convert_to_obj(rows):
+def convert_to_obj(rows, jobid_format="f58"):
     """
     Convert the results of a query to the jobs table to a list of JobRecord
     objects.
@@ -110,6 +111,7 @@ def convert_to_obj(rows):
             bank=row[9] if row[9] is not None else "",
             requested_duration=row[10],
             actual_duration=row[11],
+            jobid_format=jobid_format,
         )
         job_records.append(job_record)
 
@@ -308,9 +310,9 @@ def get_jobs(conn, **kwargs):
     return job_records
 
 
-def view_jobs(conn, fields, **kwargs):
+def view_jobs(conn, fields, jobid_format="f58", **kwargs):
     # look up jobs in jobs table
-    job_records = convert_to_obj(get_jobs(conn, **kwargs))
+    job_records = convert_to_obj(get_jobs(conn, **kwargs), jobid_format=jobid_format)
     # convert query result to a readable string
     job_records_str = convert_to_str(job_records, fields)
 

--- a/src/bindings/python/fluxacct/accounting/util.py
+++ b/src/bindings/python/fluxacct/accounting/util.py
@@ -16,6 +16,7 @@ import contextlib
 
 from flux.constants import FLUX_USERID_UNKNOWN
 from flux.util import parse_datetime
+from flux.job.JobID import JobID
 import fluxacct.accounting
 
 
@@ -146,3 +147,23 @@ def update_parent_bank_usage(conn, bank):
 
     # recursively update the parent's parent
     update_parent_bank_usage(conn, parent_bank)
+
+
+class JobIDFormat:
+    """
+    Wrapper around flux.job.JobID that allows for the specification of a specific format
+    for the jobid field.
+    """
+
+    def __init__(self, jobid, jobid_format="f58"):
+        self._jobid = JobID(jobid)
+        self.jobid_format = (jobid_format or "f58").lower()
+
+    def __getattr__(self, name):
+        return getattr(self._jobid, name)
+
+    def __str__(self):
+        return getattr(self._jobid, self.jobid_format)
+
+    def __format__(self, spec):
+        return format(str(self), spec)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -83,6 +83,7 @@ TESTSCRIPTS = \
 	t1078-mf-priority-sched-dependencies.t \
 	t1079-issue809.t \
 	t1080-clear-usage.t \
+	t1081-view-job-records-jobid-formats.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1069-duration-delta.t
+++ b/t/t1069-duration-delta.t
@@ -117,7 +117,7 @@ test_expect_success 'edit actual duration of test jobs' '
 
 test_expect_success 'view jobs with duration_delta' '
 	flux account view-job-records \
-		-o "{jobid:<20} | {duration_delta:<18}" > duration_delta.out &&
+		-o "{jobid.dec:<20} | {duration_delta:<18}" > duration_delta.out &&
 	grep ${job1} duration_delta.out | grep "55.0" &&
 	grep ${job2} duration_delta.out | grep "55.0"  &&
 	grep ${job3} duration_delta.out | grep "40.0"  &&
@@ -127,7 +127,7 @@ test_expect_success 'view jobs with duration_delta' '
 
 test_expect_success 'filter for jobs with a duration_delta < 10 seconds' '
 	flux account view-job-records \
-		-D "< 10" -o "{jobid:<20}" > delta_lt_10_seconds.out &&
+		-D "< 10" -o "{jobid.dec:<20}" > delta_lt_10_seconds.out &&
 	test_must_fail grep ${job1} delta_lt_10_seconds.out &&
 	test_must_fail grep ${job2} delta_lt_10_seconds.out &&
 	test_must_fail grep ${job3} delta_lt_10_seconds.out &&
@@ -137,7 +137,7 @@ test_expect_success 'filter for jobs with a duration_delta < 10 seconds' '
 
 test_expect_success 'filter for jobs with a duration_delta >= 1 second' '
 	flux account view-job-records \
-		-D ">= 1" -o "{jobid:<20}" > delta_ge_1_seconds.out &&
+		-D ">= 1" -o "{jobid.dec:<20}" > delta_ge_1_seconds.out &&
 	grep ${job1} delta_ge_1_seconds.out &&
 	grep ${job2} delta_ge_1_seconds.out &&
 	grep ${job3} delta_ge_1_seconds.out &&
@@ -147,7 +147,7 @@ test_expect_success 'filter for jobs with a duration_delta >= 1 second' '
 
 test_expect_success 'filter for jobs with a duration_delta > 10 and < 55 seconds' '
 	flux account view-job-records \
-		-D "> 10" "< 55" -o "{jobid:<20}" > delta_multiple_filters.out &&
+		-D "> 10" "< 55" -o "{jobid.dec:<20}" > delta_multiple_filters.out &&
 	test_must_fail grep ${job1} delta_multiple_filters.out &&
 	test_must_fail grep ${job2} delta_multiple_filters.out &&
 	grep ${job3} delta_multiple_filters.out &&

--- a/t/t1081-view-job-records-jobid-formats.t
+++ b/t/t1081-view-job-records-jobid-formats.t
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+test_description='test viewing jobs with different ID formats'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -Slog-stderr-level=1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association' '
+	flux account add-user --username=user1 --userid=50001 --bank=A
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job' '
+	jobid=$(flux python ${SUBMIT_AS} 50001 hostname) &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux cancel ${jobid}
+'
+
+test_expect_success 'run fetch-job-records script' '
+	flux account-fetch-job-records -p ${DB_PATH}
+'
+
+test_expect_success 'call view-job-records with bad format raises error' '
+	test_must_fail flux account view-job-records --format="{jobid.foo}" > bad_arg.err 2>&1 &&
+	grep "ValueError: Unknown format field: jobid.foo" bad_arg.err
+'
+
+test_expect_success 'view-job-records by default will display jobID format in f58' '
+	flux account view-job-records > jobid_default.out &&
+	grep ${jobid} jobid_default.out
+'
+
+test_expect_success 'jobID is displayed in f58 by default in custom format' '
+	flux account view-job-records \
+		--format="{jobid:<20} | {nnodes:<8}" > jobid_custom_format.out &&
+	grep ${jobid} jobid_custom_format.out
+'
+
+test_expect_success 'jobid.dec can be specified in --format' '
+	flux account view-job-records \
+		--format="{jobid.dec:<20} | {nnodes:<8}" > jobid_dec_custom_format.out &&
+	grep $(flux job id --to=dec ${jobid}) jobid_dec_custom_format.out
+'
+
+test_expect_success 'jobid.hex can be specified in --format' '
+	flux account view-job-records \
+		--format="{jobid.hex:<20} | {nnodes:<8}" > jobid_hex_custom_format.out &&
+	grep $(flux job id --to=hex ${jobid}) jobid_hex_custom_format.out
+'
+
+test_expect_success 'jobid.dothex can be specified in --format' '
+	flux account view-job-records \
+		--format="{jobid.dothex:<20} | {nnodes:<8}" > jobid_dothex_custom_format.out &&
+	grep $(flux job id --to=dothex ${jobid}) jobid_dothex_custom_format.out
+'
+
+test_expect_success 'jobid.kvs can be specified in --format' '
+	flux account view-job-records \
+		--format="{jobid.kvs:<20} | {nnodes:<8}" > jobid_kvs_custom_format.out &&
+	grep $(flux job id --to=kvs ${jobid}) jobid_kvs_custom_format.out
+'
+
+test_expect_success 'jobid.words can be specified in --format' '
+	flux account view-job-records \
+		--format="{jobid.words:<20} | {nnodes:<8}" > jobid_words_custom_format.out &&
+	grep $(flux job id --to=words ${jobid}) jobid_words_custom_format.out
+'
+
+test_expect_success 'jobid.f58plain can be specified in --format' '
+	flux account view-job-records \
+		--format="{jobid.f58plain:<20} | {nnodes:<8}" > jobid_f58plain_custom_format.out &&
+	grep $(flux job id --to=f58plain ${jobid}) jobid_f58plain_custom_format.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The `view-job-records` command displays job IDs in decimal format instead of f58 format, which is what the rest of the Flux command suite uses. It would be more consistent for this command to follow the same format as other job-related Flux commands.

---

This PR changes the default job ID format for the `view-job-records` command to be in [f58](https://github.com/flux-framework/rfc/blob/master/spec_19.rst) format. It uses flux-core's `JobID` class to convert the decimal version of the job ID (which is how it is stored in the `jobs` table in the flux-accounting DB) to any of the available formats provided by the class.

It adds an optional argument to the view-job-records command called `--jobid-format`, which will allow the user to specify a number of allowed job ID formats when displaying job records.

A new set of tests are added that specify the `--jobid-format` optional argument in a mixture of both default and custom formatting for the `view-job-records` command.

I've also snuck in a commit to add a missing `|` between two fields in the header for `view-job-records`.