### PR TITLE
docker: add `noble` Dockerfile to CI

### DIFF
--- a/src/test/docker/noble/Dockerfile
+++ b/src/test/docker/noble/Dockerfile
@@ -1,0 +1,21 @@
+FROM fluxrm/flux-core:noble
+
+ARG USER=flux
+ARG UID=1000
+
+# Install necessary tools
+USER root
+RUN apt-get update && \
+    apt-get install -y sudo passwd
+
+# add configured user to image with sudo access:
+RUN \
+ if test "$USER" != "flux"; then  \
+      groupadd -g $UID $USER \
+    && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+    && sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+    && sudo adduser $USER sudo ; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -162,6 +162,13 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# noble
+matrix.add_build(
+    name="noble",
+    image="noble",
+    docker_tag=True,
+)
+
 # Ubuntu: gcc-8, distcheck
 matrix.add_build(
     name="el8 - distcheck",


### PR DESCRIPTION
#### Problem

flux-accounting does not have a `noble` Docker image, which is useful for testing things like the bindings against Python 3.12.

---

This PR adds a `noble` Dockerfile to the repository and adds it to the matrix of builders that run during CI.