### PR TITLE
plugin: add limit of max number of jobs in SCHED state per-queue

### DIFF
--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -164,6 +164,7 @@ def export_as_json(conn, cursor):
             "priority": int(row["priority"]),
             "max_running_jobs": int(row["max_running_jobs"]),
             "max_nodes_per_assoc": int(row["max_nodes_per_assoc"]),
+            "max_sched_jobs": int(row["max_sched_jobs"]),
         }
         queues.append(queue)
 

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -114,6 +114,7 @@ def bulk_update(path):
             "priority": int(row["priority"]),
             "max_running_jobs": int(row["max_running_jobs"]),
             "max_nodes_per_assoc": int(row["max_nodes_per_assoc"]),
+            "max_sched_jobs": int(row["max_sched_jobs"]),
         }
         bulk_q_data.append(single_q_data)
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -492,8 +492,8 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
                  std::string *errmsg)
 {
     char *queue = NULL;
-    int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority = 0;
-    int max_running_jobs, max_nodes_per_assoc, max_sched_jobs = 0;
+    int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority;
+    int max_running_jobs, max_nodes_per_assoc, max_sched_jobs;
     json_error_t error;
     int num_data = 0;
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -360,6 +360,18 @@ bool Association::under_max_sched_jobs ()
     return cur_sched_jobs < max_sched_jobs;
 }
 
+bool Association::under_queue_max_sched_jobs (
+                                const std::string &queue,
+                                std::map<std::string, Queue> &queues)
+{
+    auto qit = queues.find (queue);
+    if (qit == queues.end ())
+        // queue is unknown to flux-accounting; skip check
+        return true;
+
+    return queue_usage[queue].cur_sched_jobs < queues[queue].max_sched_jobs;
+}
+
 json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
 {
     json_t *root = json_object ();

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -76,9 +76,10 @@ json_t* Association::to_json () const
         goto error;
     for (const auto &entry : queue_usage) {
         const QueueUsage &usage = entry.second;
-        usage_object = json_pack ("{s:i, s:i}",
+        usage_object = json_pack ("{s:i, s:i, s:i}",
                                   "cur_run_jobs", usage.cur_run_jobs,
-                                  "cur_nodes", usage.cur_nodes);
+                                  "cur_nodes", usage.cur_nodes,
+                                  "cur_sched_jobs", usage.cur_sched_jobs);
         if (!usage_object)
             goto error;
 
@@ -370,14 +371,15 @@ json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
         const Queue &q = kv.second;
 
         json_t *qobj = json_pack (
-                                "{s:s, s:i, s:i, s:i, s:i, s:i, s:i}",
+                                "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
                                 "name", q.name.c_str (),
                                 "min_nodes_per_job", q.min_nodes_per_job,
                                 "max_nodes_per_job", q.max_nodes_per_job,
                                 "max_time_per_job", q.max_time_per_job,
                                 "priority", q.priority,
                                 "max_running_jobs", q.max_running_jobs,
-                                "max_nodes_per_assoc", q.max_nodes_per_assoc);
+                                "max_nodes_per_assoc", q.max_nodes_per_assoc,
+                                "max_sched_jobs", q.max_sched_jobs);
         if (!qobj) {
             json_decref (root);
             return nullptr;
@@ -491,7 +493,7 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
 {
     char *queue = NULL;
     int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority = 0;
-    int max_running_jobs, max_nodes_per_assoc = 0;
+    int max_running_jobs, max_nodes_per_assoc, max_sched_jobs = 0;
     json_error_t error;
     int num_data = 0;
 
@@ -509,14 +511,15 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
         json_t *el = json_array_get(data, i);
 
         if (json_unpack_ex (el, &error, 0,
-                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i}",
+                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
                             "queue", &queue,
                             "min_nodes_per_job", &min_nodes_per_job,
                             "max_nodes_per_job", &max_nodes_per_job,
                             "max_time_per_job", &max_time_per_job,
                             "priority", &priority,
                             "max_running_jobs", &max_running_jobs,
-                            "max_nodes_per_assoc", &max_nodes_per_assoc) < 0) {
+                            "max_nodes_per_assoc", &max_nodes_per_assoc,
+                            "max_sched_jobs", &max_sched_jobs) < 0) {
             if (errmsg)
                 *errmsg = error.text;
             return -1;
@@ -532,6 +535,7 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
         q->priority = priority;
         q->max_running_jobs = max_running_jobs;
         q->max_nodes_per_assoc = max_nodes_per_assoc;
+        q->max_sched_jobs = max_sched_jobs;
     }
 
     return 0;

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -53,6 +53,7 @@ extern "C" {
 #define D_ASSOC_MRES "max-resources-user-limit"
 #define D_QUEUE_MRES "max-resources-queue"
 #define D_ASSOC_MSJ  "max-sched-jobs-user-limit"
+#define D_QUEUE_MSJ  "max-sched-jobs-queue-limit"
 
 // error messages for flux-accounting-specific validation messages
 #define MSG_INVALID_QUEUE \
@@ -84,8 +85,9 @@ public:
 // a class to track an association's usage in a particular queue
 class QueueUsage {
 public:
-    int cur_run_jobs = 0; // number of running jobs in queue
-    int cur_nodes = 0;    // number of nodes across all running jobs in queue
+    int cur_run_jobs = 0;   // number of running jobs in queue
+    int cur_nodes = 0;      // number of nodes across all running jobs in queue
+    int cur_sched_jobs = 0; // number of jobs in SCHED state in queue
 };
 
 // all attributes are per-user/bank
@@ -127,6 +129,8 @@ public:
                                   const std::string &queue,
                                   const std::map<std::string, Queue> &queues);
     bool under_max_sched_jobs ();
+    bool under_queue_max_sched_jobs (const std::string &queue,
+                                     std::map<std::string, Queue> &queues);
 };
 
 class Bank {

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -78,6 +78,7 @@ public:
     int priority = 0;
     int max_running_jobs = std::numeric_limits<int>::max ();
     int max_nodes_per_assoc = 2147483647;
+    int max_sched_jobs = 2147483647;
 };
 
 // a class to track an association's usage in a particular queue

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -317,6 +317,19 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
             }
             held_job.remove_dep (D_QUEUE_MRJ);
         }
+        // is association under the max SCHED jobs limit for the queue the
+        // held job is submitted under?
+        if (b->under_queue_max_sched_jobs (held_job.queue, queues) &&
+            held_job.contains_dep (D_QUEUE_MSJ)) {
+            if (flux_jobtap_dependency_remove (p,
+                                               held_job.id,
+                                               D_QUEUE_MSJ) < 0) {
+                dependency = D_QUEUE_MSJ;
+                held_job_id = held_job.id;
+                goto error;
+            }
+            held_job.remove_dep (D_QUEUE_MSJ);
+        }
         // is the association under the max nodes limit for the queue the
         // held job is submitted under?
         if (b->under_queue_max_resources (held_job, held_job.queue, queues) &&
@@ -1253,6 +1266,7 @@ static int new_cb (flux_plugin_t *p,
         // this job was in SCHED state; increment the association's sched
         // jobs count
         b->cur_sched_jobs++;
+        b->queue_usage[queue_str].cur_sched_jobs++;
     }
 
     return 0;
@@ -1329,6 +1343,13 @@ static int depend_cb (flux_plugin_t *p,
                 goto error;
             job.add_dep (D_QUEUE_MRJ);
         }
+        if (!b->under_queue_max_sched_jobs (queue_str, queues)) {
+            // association is already at their max sched jobs limit in
+            // this queue; add a dependency
+            if (flux_jobtap_dependency_add (p, id, D_QUEUE_MSJ) < 0)
+                goto error;
+            job.add_dep (D_QUEUE_MSJ);
+        }
         if (!b->under_queue_max_resources (job, queue_str, queues)) {
             // association is already at their max nodes limit across their
             // running jobs in this queue; add a dependency
@@ -1387,6 +1408,22 @@ static int sched_cb (flux_plugin_t *p,
                      void *data)
 {
     Association *a;
+    char *queue = NULL;
+
+    flux_t *h = flux_jobtap_get_flux (p);
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s{s{s{s?s}}}}",
+                                "jobspec", "attributes", "system",
+                                "queue", &queue) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority",
+                                     0,
+                                     "job.state.sched: failed to unpack " \
+                                     "queue from jobspec");
+        return -1;
+    }
 
     a = static_cast<Association *>
         (flux_jobtap_job_aux_get (p,
@@ -1404,6 +1441,8 @@ static int sched_cb (flux_plugin_t *p,
 
     // increment association's current SCHED jobs count
     a->cur_sched_jobs++;
+    std::string queue_str = queue ? queue : "";
+    a->queue_usage[queue_str].cur_sched_jobs++;
 
     return 0;
 }
@@ -1478,6 +1517,8 @@ static int run_cb (flux_plugin_t *p,
 
     // decrement the association's current SCHED jobs count
     b->cur_sched_jobs--;
+    queue_str = queue ? queue : "";
+    b->queue_usage[queue_str].cur_sched_jobs--;
     // check to see if any jobs held due to max_sched_jobs limit can now
     // have their dependency removed
     if (!b->held_jobs.empty ()) {

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -620,7 +620,7 @@ static void rec_q_cb (flux_t *h,
 {
     char *queue = NULL;
     int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority = 0;
-    int max_running_jobs, max_nodes_per_assoc = 0;
+    int max_running_jobs, max_nodes_per_assoc, max_sched_jobs = 0;
     json_t *data, *jtemp = NULL;
     json_error_t error;
     int num_data = 0;
@@ -643,14 +643,15 @@ static void rec_q_cb (flux_t *h,
         json_t *el = json_array_get(data, i);
 
         if (json_unpack_ex (el, &error, 0,
-                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i}",
+                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
                             "queue", &queue,
                             "min_nodes_per_job", &min_nodes_per_job,
                             "max_nodes_per_job", &max_nodes_per_job,
                             "max_time_per_job", &max_time_per_job,
                             "priority", &priority,
                             "max_running_jobs", &max_running_jobs,
-                            "max_nodes_per_assoc", &max_nodes_per_assoc) < 0)
+                            "max_nodes_per_assoc", &max_nodes_per_assoc,
+                            "max_sched_jobs", &max_sched_jobs) < 0)
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
 
         Queue *q;
@@ -663,6 +664,7 @@ static void rec_q_cb (flux_t *h,
         q->priority = priority;
         q->max_running_jobs = max_running_jobs;
         q->max_nodes_per_assoc = max_nodes_per_assoc;
+        q->max_sched_jobs = max_sched_jobs;
     }
 
     if (flux_respond (h, msg, NULL) < 0)

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -619,8 +619,8 @@ static void rec_q_cb (flux_t *h,
                       void *arg)
 {
     char *queue = NULL;
-    int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority = 0;
-    int max_running_jobs, max_nodes_per_assoc, max_sched_jobs = 0;
+    int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority;
+    int max_running_jobs, max_nodes_per_assoc, max_sched_jobs;
     json_t *data, *jtemp = NULL;
     json_error_t error;
     int num_data = 0;

--- a/src/plugins/test/queue_limits_test05.cpp
+++ b/src/plugins/test/queue_limits_test05.cpp
@@ -139,6 +139,60 @@ void association_release_held_job_true ()
         "association has no more held jobs");
 }
 
+/*
+ * A Queue object's max_sched_jobs property can be set and configured.
+ */
+void set_queue_max_sched_jobs_limit ()
+{
+    queues["bronze"].max_sched_jobs = 1;
+    ok (queues["bronze"].max_sched_jobs == 1,
+        "bronze queue has a max_sched_jobs limit of 1");
+}
+
+/*
+ * If the queue being specified cannot be found, it will be initialized in the
+ * queues map with default properties, including max_sched_jobs.
+ */
+void association_under_queue_max_sched_jobs_default ()
+{
+    Association *a = &users[50001]["bank_A"];
+    ok (a->under_queue_max_sched_jobs ("foo", queues) == true,
+        "check returns true when queue cannot be found");
+
+    ok (queues["foo"].max_sched_jobs == 2147483647,
+        "queue initialized in queues map with max max_sched_jobs value");
+}
+
+/*
+ * If an association is under the queue's max_sched_jobs limit,
+ * under_queue_max_sched_jobs () will return true.
+ */
+void association_under_queue_max_sched_jobs_limit_true ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_active_jobs = 0;
+    a->cur_sched_jobs = 0;
+    a->queue_usage["bronze"].cur_sched_jobs = 0;
+
+    ok (a->under_queue_max_sched_jobs ("bronze", queues) == true,
+        "association is under max_sched_jobs limit");
+}
+
+/*
+ * If an association is *not* under the queue's max_sched_jobs limit,
+ * under_queue_max_sched_jobs () will return false.
+ */
+void association_under_queue_max_sched_jobs_limit_false ()
+{
+    Association *a = &users[50001]["bank_A"];
+    a->cur_active_jobs = 2;
+    a->cur_sched_jobs = 1;
+    a->queue_usage["bronze"].cur_sched_jobs = 1;
+
+    ok (a->under_queue_max_sched_jobs ("bronze", queues) == false,
+        "association is not under max_sched_jobs limit");
+}
+
 int main (int argc, char* argv[])
 {
     // add an association
@@ -150,6 +204,10 @@ int main (int argc, char* argv[])
     association_under_queue_max_nodes_limit_true ();
     association_under_queue_max_nodes_limit_false ();
     association_release_held_job_true ();
+    set_queue_max_sched_jobs_limit ();
+    association_under_queue_max_sched_jobs_limit_true ();
+    association_under_queue_max_sched_jobs_limit_false ();
+    association_under_queue_max_sched_jobs_default ();
 
     // indicate we are done testing
     done_testing ();

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -85,6 +85,7 @@ TESTSCRIPTS = \
 	t1080-clear-usage.t \
 	t1081-view-job-records-jobid-formats.t \
 	t1082-max-sched-jobs-queue-basic.t \
+	t1083-mf-priority-queue-sched-dependency.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1083-mf-priority-queue-sched-dependency.t
+++ b/t/t1083-mf-priority-queue-sched-dependency.t
@@ -1,0 +1,380 @@
+#!/bin/bash
+
+test_description='test limiting number of jobs in SCHED per-queue'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+# Setting max-sched-jobs to 1 means that the association can have up to 1 job
+# in SCHED state in the "pdebug" queue at any given time.
+test_expect_success 'add a queue to DB' '
+	flux account add-queue pdebug --max-sched-jobs=1
+'
+
+test_expect_success 'add banks to DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add associations to DB' '
+	flux account add-user \
+		--username=user1 \
+		--bank=A \
+		--userid=50001 \
+		--queues=pdebug \
+		--max-active-jobs=10000 \
+		--max-running-jobs=1000
+'
+
+test_expect_success 'load priority plugin' '
+	flux jobtap load -r .priority-default \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'configure flux with queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'queue is properly configured in plugin internal data structure' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".queues.pdebug.max_sched_jobs == 1" <query.json
+'
+
+# This job will proceed to RUN immediately but take up all current resources
+# of this instance, so any job submitted while this job is running will be
+# placed in SCHED state.
+test_expect_success 'first job proceeds to RUN immediately' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc
+'
+
+# Since the first job is currently running, this job is placed in SCHED state
+# until enough resources are freed up for this job to run.
+test_expect_success 'second job gets placed in SCHED state' '
+	job2=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority
+'
+
+# Since the association already has a job in SCHED state, this job has a
+# dependency placed on it.
+test_expect_success 'third submitted job has SCHED-state-related dependency' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-add
+'
+
+# When the first job gets cancelled, the second job can proceed to run because
+# enough resources are freed.
+test_expect_success 'second job receives alloc event' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job2} alloc
+'
+
+# When the second job proceeds to run, the job.state.run callback checks to see
+# if any other jobs held due to the max_sched_jobs limit can have their
+# dependency removed.
+test_expect_success 'third job has max-sched-jobs dependency removed' '
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-remove
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job2} ${job3}
+'
+
+# In this set of tests, we make sure that an association who has hit their max
+# SCHED jobs per-queue limit preserves this same limit after a plugin
+# reload.
+test_expect_success 'submit jobs to trigger max-run-jobs per-association limit' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority &&
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-add
+'
+
+test_expect_success 'reload plugin' '
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} \
+		"config=$(flux account export-json)"
+'
+
+test_expect_success 'total job counts for associations are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json
+'
+
+test_expect_success 'job counts for association in queue are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_run_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_sched_jobs == 1" <query.json
+'
+
+test_expect_success 'second job receives alloc event after first job goes inactive' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job2} alloc
+'
+
+test_expect_success 'third job has max-sched-jobs dependency removed' '
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-remove
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job2} ${job3}
+'
+
+# In this set of tests, we make sure that *both* the per-association and the
+# per-queue max SCHED jobs dependency are applied at the same time.
+test_expect_success 'edit association to have a max_sched_jobs limit of 1' '
+	flux account edit-user user1 --max-sched-jobs=1 &&
+	flux account-priority-update -p ${DB} &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].max_sched_jobs == 1" <query.json
+'
+
+test_expect_success 'first job proceeds to RUN immediately' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc
+'
+
+test_expect_success 'second job gets placed in SCHED state' '
+	job2=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority
+'
+
+test_expect_success 'third submitted job has both SCHED state-related dependencies' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job3} dependency-add
+'
+
+# When the first job gets cancelled, the second job can proceed to run because
+# enough resources are freed.
+test_expect_success 'second job receives alloc event' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job2} alloc
+'
+
+# When the second job proceeds to run, the job.state.run callback checks to see
+# if any other jobs held due to the max_sched_jobs limit can have their
+# dependency removed.
+test_expect_success 'third job has max-sched-jobs dependency removed' '
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-remove &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job3} dependency-remove
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job2} ${job3}
+'
+
+# In this set of tests, we make sure that with two queues, a job held in queue
+# A due to a max SCHED limit is not released when a job in B transitions to RUN
+# state.
+test_expect_success 'add another queue and give association access to that queue' '
+	flux account add-queue pbatch --max-sched-jobs=1 &&
+	flux account edit-user user1 --max-sched-jobs=-1 --queues=pdebug,pbatch &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'update flux with the new queue' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	[queues.pbatch]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'association hits max-sched-jobs limit in both queues' '
+	pdebug_job1=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${pdebug_job1} alloc &&
+	pbatch_job1=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pbatch sleep inf) &&
+	flux job wait-event -t 5 ${pbatch_job1} alloc &&
+	pdebug_job2=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${pdebug_job2} priority &&
+	pbatch_job2=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pbatch sleep inf) &&
+	flux job wait-event -t 5 ${pbatch_job2} priority &&
+	pdebug_job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${pdebug_job3} dependency-add &&
+	pbatch_job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pbatch sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${pbatch_job3} dependency-add
+'
+
+test_expect_success 'ensure job counts for association are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 6" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 2" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_run_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pbatch\"].cur_run_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_sched_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pbatch\"].cur_sched_jobs == 1" <query.json
+'
+
+test_expect_success 'job1 in pdebug is cancelled; job2 in pdebug can now run' '
+	flux cancel ${pdebug_job1} &&
+	flux job wait-event -t 5 ${pdebug_job2} alloc
+'
+
+test_expect_success 'held job in pbatch is still not released' '
+	pbatch_job3_dec=$(flux job id -t dec ${pbatch_job3}) &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 5" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${pbatch_job3_dec}\"].deps \
+			| length == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${pbatch_job3_dec}\"].deps[0] \
+			== \"max-sched-jobs-queue-limit\"" <query.json
+'
+
+test_expect_success 'job2 in pdebug cancelled; job2 in pbatch can run' '
+	flux cancel ${pdebug_job2} &&
+	flux job wait-event -t 5 ${pbatch_job2} alloc
+'
+
+test_expect_success 'dependency removed from job3 in pbatch now that job2 in pbatch runs' '
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${pbatch_job3} dependency-remove &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+test_expect_success 'cancel rest of jobs' '
+	flux cancel ${pdebug_job3} ${pbatch_job1} ${pbatch_job2} ${pbatch_job3}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The priority plugin does not enforce a limit on an association's job(s) if they have a certain number of jobs in SCHED state in a particular queue already.

---

This PR (built on top of #837) adds enforcement of a per-queue max SCHED jobs limit in the priority plugin. It adds a new property to the `QueueUsage` class to keep track of how many jobs in SCHED state an association has in a particular queue as well as a new method to the `Association` class to compare the association's number of jobs in SCHED state versus the queue's `max_sched_jobs` property. If the association is at the limit, the job is held with a dependency called `"max-sched-jobs-queue-limit"`.

The current number of jobs in SCHED state for a particular queue is incremented when a new job enters `job.state.sched` and is decremented when a job enters `job.state.run`. After decrementing the count in `job.state.run`, the association's set of held jobs (if any) is re-checked to see if any jobs held due to the `"max-sched-jobs-queue-limit"` can also be released.

Some basic tests are added to check the enforcement of the `"max-sched-jobs-queue-limit"` limit both with the plugin fully loaded and after a restart.