### PR TITLE
edit-factor: add the possibility to edit the urgency weight

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -2,7 +2,7 @@ DB_DIR = "@X_LOCALSTATEDIR@/lib/flux/"
 DB_PATH = "@X_LOCALSTATEDIR@/lib/flux/FluxAccounting.db"
 DB_SCHEMA_VERSION = 32
 
-PRIORITY_FACTORS = ["fairshare", "queue", "bank"]
+PRIORITY_FACTORS = ["fairshare", "queue", "bank", "urgency"]
 FSHARE_WEIGHT_DEFAULT = 100000
 QUEUE_WEIGHT_DEFAULT = 10000
 BANK_WEIGHT_DEFAULT = 0

--- a/t/python/t1011_priorities.py
+++ b/t/python/t1011_priorities.py
@@ -59,6 +59,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertIn("fairshare | 999", test)
         self.assertIn("queue     | 10000", test)
         self.assertIn("bank      | 0", test)
+        self.assertIn("urgency   | 1000", test)
 
     # list all of the factors in the table in JSON format
     def test_06_list_factors_json(self):
@@ -69,6 +70,8 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertIn('"weight": 10000', test)
         self.assertIn('"factor": "bank"', test)
         self.assertIn('"weight": 0', test)
+        self.assertIn('"factor": "urgency"', test)
+        self.assertIn('"weight": 1000', test)
 
     # list all of the factors in the table with no weight
     def test_07_list_factors_custom(self):
@@ -80,7 +83,7 @@ class TestAccountingCLI(unittest.TestCase):
         bank     
         fairshare
         queue    
-        urgency
+        urgency  
         """
         )
         self.assertEqual(expected.strip(), test.strip())

--- a/t/t1054-mf-priority-bank-priorities.t
+++ b/t/t1054-mf-priority-bank-priorities.t
@@ -65,6 +65,7 @@ test_expect_success 'make "bank" the only factor in priority calculation' '
 	flux account edit-factor --factor=fairshare --weight=0 &&
 	flux account edit-factor --factor=queue --weight=0 &&
 	flux account edit-factor --factor=bank --weight=100 &&
+	flux account edit-factor --factor=urgency --weight=0 &&
 	flux account-priority-update -p ${DB_PATH}
 '
 

--- a/t/t1055-flux-account-priorities.t
+++ b/t/t1055-flux-account-priorities.t
@@ -71,7 +71,8 @@ test_expect_success 'list all of the priority factors' '
 	flux account list-factors > list_factors.default &&
 	grep "fairshare | 999" list_factors.default &&
 	grep "queue     | 10000" list_factors.default &&
-	grep "bank      | 0" list_factors.default
+	grep "bank      | 0" list_factors.default &&
+	grep "urgency   | 1000" list_factors.default
 '
 
 test_expect_success 'list all of the priority factors in JSON format' '
@@ -82,14 +83,18 @@ test_expect_success 'list all of the priority factors in JSON format' '
 	grep "\"weight\": 10000" list_factors.json &&
 	grep "\"factor\": \"bank\"" list_factors.json &&
 	grep "\"weight\": 0" list_factors.json
+	grep "\"factor\": \"urgency\"" list_factors.json &&
+	grep "\"weight\": 1000" list_factors.json
 '
 
-test_expect_success 'edit the other two factors to have non-default weights' '
+test_expect_success 'edit the other three factors to have non-default weights' '
 	flux account edit-factor --factor=queue --weight=50 &&
 	flux account edit-factor --factor=bank --weight=1 &&
+	flux account edit-factor --factor=urgency --weight=250 &&
 	flux account list-factors --json > list_factors_edited.json &&
 	grep "\"weight\": 50" list_factors_edited.json &&
-	grep "\"weight\": 1" list_factors_edited.json
+	grep "\"weight\": 1" list_factors_edited.json &&
+	grep "\"weight\": 250" list_factors_edited.json
 '
 
 test_expect_success 'reset the priority factors and their weights' '
@@ -97,7 +102,8 @@ test_expect_success 'reset the priority factors and their weights' '
 	flux account list-factors > list_factors.reset &&
 	grep "fairshare | 100000" list_factors.reset &&
 	grep "queue     | 10000" list_factors.reset &&
-	grep "bank      | 0" list_factors.reset
+	grep "bank      | 0" list_factors.reset &&
+	grep "urgency   | 1000" list_factors.reset
 '
 
 test_expect_success 'shut down flux-accounting service' '


### PR DESCRIPTION
Hi,

**The problem**

I noticed that the `urgency` factor was not mentioned in the list of `PRIORITY_FACTORS` in `__init__.py.in` file: 
https://github.com/flux-framework/flux-accounting/blob/4c730acbc1fc3531f2712269dba86bbb8a4bcaf3/src/bindings/python/fluxacct/accounting/__init__.py.in#L5

This caused the command `flux account edit-factor --factor urgency --weight ...` to not work, as it was not in the `PRIORITY_FACTORS` list:
https://github.com/flux-framework/flux-accounting/blob/4c730acbc1fc3531f2712269dba86bbb8a4bcaf3/src/bindings/python/fluxacct/accounting/priorities.py#L264

**Changes**
- included `urgency` in the list of `PRIORITY_FACTORS`
- updated existing tests to include the  `urgency` information when it was missing