### PR TITLE
`view-job-records`: add dynamic width sizing for columns

### DIFF
--- a/src/bindings/python/fluxacct/accounting/__init__.py.in
+++ b/src/bindings/python/fluxacct/accounting/__init__.py.in
@@ -66,6 +66,28 @@ JOBS_TABLE = [
     "actual_duration",
 ]
 PRIORITY_FACTOR_WEIGHTS_TABLE = ["factor", "weight"]
+JOB_RECORD_FIELDS = [
+    "jobid",
+    "username",
+    "userid",
+    "t_submit",
+    "t_run",
+    "t_inactive",
+    "nnodes",
+    "project",
+    "bank",
+    "requested_duration",
+    "actual_duration",
+    "duration_delta",
+]
+JOB_RECORD_FLOAT_FIELDS = {
+    "t_submit",
+    "t_run",
+    "t_inactive",
+    "requested_duration",
+    "actual_duration",
+    "duration_delta",
+}
 
 __all__ = [
     "DB_DIR",

--- a/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/jobs_table_subcommands.py
@@ -16,6 +16,7 @@ from flux.job.JobID import JobID
 from flux.constants import FLUX_USERID_UNKNOWN
 from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import util
+from fluxacct.accounting import JOB_RECORD_FIELDS, JOB_RECORD_FLOAT_FIELDS
 
 
 class JobRecord:
@@ -69,18 +70,35 @@ def convert_to_str(job_records, fmt_string=None):
     Convert the results of a query to the jobs table to a readable string
     that can either be output to stdout or written to a file.
     """
-    # default format string
-    if not fmt_string:
-        fmt_string = (
-            "{jobid:<15} | {username:<8} | {userid:<8} | {t_submit:<15.2f} | "
-            + "{t_run:<15.2f} | {t_inactive:<15.2f} | {nnodes:<8} | {project:<8} | "
-            + "{bank:<8} | {requested_duration:<18.2f} | {actual_duration:<15.2f} | "
-            + "{duration_delta:<18.2f}"
-        )
-    output = fmt.JobsFormatter(fmt_string)
-    job_record_str = output.build_table(job_records)
+    if fmt_string:
+        output = fmt.JobsFormatter(fmt_string)
+        return output.build_table(job_records)
 
-    return job_record_str
+    def field_str(record, field):
+        val = getattr(record, field)
+        if field in JOB_RECORD_FLOAT_FIELDS:
+            return f"{val:.2f}"
+        return str(val)
+
+    col_widths = {field: len(field) for field in JOB_RECORD_FIELDS}
+    for record in job_records:
+        for field in JOB_RECORD_FIELDS:
+            # make sure length of the field itself doesn't truncate header length
+            col_widths[field] = max(col_widths[field], len(field_str(record, field)))
+
+    # build a format string using the computed widths
+    parts = []
+    for field in JOB_RECORD_FIELDS:
+        width = col_widths[field]
+        if field in JOB_RECORD_FLOAT_FIELDS:
+            parts.append(f"{{{field}:<{width}.2f}}")
+        else:
+            parts.append(f"{{{field}:<{width}}}")
+
+    fmt_string = " | ".join(parts)
+
+    output = fmt.JobsFormatter(fmt_string)
+    return output.build_table(job_records)
 
 
 def convert_to_obj(rows, jobid_format="f58"):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -88,6 +88,7 @@ TESTSCRIPTS = \
 	t1083-mf-priority-queue-sched-dependency.t \
 	t1084-issue849.t \
 	t1085-issue850.t \
+	t1086-view-job-records-dynamic-width.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -74,7 +74,7 @@ test_expect_success 'check that usage does not get affected by canceled jobs' '
 test_expect_success 'check that no jobs show up under user' '
 	flux account -p ${DB_PATH} view-job-records --user $username > no_jobs.test &&
 	cat <<-EOF >no_jobs.expected &&
-	jobid           | username | userid   | t_submit        | t_run           | t_inactive      | nnodes   | project  | bank
+	jobid | username | userid | t_submit | t_run | t_inactive | nnodes | project | bank | requested_duration | actual_duration | duration_delta
 	EOF
 	grep -f no_jobs.expected no_jobs.test
 '
@@ -108,7 +108,7 @@ test_expect_success 'check that usage does not get affected by canceled jobs' '
 test_expect_success 'check that no jobs show up under user' '
 	flux account -p ${DB_PATH} view-job-records --user $username > no_jobs.test2 &&
 	cat <<-EOF >no_jobs.expected2 &&
-	jobid           | username | userid   | t_submit        | t_run           | t_inactive      | nnodes   | project  | bank
+	jobid | username | userid | t_submit | t_run | t_inactive | nnodes | project | bank | requested_duration | actual_duration | duration_delta
 	EOF
 	grep -f no_jobs.expected2 no_jobs.test2
 '

--- a/t/t1086-view-job-records-dynamic-width.t
+++ b/t/t1086-view-job-records-dynamic-width.t
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+test_description='test viewing jobs with different ID formats'
+
+. `dirname $0`/sharness.sh
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -Slog-stderr-level=1
+
+test_expect_success 'load multi-factor priority plugin' '
+	flux jobtap load -r .priority-default ${MULTI_FACTOR_PRIORITY}
+'
+
+test_expect_success 'check that mf_priority plugin is loaded' '
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+# create two banks, each with varying string width
+test_expect_success 'add banks to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root very_long_bank_name 1
+'
+
+test_expect_success 'add an association' '
+	flux account add-user --username=user1 --userid=50001 --bank=A &&
+	flux account add-user --username=user1 --userid=50001 --bank=very_long_bank_name
+'
+
+test_expect_success 'send flux-accounting DB information to the plugin' '
+	flux account-priority-update -p ${DB_PATH}
+'
+
+test_expect_success 'submit a job to bank A' '
+	jobid=$(flux python ${SUBMIT_AS} 50001 hostname) &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux cancel ${jobid}
+'
+
+test_expect_success 'submit a job to bank very_long_bank_name' '
+	jobid=$(flux python ${SUBMIT_AS} 50001 --bank=very_long_bank_name hostname) &&
+	flux job wait-event -f json ${jobid} priority &&
+	flux cancel ${jobid}
+'
+
+test_expect_success 'run fetch-job-records script' '
+	flux account-fetch-job-records -p ${DB_PATH}
+'
+
+test_expect_success 'view-job-records dynamically sizes output based on string length' '
+	flux account view-job-records --user=user1 > output.test &&
+	cat <<-EOF >output.expected &&
+	| bank                |
+	| very_long_bank_name |
+	| A                   |
+	EOF
+	grep -f output.test output.expected
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

The column widths for the output of the `view-job-records` command is statically defined, which can cause problems if the field
itself is very long.

---

This PR adds dynamic sizing to the width of the different columns in the output of the `view-job-records` command by comparing the max length of the longest field and its corresponding header to create cleaner and more uniform output. Add special formatting for the floating point values to only go to 2 decimal places when printing those values.

It also includes an adjustment a couple of the sharness tests in `t1011-job-archive-interface.t` that look at the output of the headers when there are no job records to account for the new dynamic sizing. I've added a simple set of tests to check that the output also adjusts when there are two rows with drastically different text lengths and making sure that the width adjusts to the longer string.