### PR TITLE
edit-bank: fix `ValueError` message when trying to edit a bank's shares to `<= 0`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -291,7 +291,7 @@ def edit_bank(
                     raise sqlite3.OperationalError(exc)
             if field == "shares":
                 if int(shares) <= 0:
-                    raise ValueError("new shares amount must be >= 0")
+                    raise ValueError("new shares amount must be > 0")
 
             update_stmt = "UPDATE bank_table SET " + field
 

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -97,7 +97,7 @@ test_expect_success 'edit a field in a bank account' '
 
 test_expect_success 'try to edit a field in a bank account with a bad value' '
 	test_must_fail flux account edit-bank C --shares=-1000 > bad_edited_value.out 2>&1 &&
-	grep "new shares amount must be >= 0" bad_edited_value.out
+	grep "new shares amount must be > 0" bad_edited_value.out
 '
 
 test_expect_success 'remove a bank (and any corresponding users that belong to that bank)' '


### PR DESCRIPTION
##### Problem

The `ValueError` message that is returned when a shares value of less than or equal to 0 is passed is incorrect; it should specify that the new shares value must be greater than 0, not greater than or equal to 0.

---

This PR just corrects the error message to specify that the new shares value must be greater than 0.

It also updates one of the tests in `t1023-flux-account-banks.t` that `grep`s for this error message as a result of the message changing.