### PR TITLE
spelling: fix mistake, exclude `INSTALL` file from spellcheck

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,7 @@ extend-exclude = [
   "doc/test/spell.en.pws",
   "t/sharness",
   "t/t0000-sharness.t",
+  "INSTALL"
 ]
 
 [default.extend-words]

--- a/src/plugins/test/dependencies_test03.cpp
+++ b/src/plugins/test/dependencies_test03.cpp
@@ -161,7 +161,7 @@ void max_run_jobs_per_queue_and_per_association ()
     a->held_jobs.emplace_back (job);
 
     ok (a->held_jobs.size () == 1,
-        "asociation has one held job due to max-run-jobs per-association and "
+        "association has one held job due to max-run-jobs per-association and "
         "per-queue limits");
     ok (job.deps.size () == 2,
         "held job has max-run-jobs per-association and per-queue dependencies "


### PR DESCRIPTION
#### Problem

The typos checker in CI caught a spelling mistake for "association" in one of the unit tests and "Tru64" in the `INSTALL` file.

---

This PR fixes the "association" misspelling in `dependencies_test03.cpp` and adds the `INSTALL` file to the list of files ignored by the spellcheck action in CI.