### PR TITLE
.github: update tarball release GitHub actions version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
         && matrix.create_release
         && github.repository == 'flux-framework/flux-accounting'
       env: ${{matrix.env}}
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2.6.1
       with:
         tag_name: ${{ matrix.tag }}
         name: flux-accounting ${{ matrix.tag }}


### PR DESCRIPTION
#### Problem

The action that creates a tarball for flux-accounting uses a very old version of `softprops/action-gh-release`.

---

This PR just updates the version.