### PR TITLE
t: add valgrind suppression

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -142,3 +142,20 @@
    fun:uuid_generate*
    ...
 }
+{
+   <libhwloc_topology_load_leak>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:*alloc
+   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2
+   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2
+   fun:hwloc_topology_load
+   fun:init_topo_from_xml
+   fun:rhwloc_xml_topology_load
+   fun:rlist_from_hwloc
+   fun:topo_create
+   fun:mod_main
+   fun:module_thread
+   fun:start_thread
+   fun:clone
+}


### PR DESCRIPTION
#### Problem

We get occasional failures in CI from the valgrind test:

```
  ==33999== HEAP SUMMARY:
  ==33999==     in use at exit: 44,563 bytes in 112 blocks
  ==33999==   total heap usage: 54,135 allocs, 54,023 frees, 70,432,846 bytes allocated
  ==33999==
  ==33999== 147 (128 direct, 19 indirect) bytes in 1 blocks are definitely lost in loss record 7 of 16
  ==33999==    at 0x48487A9: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
  ==33999==    by 0x15F55FBF: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2)
  ==33999==    by 0x15F764CE: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2)
  ==33999==    by 0x15F5F6A4: hwloc_topology_load (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2)
  ==33999==    by 0x15F2CA03: init_topo_from_xml (rhwloc.c:75)
  ==33999==    by 0x15F2CA03: rhwloc_xml_topology_load (rhwloc.c:109)
  ==33999==    by 0x15F2D159: rlist_from_hwloc (rhwloc.c:348)
  ==33999==    by 0x15F245B9: topo_create (topo.c:319)
  ==33999==    by 0x15F231DF: mod_main (resource.c:486)
  ==33999==    by 0x11D0FA: module_thread (module_thread.c:142)
  ==33999==    by 0x4A62AC2: start_thread (pthread_create.c:442)
  ==33999==    by 0x4AF3A03: clone (clone.S:100)
  ==33999==
  {
     <insert_a_suppression_name_here>
     Memcheck:Leak
     match-leak-kinds: definite
     fun:malloc
     obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2
     obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2
     fun:hwloc_topology_load
     fun:init_topo_from_xml
     fun:rhwloc_xml_topology_load
     fun:rlist_from_hwloc
     fun:topo_create
     fun:mod_main
     fun:module_thread
     fun:start_thread
     fun:clone
  }
```

This PR just amends `valgrind.supp` to match the listed calls above.