### PR TITLE
ci: upgrade actions version to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: validate commits
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -18,7 +18,7 @@ jobs:
   spelling:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Check Spelling
       uses: crate-ci/typos@v1.35.5
 
@@ -26,12 +26,12 @@ jobs:
     name: python format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -48,10 +48,10 @@ jobs:
     name: python lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -67,7 +67,7 @@ jobs:
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
     name: ${{matrix.name}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0


### PR DESCRIPTION
#### Problem

Node20 will reach end-of-life in [April 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), but many of the actions in flux-accounting still reference this soon-to-be deprecated version in CI.

---

This PR just upgrades the `checkout` actions to `v5` and upgrades the `setup-python` actions to `v6`.