### PR TITLE
github: add dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "github: "
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
#### Problem

GitHub Actions are pinned to older versions and there is no automated process to keep them up to date.

---

This PR adds a `dependabot.yml` to automatically check for GitHub Actions updates monthly and group them into a single PR, matching the configuration in flux-core.