### PR TITLE
NEWS: add release notes for v0.57.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,45 @@
+flux-accounting version 0.57.0 - 2026-04-07
+-------------------------------------------
+
+#### Fixes
+
+* priority-update: add max_sched_jobs field (#823)
+
+* `view-job-records`: change default job ID format to f58 (#824)
+
+* edit-factor: add the possibility to edit the urgency weight (#828)
+
+* edit-bank: fix `ValueError` message when trying to edit a bank's shares to
+`<= 0` (#830)
+
+#### Features
+
+* database: add `max_sched_jobs` property for queues in flux-accounting DB
+(#837)
+
+* plugin: add limit of max number of jobs in SCHED state per-queue (#840)
+
+#### Documentation
+
+* doc: add link to HPSF presentation (#839)
+
+#### Testsuite
+
+* ci: upgrade actions to v5 (#826)
+
+* docker: add `noble` Dockerfile to CI (#832)
+
+* t: add valgrind suppression (#833)
+
+* .github: update tarball release GitHub actions version (#834)
+
+* valgrind.supp: generalize suppression for mem leak (#835)
+
+* t: just add entire `expected/` directory (#836)
+
+* t: use format string for comparing output in `t1043-view-jobs-by-bank.t` 
+(#841)
+
 flux-accounting version 0.56.0 - 2026-03-02
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.57.0.`

---

This PR just adds some release notes. It is waiting on the approval of #840. Once this lands, I'll create an annotated tag with the following:

```console
git tag -a v0.57.0 -m "Tag v0.57.0" && git push upstream v0.57.0
```