### PR TITLE
`view-bank`: add `active` column, optional argument to filter for only active users

### DIFF
--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -163,6 +163,7 @@ def view_bank(
     cols=None,
     format_string="",
     concise=False,
+    active=False,
 ):
     if tree and cols is not None:
         # tree format cannot be combined with custom formatting, so raise an Exception
@@ -186,10 +187,10 @@ def view_bank(
         return formatter.as_format_string(format_string)
     if tree:
         if parsable:
-            return formatter.as_parsable_tree(bank, concise)
-        return formatter.as_tree(concise)
+            return formatter.as_parsable_tree(bank, concise, active)
+        return formatter.as_tree(concise, active)
     if users:
-        return formatter.with_users(bank, concise)
+        return formatter.with_users(bank, concise, active)
     return formatter.as_json()
 
 

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -32,6 +32,16 @@ class AccountingFormatter:
             # the SQL query didn't fetch any results; raise an Exception
             raise ValueError(error_msg)
 
+    def _transform_row(self, row):
+        """Transform display values in a row before formatting."""
+        transformed = []
+        for col_name, value in zip(self.column_names, row):
+            if col_name == "active":
+                transformed.append("true" if value == 1 else "false")
+            else:
+                transformed.append(u.format_value(value))
+        return transformed
+
     def get_column_names(self):
         """
         Return the column names from the query result.
@@ -57,29 +67,25 @@ class AccountingFormatter:
         Returns:
             table: the data from the query formatted as a table.
         """
-        # fetch column names and determine the width of each column
-        col_names = [description[0] for description in self.cursor.description]
+        transformed_rows = [self._transform_row(row) for row in self.rows]
+
         col_widths = [
             max(
-                len(str(u.format_value(value)))
-                for value in [col] + [row[i] for row in self.rows]
+                len(str(value))
+                for value in [col] + [row[i] for row in transformed_rows]
             )
-            for i, col in enumerate(col_names)
+            for i, col in enumerate(self.column_names)
         ]
 
         # format a row of data
         def format_row(row):
             return " | ".join(
-                [
-                    f"{str(u.format_value(value)).ljust(col_widths[i])}"
-                    for i, value in enumerate(row)
-                ]
+                f"{str(value).ljust(col_widths[i])}" for i, value in enumerate(row)
             )
 
-        # format the header, separator, and data rows
-        header = format_row(col_names)
+        header = format_row(self.column_names)
         separator = "-+-".join(["-" * width for width in col_widths])
-        data_rows = "\n".join([format_row(row) for row in self.rows])
+        data_rows = "\n".join([format_row(row) for row in transformed_rows])
 
         table = f"{header}\n{separator}\n{data_rows}"
 

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -153,24 +153,30 @@ class BankFormatter(AccountingFormatter):
             cursor, error_msg=f"bank {self.bank_name} not found in bank_table"
         )
 
-    def _iterate_hierarchy(self, bank, fmt_bank, fmt_user, indent="", concise=False):
+    def _iterate_hierarchy(
+        self, bank, fmt_bank, fmt_user, indent="", concise=False, active=False
+    ):
         """
         Internal generator to traverse banks and yield formatted lines.
         """
         # fetch direct sub banks
         self.cursor.execute(
-            "SELECT bank,shares,job_usage FROM bank_table WHERE parent_bank=?", (bank,)
+            "SELECT bank,active,shares,job_usage FROM bank_table WHERE parent_bank=?",
+            (bank,),
         )
         sub_banks = self.cursor.fetchall()
         if not sub_banks:
             # leaf bank: list users
             select_stmt = (
-                "SELECT username,shares,job_usage,fairshare FROM association_table "
+                "SELECT username,shares,job_usage,fairshare,active FROM association_table "
                 "WHERE bank=?"
             )
             if concise:
                 # only display associations that have a job usage value greater than 0
                 select_stmt += " AND job_usage > 0"
+            if active:
+                # only display associations that are currently active under this bank
+                select_stmt += " AND active=1"
             self.cursor.execute(
                 select_stmt,
                 (bank,),
@@ -181,10 +187,10 @@ class BankFormatter(AccountingFormatter):
             for sub_bank in sub_banks:
                 yield fmt_bank(sub_bank, indent)
                 yield from self._iterate_hierarchy(
-                    sub_bank["bank"], fmt_bank, fmt_user, indent + " ", concise
+                    sub_bank["bank"], fmt_bank, fmt_user, indent + " ", concise, active
                 )
 
-    def as_tree(self, concise):
+    def as_tree(self, concise, active):
         """
         Format the flux-accounting bank hierarchy in tree format. The bank passed
         into the query will serve as the root of the tree.
@@ -197,6 +203,7 @@ class BankFormatter(AccountingFormatter):
         header = (
             "Bank".ljust(20)
             + "Username".rjust(20)
+            + "Active".rjust(20)
             + "RawShares".rjust(20)
             + "RawUsage".rjust(20)
             + "Fairshare".rjust(20)
@@ -204,29 +211,35 @@ class BankFormatter(AccountingFormatter):
 
         # the root line of the hierarchy will not have an indent
         root_bank = self.rows[0]
+        root_bank_status = "true" if root_bank["active"] == 1 else "false"
         root_line = (
             str(root_bank["bank"]).ljust(20)
             + "".rjust(20)
+            + str(root_bank_status).rjust(20)
             + str(root_bank["shares"]).rjust(20)
             + str(round(root_bank["job_usage"], 2)).rjust(20)
         )
 
         def fmt_bank(row, indent):
             prefix = indent + " "
+            bank_status = "true" if row["active"] == 1 else "false"
             return (
                 prefix
                 + str(row["bank"]).ljust(20)
                 + "".rjust(20 - (len(prefix)))
+                + str(bank_status).rjust(20)
                 + str(row["shares"]).rjust(20)
                 + str(row["job_usage"]).rjust(20)
             )
 
         def fmt_user(bank, user, indent):
             prefix = indent + " "
+            user_status = "true" if user["active"] == 1 else "false"
             return (
                 prefix
                 + bank.ljust(20)
                 + str(user["username"]).rjust(20 - len(prefix))
+                + str(user_status).rjust(20)
                 + str(user["shares"]).rjust(20)
                 + str(user["job_usage"]).rjust(20)
                 + str(user["fairshare"]).rjust(20)
@@ -234,11 +247,13 @@ class BankFormatter(AccountingFormatter):
 
         lines = [header, root_line]
         lines.extend(
-            self._iterate_hierarchy(root_bank["bank"], fmt_bank, fmt_user, "", concise)
+            self._iterate_hierarchy(
+                root_bank["bank"], fmt_bank, fmt_user, "", concise, active
+            )
         )
         return "\n".join(lines) + "\n"
 
-    def as_parsable_tree(self, bank, concise):
+    def as_parsable_tree(self, bank, concise, active):
         """
         Format the flux-accounting bank hierarchy in a parsable tree format starting with
         the bank passed in serving as the root of the tree. Delimit the items in each row
@@ -249,33 +264,38 @@ class BankFormatter(AccountingFormatter):
                 flux-accounting DB as a parsable tree.
         """
         # header for hierarchy string
-        header = "Bank|Username|RawShares|RawUsage|Fairshare"
+        header = "Bank|Username|Active|RawShares|RawUsage|Fairshare"
 
         # the root line of the hierarchy will not have an indent
         root_bank = self.rows[0]
+        root_bank_status = "true" if root_bank["active"] == 1 else "false"
         root_line = (
-            f"{root_bank['bank']}||{root_bank['shares']}|"
+            f"{root_bank['bank']}||{root_bank_status}|{root_bank['shares']}|"
             f"{str(round(root_bank['job_usage'], 2))}"
         )
 
         def fmt_bank(row, indent):
             prefix = indent + " "
-            return f"{prefix}{row['bank']}||{row['shares']}|{row['job_usage']}"
+            bank_status = "true" if row["active"] == 1 else "false"
+            return f"{prefix}{row['bank']}||{bank_status}|{row['shares']}|{row['job_usage']}"
 
         def fmt_user(bank, user, indent):
             prefix = indent + " "
+            user_status = "true" if user["active"] == 1 else "false"
             return (
-                f"{prefix}{bank}|{user['username']}|{user['shares']}|"
+                f"{prefix}{bank}|{user['username']}|{user_status}|{user['shares']}|"
                 f"{user['job_usage']}|{user['fairshare']}"
             )
 
         lines = [header, root_line]
         lines.extend(
-            self._iterate_hierarchy(root_bank["bank"], fmt_bank, fmt_user, "", concise)
+            self._iterate_hierarchy(
+                root_bank["bank"], fmt_bank, fmt_user, "", concise, active
+            )
         )
         return "\n".join(lines) + "\n"
 
-    def with_users(self, bank, concise):
+    def with_users(self, bank, concise, active):
         """
         Print basic information for all of the users under a given bank in table
         format.
@@ -288,11 +308,13 @@ class BankFormatter(AccountingFormatter):
             info = self.as_table()
 
             select_stmt = (
-                "SELECT username,default_bank,shares,job_usage,fairshare "
+                "SELECT username,active,default_bank,shares,job_usage,fairshare "
                 "FROM association_table WHERE bank=?"
             )
             if concise:
                 select_stmt += " AND job_usage > 0"
+            if active:
+                select_stmt += " AND active=1"
             self.cursor.execute(
                 select_stmt,
                 (bank,),

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -289,6 +289,7 @@ class AccountingService:
                 else None,
                 msg.payload.get("format"),
                 msg.payload.get("concise"),
+                msg.payload.get("active"),
             )
 
             payload = {"view_bank": val}

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -664,6 +664,12 @@ def add_view_bank_arg(subparsers):
         const=True,
         help="only list associations that have a job usage value > 0",
     )
+    subparser_view_bank.add_argument(
+        "-A",
+        "--active",
+        action="store_true",
+        help="only list active associations under this bank",
+    )
 
 
 def add_delete_bank_arg(subparsers):

--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -1,8 +1,8 @@
 bank_id | bank | active | parent_bank | shares | job_usage | priority | ignore_older_than
 --------+------+--------+-------------+--------+-----------+----------+------------------
-2       | A    | 1      | root        | 1      | 0.0       | 0.0      | 0                
+2       | A    | true   | root        | 1      | 0.0       | 0.0      | 0                
 
 username | active | default_bank | shares | job_usage | fairshare
 ---------+--------+--------------+--------+-----------+----------
-user5011 | 1      | A            | 1      | 0.0       | 0.5      
-user5012 | 1      | A            | 1      | 0.0       | 0.5      
+user5011 | true   | A            | 1      | 0.0       | 0.5      
+user5012 | true   | A            | 1      | 0.0       | 0.5      

--- a/t/expected/flux_account/A_bank.expected
+++ b/t/expected/flux_account/A_bank.expected
@@ -2,7 +2,7 @@ bank_id | bank | active | parent_bank | shares | job_usage | priority | ignore_o
 --------+------+--------+-------------+--------+-----------+----------+------------------
 2       | A    | 1      | root        | 1      | 0.0       | 0.0      | 0                
 
-username | default_bank | shares | job_usage | fairshare
----------+--------------+--------+-----------+----------
-user5011 | A            | 1      | 0.0       | 0.5      
-user5012 | A            | 1      | 0.0       | 0.5      
+username | active | default_bank | shares | job_usage | fairshare
+---------+--------+--------------+--------+-----------+----------
+user5011 | 1      | A            | 1      | 0.0       | 0.5      
+user5012 | 1      | A            | 1      | 0.0       | 0.5      

--- a/t/expected/flux_account/D_bank.expected
+++ b/t/expected/flux_account/D_bank.expected
@@ -1,5 +1,5 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-D                                                          1                 0.0
- E                                                         1                 0.0
- F                                                         1                 0.0
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+D                                                       true                   1                 0.0
+ E                                                      true                   1                 0.0
+ F                                                      true                   1                 0.0
 

--- a/t/expected/flux_account/E_bank.expected
+++ b/t/expected/flux_account/E_bank.expected
@@ -1,5 +1,5 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-E                                                          1                 0.0
- E                              user5030                   1                 0.0                 0.5
- E                              user5031                   1                 0.0                 0.5
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+E                                                       true                   1                 0.0
+ E                              user5030                true                   1                 0.0                 0.5
+ E                              user5031                true                   1                 0.0                 0.5
 

--- a/t/expected/flux_account/F_bank_tree.expected
+++ b/t/expected/flux_account/F_bank_tree.expected
@@ -1,3 +1,3 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-F                                                          1                 0.0
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+F                                                       true                   1                 0.0
 

--- a/t/expected/flux_account/F_bank_users.expected
+++ b/t/expected/flux_account/F_bank_users.expected
@@ -1,5 +1,5 @@
 bank_id | bank | active | parent_bank | shares | job_usage | priority | ignore_older_than
 --------+------+--------+-------------+--------+-----------+----------+------------------
-7       | F    | 1      | D           | 1      | 0.0       | 0.0      | 0                
+7       | F    | true   | D           | 1      | 0.0       | 0.0      | 0                
 
 no users under F

--- a/t/expected/flux_account/full_hierarchy.expected
+++ b/t/expected/flux_account/full_hierarchy.expected
@@ -1,13 +1,13 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                       1                 0.0
- A                                                         1                 0.0
-  A                             user5011                   1                 0.0                 0.5
-  A                             user5012                   1                 0.0                 0.5
- B                                                         1                 0.0
-  B                             user5013                   1                 0.0                 0.5
- C                                                         1                 0.0
-  C                             user5014                   1                 0.0                 0.5
- D                                                         1                 0.0
-  E                                                        1                 0.0
-  F                                                        1                 0.0
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                   1                 0.0
+ A                                                      true                   1                 0.0
+  A                             user5011                true                   1                 0.0                 0.5
+  A                             user5012                true                   1                 0.0                 0.5
+ B                                                      true                   1                 0.0
+  B                             user5013                true                   1                 0.0                 0.5
+ C                                                      true                   1                 0.0
+  C                             user5014                true                   1                 0.0                 0.5
+ D                                                      true                   1                 0.0
+  E                                                     true                   1                 0.0
+  F                                                     true                   1                 0.0
 

--- a/t/expected/pop_db/db_hierarchy_base.expected
+++ b/t/expected/pop_db/db_hierarchy_base.expected
@@ -1,12 +1,12 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                       1                 0.0
- A                                                         1                 0.0
-  A                             user1000                   1                 0.0                 0.5
-  A                             user1001                   1                 0.0                 0.5
-  A                             user1002                   1                 0.0                 0.5
-  A                             user1003                   1                 0.0                 0.5
-  A                             user1004                   1                 0.0                 0.5
- B                                                         1                 0.0
- C                                                         1                 0.0
-  D                                                        1                 0.0
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                   1                 0.0
+ A                                                      true                   1                 0.0
+  A                             user1000                true                   1                 0.0                 0.5
+  A                             user1001                true                   1                 0.0                 0.5
+  A                             user1002                true                   1                 0.0                 0.5
+  A                             user1003                true                   1                 0.0                 0.5
+  A                             user1004                true                   1                 0.0                 0.5
+ B                                                      true                   1                 0.0
+ C                                                      true                   1                 0.0
+  D                                                     true                   1                 0.0
 

--- a/t/expected/pop_db/db_hierarchy_new_users.expected
+++ b/t/expected/pop_db/db_hierarchy_new_users.expected
@@ -1,17 +1,17 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                       1                 0.0
- A                                                         1                 0.0
-  A                             user1000                   1                 0.0                 0.5
-  A                             user1001                   1                 0.0                 0.5
-  A                             user1002                   1                 0.0                 0.5
-  A                             user1003                   1                 0.0                 0.5
-  A                             user1004                   1                 0.0                 0.5
- B                                                         1                 0.0
-  B                             user1005                   1                 0.0                 0.5
-  B                             user1006                   1                 0.0                 0.5
-  B                             user1007                   1                 0.0                 0.5
-  B                             user1008                   1                 0.0                 0.5
-  B                             user1009                   1                 0.0                 0.5
- C                                                         1                 0.0
-  D                                                        1                 0.0
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                   1                 0.0
+ A                                                      true                   1                 0.0
+  A                             user1000                true                   1                 0.0                 0.5
+  A                             user1001                true                   1                 0.0                 0.5
+  A                             user1002                true                   1                 0.0                 0.5
+  A                             user1003                true                   1                 0.0                 0.5
+  A                             user1004                true                   1                 0.0                 0.5
+ B                                                      true                   1                 0.0
+  B                             user1005                true                   1                 0.0                 0.5
+  B                             user1006                true                   1                 0.0                 0.5
+  B                             user1007                true                   1                 0.0                 0.5
+  B                             user1008                true                   1                 0.0                 0.5
+  B                             user1009                true                   1                 0.0                 0.5
+ C                                                      true                   1                 0.0
+  D                                                     true                   1                 0.0
 

--- a/t/expected/print_hierarchy/small_no_tie.txt
+++ b/t/expected/print_hierarchy/small_no_tie.txt
@@ -1,13 +1,13 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                    1000               133.0
- account1                                               1000               121.0
-  account1                      leaf.1.1               10000               100.0            0.285714
-  account1                      leaf.1.2                1000                11.0            0.142857
-  account1                      leaf.1.3              100000                10.0            0.428571
- account2                                                100                11.0
-  account2                      leaf.2.1              100000                 8.0            0.714286
-  account2                      leaf.2.2               10000                 3.0            0.571429
- account3                                                 10                 1.0
-  account3                      leaf.3.1                 100                 0.0                 1.0
-  account3                      leaf.3.2                  10                 1.0            0.857143
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                1000               133.0
+ account1                                               true                1000               121.0
+  account1                      leaf.1.1                true               10000               100.0            0.285714
+  account1                      leaf.1.2                true                1000                11.0            0.142857
+  account1                      leaf.1.3                true              100000                10.0            0.428571
+ account2                                               true                 100                11.0
+  account2                      leaf.2.1                true              100000                 8.0            0.714286
+  account2                      leaf.2.2                true               10000                 3.0            0.571429
+ account3                                               true                  10                 1.0
+  account3                      leaf.3.1                true                 100                 0.0                 1.0
+  account3                      leaf.3.2                true                  10                 1.0            0.857143
 

--- a/t/expected/print_hierarchy/small_no_tie_parsable.txt
+++ b/t/expected/print_hierarchy/small_no_tie_parsable.txt
@@ -1,13 +1,13 @@
-Bank|Username|RawShares|RawUsage|Fairshare
-root||1000|133.0
- account1||1000|121.0
-  account1|leaf.1.1|10000|100.0|0.285714
-  account1|leaf.1.2|1000|11.0|0.142857
-  account1|leaf.1.3|100000|10.0|0.428571
- account2||100|11.0
-  account2|leaf.2.1|100000|8.0|0.714286
-  account2|leaf.2.2|10000|3.0|0.571429
- account3||10|1.0
-  account3|leaf.3.1|100|0.0|1.0
-  account3|leaf.3.2|10|1.0|0.857143
+Bank|Username|Active|RawShares|RawUsage|Fairshare
+root||true|1000|133.0
+ account1||true|1000|121.0
+  account1|leaf.1.1|true|10000|100.0|0.285714
+  account1|leaf.1.2|true|1000|11.0|0.142857
+  account1|leaf.1.3|true|100000|10.0|0.428571
+ account2||true|100|11.0
+  account2|leaf.2.1|true|100000|8.0|0.714286
+  account2|leaf.2.2|true|10000|3.0|0.571429
+ account3||true|10|1.0
+  account3|leaf.3.1|true|100|0.0|1.0
+  account3|leaf.3.2|true|10|1.0|0.857143
 

--- a/t/expected/print_hierarchy/small_tie.txt
+++ b/t/expected/print_hierarchy/small_tie.txt
@@ -1,14 +1,14 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                    1000               133.0
- account1                                               1000               120.0
-  account1                      leaf.1.1               10000               100.0                 0.5
-  account1                      leaf.1.2                1000                10.0                 0.5
-  account1                      leaf.1.3              100000                10.0                0.75
- account2                                                100                12.0
-  account2                      leaf.2.1               10000                10.0                 0.5
-  account2                      leaf.2.2                1000                 1.0                 0.5
-  account2                      leaf.2.3              100000                 1.0                0.75
- account3                                                 10                 1.0
-  account3                      leaf.3.1                 100                 0.0                 1.0
-  account3                      leaf.3.2                  10                 1.0               0.875
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                1000               133.0
+ account1                                               true                1000               120.0
+  account1                      leaf.1.1                true               10000               100.0                 0.5
+  account1                      leaf.1.2                true                1000                10.0                 0.5
+  account1                      leaf.1.3                true              100000                10.0                0.75
+ account2                                               true                 100                12.0
+  account2                      leaf.2.1                true               10000                10.0                 0.5
+  account2                      leaf.2.2                true                1000                 1.0                 0.5
+  account2                      leaf.2.3                true              100000                 1.0                0.75
+ account3                                               true                  10                 1.0
+  account3                      leaf.3.1                true                 100                 0.0                 1.0
+  account3                      leaf.3.2                true                  10                 1.0               0.875
 

--- a/t/expected/print_hierarchy/small_tie_all.txt
+++ b/t/expected/print_hierarchy/small_tie_all.txt
@@ -1,15 +1,15 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                    1000              1332.0
- account1                                               1000               120.0
-  account1                      leaf.1.1               10000               100.0            0.666667
-  account1                      leaf.1.2                1000                10.0            0.666667
-  account1                      leaf.1.3              100000                10.0                 1.0
- account2                                                100                12.0
-  account2                      leaf.2.1               10000                10.0            0.666667
-  account2                      leaf.2.2                1000                 1.0            0.666667
-  account2                      leaf.2.3              100000                 1.0                 1.0
- account3                                              10000              1200.0
-  account3                      leaf.3.1               10000              1000.0            0.666667
-  account3                      leaf.3.2                1000               100.0            0.666667
-  account3                      leaf.3.3              100000               100.0                 1.0
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                1000              1332.0
+ account1                                               true                1000               120.0
+  account1                      leaf.1.1                true               10000               100.0            0.666667
+  account1                      leaf.1.2                true                1000                10.0            0.666667
+  account1                      leaf.1.3                true              100000                10.0                 1.0
+ account2                                               true                 100                12.0
+  account2                      leaf.2.1                true               10000                10.0            0.666667
+  account2                      leaf.2.2                true                1000                 1.0            0.666667
+  account2                      leaf.2.3                true              100000                 1.0                 1.0
+ account3                                               true               10000              1200.0
+  account3                      leaf.3.1                true               10000              1000.0            0.666667
+  account3                      leaf.3.2                true                1000               100.0            0.666667
+  account3                      leaf.3.3                true              100000               100.0                 1.0
 

--- a/t/expected/print_hierarchy/small_tie_all_parsable.txt
+++ b/t/expected/print_hierarchy/small_tie_all_parsable.txt
@@ -1,15 +1,15 @@
-Bank|Username|RawShares|RawUsage|Fairshare
-root||1000|1332.0
- account1||1000|120.0
-  account1|leaf.1.1|10000|100.0|0.666667
-  account1|leaf.1.2|1000|10.0|0.666667
-  account1|leaf.1.3|100000|10.0|1.0
- account2||100|12.0
-  account2|leaf.2.1|10000|10.0|0.666667
-  account2|leaf.2.2|1000|1.0|0.666667
-  account2|leaf.2.3|100000|1.0|1.0
- account3||10000|1200.0
-  account3|leaf.3.1|10000|1000.0|0.666667
-  account3|leaf.3.2|1000|100.0|0.666667
-  account3|leaf.3.3|100000|100.0|1.0
+Bank|Username|Active|RawShares|RawUsage|Fairshare
+root||true|1000|1332.0
+ account1||true|1000|120.0
+  account1|leaf.1.1|true|10000|100.0|0.666667
+  account1|leaf.1.2|true|1000|10.0|0.666667
+  account1|leaf.1.3|true|100000|10.0|1.0
+ account2||true|100|12.0
+  account2|leaf.2.1|true|10000|10.0|0.666667
+  account2|leaf.2.2|true|1000|1.0|0.666667
+  account2|leaf.2.3|true|100000|1.0|1.0
+ account3||true|10000|1200.0
+  account3|leaf.3.1|true|10000|1000.0|0.666667
+  account3|leaf.3.2|true|1000|100.0|0.666667
+  account3|leaf.3.3|true|100000|100.0|1.0
 

--- a/t/expected/print_hierarchy/small_tie_parsable.txt
+++ b/t/expected/print_hierarchy/small_tie_parsable.txt
@@ -1,14 +1,14 @@
-Bank|Username|RawShares|RawUsage|Fairshare
-root||1000|133.0
- account1||1000|120.0
-  account1|leaf.1.1|10000|100.0|0.5
-  account1|leaf.1.2|1000|10.0|0.5
-  account1|leaf.1.3|100000|10.0|0.75
- account2||100|12.0
-  account2|leaf.2.1|10000|10.0|0.5
-  account2|leaf.2.2|1000|1.0|0.5
-  account2|leaf.2.3|100000|1.0|0.75
- account3||10|1.0
-  account3|leaf.3.1|100|0.0|1.0
-  account3|leaf.3.2|10|1.0|0.875
+Bank|Username|Active|RawShares|RawUsage|Fairshare
+root||true|1000|133.0
+ account1||true|1000|120.0
+  account1|leaf.1.1|true|10000|100.0|0.5
+  account1|leaf.1.2|true|1000|10.0|0.5
+  account1|leaf.1.3|true|100000|10.0|0.75
+ account2||true|100|12.0
+  account2|leaf.2.1|true|10000|10.0|0.5
+  account2|leaf.2.2|true|1000|1.0|0.5
+  account2|leaf.2.3|true|100000|1.0|0.75
+ account3||true|10|1.0
+  account3|leaf.3.1|true|100|0.0|1.0
+  account3|leaf.3.2|true|10|1.0|0.875
 

--- a/t/expected/update_fshare/post_fshare_update.expected
+++ b/t/expected/update_fshare/post_fshare_update.expected
@@ -1,13 +1,13 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                    1000               180.0
- account1                                               1000               121.0
-  account1                      leaf.1.1               10000               100.0            0.571429
-  account1                      leaf.1.2                1000                11.0            0.428571
-  account1                      leaf.1.3              100000                10.0            0.714286
- account2                                                100                58.0
-  account2                      leaf.2.1              100000                55.0            0.142857
-  account2                      leaf.2.2               10000                 3.0            0.285714
- account3                                                 10                 1.0
-  account3                      leaf.3.1                 100                 0.0                 1.0
-  account3                      leaf.3.2                  10                 1.0            0.857143
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                1000               180.0
+ account1                                               true                1000               121.0
+  account1                      leaf.1.1                true               10000               100.0            0.571429
+  account1                      leaf.1.2                true                1000                11.0            0.428571
+  account1                      leaf.1.3                true              100000                10.0            0.714286
+ account2                                               true                 100                58.0
+  account2                      leaf.2.1                true              100000                55.0            0.142857
+  account2                      leaf.2.2                true               10000                 3.0            0.285714
+ account3                                               true                  10                 1.0
+  account3                      leaf.3.1                true                 100                 0.0                 1.0
+  account3                      leaf.3.2                true                  10                 1.0            0.857143
 

--- a/t/expected/update_fshare/pre_fshare_update.expected
+++ b/t/expected/update_fshare/pre_fshare_update.expected
@@ -1,13 +1,13 @@
-Bank                            Username           RawShares            RawUsage           Fairshare
-root                                                    1000               133.0
- account1                                               1000               121.0
-  account1                      leaf.1.1               10000               100.0            0.285714
-  account1                      leaf.1.2                1000                11.0            0.142857
-  account1                      leaf.1.3              100000                10.0            0.428571
- account2                                                100                11.0
-  account2                      leaf.2.1              100000                 8.0            0.714286
-  account2                      leaf.2.2               10000                 3.0            0.571429
- account3                                                 10                 1.0
-  account3                      leaf.3.1                 100                 0.0                 1.0
-  account3                      leaf.3.2                  10                 1.0            0.857143
+Bank                            Username              Active           RawShares            RawUsage           Fairshare
+root                                                    true                1000               133.0
+ account1                                               true                1000               121.0
+  account1                      leaf.1.1                true               10000               100.0            0.285714
+  account1                      leaf.1.2                true                1000                11.0            0.142857
+  account1                      leaf.1.3                true              100000                10.0            0.428571
+ account2                                               true                 100                11.0
+  account2                      leaf.2.1                true              100000                 8.0            0.714286
+  account2                      leaf.2.2                true               10000                 3.0            0.571429
+ account3                                               true                  10                 1.0
+  account3                      leaf.3.1                true                 100                 0.0                 1.0
+  account3                      leaf.3.2                true                  10                 1.0            0.857143
 

--- a/t/python/t1008_banks_output.py
+++ b/t/python/t1008_banks_output.py
@@ -224,8 +224,8 @@ class TestAccountingCLI(unittest.TestCase):
             """\
         bank_id | bank | active | parent_bank | shares | job_usage | priority | ignore_older_than
         --------+------+--------+-------------+--------+-----------+----------+------------------
-        1       | root | 1      |             | 1      | 0.0       | 0.0      | 0                
-        2       | A    | 1      | root        | 1      | 0.0       | 0.0      | 0      
+        1       | root | true   |             | 1      | 0.0       | 0.0      | 0                
+        2       | A    | true   | root        | 1      | 0.0       | 0.0      | 0      
         """
         )
         test = b.list_banks(conn)
@@ -260,8 +260,8 @@ class TestAccountingCLI(unittest.TestCase):
             """\
         bank_id | bank | active
         --------+------+-------
-        1       | root | 1     
-        2       | A    | 1     
+        1       | root | true  
+        2       | A    | true     
         """
         )
         test = b.list_banks(conn, cols=["bank_id", "bank", "active"])
@@ -272,8 +272,8 @@ class TestAccountingCLI(unittest.TestCase):
             """\
         bank_id | bank | active | parent_bank
         --------+------+--------+------------
-        1       | root | 1      |            
-        2       | A    | 1      | root
+        1       | root | true   |            
+        2       | A    | true   | root
         """
         )
         test = b.list_banks(conn, cols=["bank_id", "bank", "active", "parent_bank"])
@@ -284,8 +284,8 @@ class TestAccountingCLI(unittest.TestCase):
             """\
         bank_id | bank | active | parent_bank | shares
         --------+------+--------+-------------+-------
-        1       | root | 1      |             | 1     
-        2       | A    | 1      | root        | 1
+        1       | root | true   |             | 1     
+        2       | A    | true   | root        | 1
         """
         )
         test = b.list_banks(
@@ -299,8 +299,8 @@ class TestAccountingCLI(unittest.TestCase):
             """\
         bank_id | bank | active | parent_bank | shares | job_usage
         --------+------+--------+-------------+--------+----------
-        1       | root | 1      |             | 1      | 0.0      
-        2       | A    | 1      | root        | 1      | 0.0
+        1       | root | true   |             | 1      | 0.0      
+        2       | A    | true   | root        | 1      | 0.0
         """
         )
         test = b.list_banks(

--- a/t/python/t1009_users_output.py
+++ b/t/python/t1009_users_output.py
@@ -81,7 +81,7 @@ class TestAccountingCLI(unittest.TestCase):
             """\
         active | username | bank | shares
         -------+----------+------+-------
-        1      | user1    | A    | 1  
+        true   | user1    | A    | 1  
         """
         )
         test = u.view_user(

--- a/t/t1023-flux-account-banks.t
+++ b/t/t1023-flux-account-banks.t
@@ -151,8 +151,8 @@ test_expect_success 'call list-banks with a bad field' '
 '
 
 test_expect_success 'combining --tree with --fields does not work' '
-    test_must_fail flux account view-bank root --tree --fields=bank_id > error.out 2>&1 &&
-    grep "tree option does not support custom formatting" error.out
+	test_must_fail flux account view-bank root --tree --fields=bank_id > error.out 2>&1 &&
+	grep "tree option does not support custom formatting" error.out
 '
 
 test_expect_success 'call list-banks with a format string' '
@@ -189,6 +189,119 @@ test_expect_success 'edit the priority of a bank' '
 	flux account edit-bank H --priority=5000 &&
 	flux account view-bank H > bank_H_edited.out &&
 	grep "\"priority\": 5000.0" bank_H_edited.out
+'
+
+test_expect_success 'add a new bank with a set of users' '
+	flux account add-bank --parent-bank=root Z 1 &&
+	flux account add-user --username=user90001 --bank=Z &&
+	flux account add-user --username=user90002 --bank=Z
+'
+
+test_expect_success 'view-bank --parsable --tree lists active column in default output' '
+	flux account view-bank --parsable --tree Z > view_bank_tree1.test &&
+	cat view_bank_tree1.test &&
+	cat <<-EOF >view_bank_tree1.expected &&
+	Bank|Username|Active|RawShares|RawUsage|Fairshare
+	Z||true|1|0.0
+	 Z|user90001|true|1|0.0|0.5
+	 Z|user90002|true|1|0.0|0.5
+
+	EOF
+	test_cmp view_bank_tree1.test view_bank_tree1.expected
+'
+
+test_expect_success 'view-bank --tree lists active column in default output' '
+	flux account view-bank --tree Z > view_bank_tree2.test &&
+	cat <<-EOF >view_bank_tree2.expected &&
+	Bank                            Username              Active           RawShares            RawUsage           Fairshare
+	Z                                                       true                   1                 0.0
+	 Z                             user90001                true                   1                 0.0                 0.5
+	 Z                             user90002                true                   1                 0.0                 0.5
+
+	EOF
+	test_cmp view_bank_tree2.test view_bank_tree2.expected
+'
+
+test_expect_success 'view-bank --users lists active column in default output' '
+	flux account view-bank --users Z > view_bank_users1.test &&
+	cat <<-EOF > view_bank_users1.expected &&
+	username  | active | default_bank | shares | job_usage | fairshare
+	----------+--------+--------------+--------+-----------+----------
+	user90001 | 1      | Z            | 1      | 0.0       | 0.5      
+	user90002 | 1      | Z            | 1      | 0.0       | 0.5 
+	EOF
+	grep -f view_bank_users1.test view_bank_users1.expected
+'
+
+test_expect_success 'disable one of the users in bank Z' '
+	flux account delete-user user90002 Z
+'
+
+test_expect_success 'view-bank --parsable --tree lists active column in default output' '
+	flux account view-bank --parsable --tree Z > view_bank_tree3.test &&
+	cat <<-EOF >view_bank_tree3.expected &&
+	Bank|Username|Active|RawShares|RawUsage|Fairshare
+	Z||true|1|0.0
+	 Z|user90001|true|1|0.0|0.5
+	 Z|user90002|false|1|0.0|0.5
+
+	EOF
+	test_cmp view_bank_tree3.test view_bank_tree3.expected
+'
+
+test_expect_success 'view-bank --tree lists active column in default output' '
+	flux account view-bank --tree Z > view_bank_tree4.test &&
+	cat <<-EOF >view_bank_tree4.expected &&
+	Bank                            Username              Active           RawShares            RawUsage           Fairshare
+	Z                                                       true                   1                 0.0
+	 Z                             user90001                true                   1                 0.0                 0.5
+	 Z                             user90002               false                   1                 0.0                 0.5
+
+	EOF
+	test_cmp view_bank_tree4.test view_bank_tree4.expected
+'
+
+test_expect_success 'view-bank --users lists active column in default output' '
+	flux account view-bank --users Z > view_bank_users2.test &&
+	cat <<-EOF > view_bank_users2.expected &&
+	username  | active | default_bank | shares | job_usage | fairshare
+	----------+--------+--------------+--------+-----------+----------
+	user90001 | 1      | Z            | 1      | 0.0       | 0.5      
+	user90002 | 0      | Z            | 1      | 0.0       | 0.5 
+	EOF
+	grep -f view_bank_users2.test view_bank_users2.expected
+'
+
+test_expect_success 'view-bank --active --tree only shows active users under that bank' '
+	flux account view-bank --active --tree Z > view_bank_tree5.test &&
+	cat <<-EOF >view_bank_tree5.expected &&
+	Bank                            Username              Active           RawShares            RawUsage           Fairshare
+	Z                                                       true                   1                 0.0
+	 Z                             user90001                true                   1                 0.0                 0.5
+
+	EOF
+	test_cmp view_bank_tree5.test view_bank_tree5.expected
+'
+
+test_expect_success 'view-bank --active --parsable --tree only shows active users under that bank' '
+	flux account view-bank --parsable --tree --active Z > view_bank_tree6.test &&
+	cat <<-EOF >view_bank_tree6.expected &&
+	Bank|Username|Active|RawShares|RawUsage|Fairshare
+	Z||true|1|0.0
+	 Z|user90001|true|1|0.0|0.5
+
+	EOF
+	test_cmp view_bank_tree6.test view_bank_tree6.expected
+'
+
+test_expect_success 'view-bank --users --active only shows active users under that bank' '
+	flux account view-bank --users --active Z > view_bank_users3.test &&
+	cat <<-EOF > view_bank_users3.expected &&
+	username  | active | default_bank | shares | job_usage | fairshare
+	----------+--------+--------------+--------+-----------+----------
+	user90001 | 1      | Z            | 1      | 0.0       | 0.5      
+	EOF
+	grep -f view_bank_users3.test view_bank_users3.expected
 '
 
 test_expect_success 'remove flux-accounting DB' '


### PR DESCRIPTION
#### Problem

Both `flux account view-bank -t` and `flux account view-bank -u` display deleted (`active=0`) users, causing the need to run a second `list-users` command to figure out which users can actually currently use a given bank.

---

This PR adds the `active` column for banks and associations in the default output of the `view-bank` command and adds an optional argument to the `view-bank` command to *only* show users who are active under a given bank in the `view-bank` command.

I've also updated all of the tests that look for specific output of the `view-bank` command to account for the addition of the new `active` column.

Fixes #861 