### PR TITLE
plugin: clear internal data structures during initialization

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1864,6 +1864,13 @@ static const struct flux_plugin_handler tab[] = {
 
 extern "C" int flux_plugin_init (flux_plugin_t *p)
 {
+    // explicitly reset all global state of internal data structures
+    users.clear ();
+    queues.clear ();
+    banks.clear ();
+    users_def_bank.clear ();
+    projects.clear ();
+    priority_weights.clear ();
 
     json_t *config_obj = NULL;
     flux_t *h = flux_jobtap_get_flux (p);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -86,6 +86,7 @@ TESTSCRIPTS = \
 	t1081-view-job-records-jobid-formats.t \
 	t1082-max-sched-jobs-queue-basic.t \
 	t1083-mf-priority-queue-sched-dependency.t \
+	t1084-issue849.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1084-issue849.t
+++ b/t/t1084-issue849.t
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+test_description='make sure data stored in the plugin is cleared on reload'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+test_under_flux 1 job -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p $(pwd)/FluxAccountingTest.db create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'add some banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add two associations to the DB' '
+	flux account add-user --username=user1 --userid=50001 --bank=A &&
+	flux account add-user --username=user2 --userid=50002 --bank=A
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p $(pwd)/FluxAccountingTest.db
+'
+
+test_expect_success 'both associations exist in plugin map' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e "[.mf_priority_map[] | select(.userid == 50001)] | length == 1" <query.json &&
+	jq -e "[.mf_priority_map[] | select(.userid == 50002)] | length == 1" <query.json
+'
+
+test_expect_success 'remove second association from database' '
+	flux account delete-user --force user2 A &&
+	test_must_fail flux account view-user user2 > association_noexist.err 2>&1 &&
+	grep "user user2 not found in association_table" association_noexist.err
+'
+
+test_expect_success 'unload and reload mf_priority.so with flux-accounting data' '
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} \
+		"config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'only user1 exists in plugin map' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e "[.mf_priority_map[] | select(.userid == 50001)] | length == 1" <query.json &&
+	jq -e "[.mf_priority_map[] | select(.userid == 50002)] | length == 0" <query.json
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

On RHEL10 systems, unloading and reloading the plugin doesn't actually clear the data in any of the internal data structures in the plugin. Thus, a number of the tests in the testsuite fail that deal with reloading the plugin because the test expects a freshly-loaded plugin with no data in it.

It also raises a more general concern that when the plugin *is* loaded, it should clear any previously-loaded data. Data sent from the flux-accounting database could be removed, and if the data structures in the plugin are not properly cleared, then leftover data can remain in the plugin and unexpected behavior can occur, such as users who do not have a valid entry in the flux-accounting database being able to submit jobs.

---

This PR adds a clear of all the internal data structures in the plugin during `plugin_init ()` so that leftover data does not remain after a plugin reload. I've also added some tests to check that data in the plugin does not remain after a reload.

Fixes #849