### PR TITLE
`docker-run-checks.sh`: use `el10` by default

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -10,7 +10,7 @@
 PROJECT=flux-accounting
 BASE_DOCKER_REPO=fluxrm/flux-core
 
-IMAGE=el8
+IMAGE=el10
 JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 


### PR DESCRIPTION
#### Problem

`docker-run-check.sh` uses `el8` as the default image when launching into an interactive container, but there are newer images that can be used.

---

This PR updates the default image to be used to `el10`.