### PR TITLE
generate-matrix: change release builder from RHEL8 to RHEL9

### DIFF
--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -148,11 +148,15 @@ matrix.add_build(
     docker_tag=True,
 )
 
-# el9
+# el9, distcheck
 matrix.add_build(
-    name="el9 - py3.9",
+    name="el9 - py3.9,distcheck",
     image="el9",
     docker_tag=True,
+    args=" --localstatedir=/var",
+    env=dict(
+        DISTCHECK="t",
+    ),
 )
 
 # jammy
@@ -169,14 +173,11 @@ matrix.add_build(
     docker_tag=True,
 )
 
-# Ubuntu: gcc-8, distcheck
+# Ubuntu: gcc-8
 matrix.add_build(
-    name="el8 - distcheck",
+    name="el8",
     image="el8",
-    args=" --localstatedir=/var",
-    env=dict(
-        DISTCHECK="t",
-    ),
+    docker_tag=True,
 )
 
 print(matrix)


### PR DESCRIPTION
#### Problem

The builder that is responsible for creating a release tarball for flux-accounting is based off of RHEL8, which ships an extremely old version of `automake`, which subsequently fails when building TOSS packages because it is using a very old version of `py-compile` that tries to import a now deprecated Python module (`imp`).

---

Change the builder that is responsible for generating a release tarball from RHEL8 to RHEL9.