### PR TITLE
doc: add link to HPSF presentation

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -108,6 +108,7 @@ EXTRA_DIST = \
 	components/limits.rst \
 	components/job-priorities.rst \
 	components/module-structure.rst \
+	presentations/hpsf.rst \
 	$(RST_FILES) \
 	man1/index.rst
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,4 +21,5 @@ Table of Contents
    components/projects
    components/limits
    components/job-priorities
+   presentations/hpsf
    index_man

--- a/doc/presentations/hpsf.rst
+++ b/doc/presentations/hpsf.rst
@@ -1,0 +1,14 @@
+.. _hpsf:
+
+################################################
+High Performance Software Foundation (HPSF) 2026
+################################################
+
+.. raw:: html
+
+   <iframe width="560" height="315"
+   src="https://www.youtube.com/embed/5YZpgJk1CZc?si=JEOYrf74Lq6VXYVA"
+   title="YouTube video player" frameborder="0"
+   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+   referrerpolicy="strict-origin-when-cross-origin" allowfullscreen>
+   </iframe>


### PR DESCRIPTION
#### Problem

It would be nice if the flux-accounting documentation included a link to the HPSF presentation.

---

This PR just adds a new page to the ReadTheDocs site that includes a link to the flux-accounting presentation given at the HPSF conference.