### PR TITLE
python: use `INTEGER_MAX` in bindings in place of raw value

### DIFF
--- a/src/bindings/python/fluxacct/accounting/queue_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/queue_subcommands.py
@@ -42,8 +42,8 @@ def add_queue(
     max_time=60,
     priority=0,
     max_running_jobs=100,
-    max_nodes_per_assoc=2147483647,
-    max_sched_jobs=2147483647,
+    max_nodes_per_assoc=INTEGER_MAX,
+    max_sched_jobs=INTEGER_MAX,
     max_sched_nodes_per_assoc=INTEGER_MAX,
     max_sched_cores_per_assoc=INTEGER_MAX,
 ):

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -18,6 +18,7 @@ from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import sql_util as sql
 from fluxacct.accounting import util
 from fluxacct.accounting.util import with_cursor
+from fluxacct.accounting import INTEGER_MAX
 
 ###############################################################
 #                                                             #
@@ -339,12 +340,12 @@ def add_user(
     fairshare=0.5,
     max_running_jobs=5,
     max_active_jobs=7,
-    max_nodes=2147483647,
-    max_cores=2147483647,
+    max_nodes=INTEGER_MAX,
+    max_cores=INTEGER_MAX,
     queues="",
     projects="*",
     default_project=None,
-    max_sched_jobs=2147483647,
+    max_sched_jobs=INTEGER_MAX,
 ):
     if uid == FLUX_USERID_UNKNOWN:
         uid = util.get_uid(username)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -215,14 +215,14 @@ def add_add_user_arg(subparsers):
         "-N",
         "--max-nodes",
         help="max number of nodes a user can have across all of their running jobs",
-        default=2147483647,
+        default=INTEGER_MAX,
         metavar="MAX_NODES",
     )
     subparser_add_user.add_argument(
         "-c",
         "--max-cores",
         help="max number of cores a user can have across all of their running jobs",
-        default=2147483647,
+        default=INTEGER_MAX,
         metavar="MAX_CORES",
     )
     subparser_add_user.add_argument(
@@ -248,7 +248,7 @@ def add_add_user_arg(subparsers):
     subparser_add_user.add_argument(
         "--max-sched-jobs",
         help="max number of jobs in SCHED state the user can have at any given time",
-        default=2147483647,
+        default=INTEGER_MAX,
         metavar="NJOBS",
     )
 
@@ -834,7 +834,7 @@ def add_add_queue_arg(subparsers):
             "max number of nodes an association can have across all of their running "
             "jobs in the queue"
         ),
-        default=2147483647,
+        default=INTEGER_MAX,
         metavar="MAX_NODES_PER_ASSOC",
     )
     subparser_add_queue.add_argument(
@@ -844,7 +844,7 @@ def add_add_queue_arg(subparsers):
             "max number of jobs in SCHED state an association can have in this queue "
             "at any given time"
         ),
-        default=2147483647,
+        default=INTEGER_MAX,
         metavar="NJOBS",
     )
     subparser_add_queue.add_argument(
@@ -961,7 +961,7 @@ def add_edit_queue_arg(subparsers):
             "max number of jobs in SCHED state an association can have in this queue "
             "at any given time"
         ),
-        default=2147483647,
+        default=INTEGER_MAX,
         metavar="NJOBS",
     )
     subparser_edit_queue.add_argument(


### PR DESCRIPTION
#### Problem

There are still some functions in the Python bindings that do not use the defined `INTEGER_MAX` value in `__init__.py.in`.

---

This PR just replaces the raw initialization of its value (`2147483647`) with the defined constant, `INTEGER_MAX`, in the Python bindings where the raw value is still being used.