### PR TITLE
NEWS: add release notes for `v0.57.1`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+flux-accounting version 0.57.1 - 2026-04-08
+-------------------------------------------
+
+#### Testsuite
+
+* generate-matrix: change release builder from RHEL8 to RHEL9 (#844)
+
 flux-accounting version 0.57.0 - 2026-04-07
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.57.1`.

---

This PR adds some release notes. Once this lands, I'll create an annotated tag with the following:

```console
git tag -a v0.57.1 -m "Tag v0.57.1" && git push upstream v0.57.1
```