### PR TITLE
valgrind.supp: generalize suppression for mem leak

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -147,8 +147,8 @@
    Memcheck:Leak
    match-leak-kinds: definite
    fun:*alloc
-   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2
-   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.5.2
+   obj:*libhwloc.so.15.*
+   obj:*libhwloc.so.15.*
    fun:hwloc_topology_load
    fun:init_topo_from_xml
    fun:rhwloc_xml_topology_load


### PR DESCRIPTION
#### Problem

The suppression that was just added in #833 is too specific with the `obj` key by specifying a certain minor version of `libhwloc`.

---

This PR just generalizes the `libhwloc` version a little bit by adding a wildcard for the minor version of `libhwloc` as well as the path to the library.