### PR TITLE
ci: add `el10` builder

### DIFF
--- a/src/test/docker/el10/Dockerfile
+++ b/src/test/docker/el10/Dockerfile
@@ -1,0 +1,17 @@
+FROM fluxrm/flux-core:el10
+
+ARG USER=flux
+ARG UID=1000
+
+# Add configured user to image with sudo access:
+#
+RUN \
+ if test "$USER" != "flux"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -180,4 +180,11 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# el10
+matrix.add_build(
+    name="el10",
+    image="el10",
+    docker_tag=True,
+)
+
 print(matrix)


### PR DESCRIPTION
#### Problem

There is no `el10` builder in the flux-accounting testsuite.

---

This PR adds one. This is built on top of #851 as a result of discovering some test failures that were run in a `el10` container that are fixed in that PR.