### PR TITLE
plugin: add per-association dependency for max resources in SCHED state in a queue

### DIFF
--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -255,6 +255,8 @@ def export_as_json(conn, cursor):
             "max_running_jobs": int(row["max_running_jobs"]),
             "max_nodes_per_assoc": int(row["max_nodes_per_assoc"]),
             "max_sched_jobs": int(row["max_sched_jobs"]),
+            "max_sched_nodes_per_assoc": int(row["max_sched_nodes_per_assoc"]),
+            "max_sched_cores_per_assoc": int(row["max_sched_cores_per_assoc"]),
         }
         queues.append(queue)
 

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -115,6 +115,8 @@ def bulk_update(path):
             "max_running_jobs": int(row["max_running_jobs"]),
             "max_nodes_per_assoc": int(row["max_nodes_per_assoc"]),
             "max_sched_jobs": int(row["max_sched_jobs"]),
+            "max_sched_nodes_per_assoc": int(row["max_sched_nodes_per_assoc"]),
+            "max_sched_cores_per_assoc": int(row["max_sched_cores_per_assoc"]),
         }
         bulk_q_data.append(single_q_data)
 

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -76,10 +76,12 @@ json_t* Association::to_json () const
         goto error;
     for (const auto &entry : queue_usage) {
         const QueueUsage &usage = entry.second;
-        usage_object = json_pack ("{s:i, s:i, s:i}",
+        usage_object = json_pack ("{s:i, s:i, s:i, s:i, s:i}",
                                   "cur_run_jobs", usage.cur_run_jobs,
                                   "cur_nodes", usage.cur_nodes,
-                                  "cur_sched_jobs", usage.cur_sched_jobs);
+                                  "cur_sched_jobs", usage.cur_sched_jobs,
+                                  "cur_sched_nodes", usage.cur_sched_nodes,
+                                  "cur_sched_cores", usage.cur_sched_cores);
         if (!usage_object)
             goto error;
 
@@ -407,6 +409,94 @@ bool Association::under_queue_max_sched_jobs (
     return (queue_usage[queue].cur_sched_jobs + pending)
            < queues[queue].max_sched_jobs;
 }
+
+
+bool Association::under_queue_max_sched_nodes (
+                                        const Job &job,
+                                        const std::string &queue,
+                                        std::map<std::string, Queue> &queues)
+{
+    auto qit = queues.find (queue);
+    if (qit == queues.end ())
+        // queue is unknown to flux-accounting; skip check
+        return true;
+    const int max_sched_nodes = qit->second.max_sched_nodes_per_assoc;
+
+    // look up current per-queue sched node usage for the association
+    int cur_sched_nodes_in_queue = 0;
+    auto uit = queue_usage.find (queue);
+    if (uit != queue_usage.end ())
+        cur_sched_nodes_in_queue = uit->second.cur_sched_nodes;
+
+    return (cur_sched_nodes_in_queue + job.nnodes) <= max_sched_nodes;
+}
+
+
+bool Association::under_queue_max_sched_nodes (
+                                        const Job &job,
+                                        const std::string &queue,
+                                        std::map<std::string, Queue> &queues,
+                                        int pending)
+{
+    auto qit = queues.find (queue);
+    if (qit == queues.end ())
+        // queue is unknown to flux-accounting; skip check
+        return true;
+    const int max_sched_nodes = qit->second.max_sched_nodes_per_assoc;
+
+    // look up current per-queue sched node usage for the association
+    int cur_sched_nodes_in_queue = 0;
+    auto uit = queue_usage.find (queue);
+    if (uit != queue_usage.end ())
+        cur_sched_nodes_in_queue = uit->second.cur_sched_nodes;
+
+    return (cur_sched_nodes_in_queue + job.nnodes + pending)
+            <= max_sched_nodes;
+}
+
+
+bool Association::under_queue_max_sched_cores (
+                                        const Job &job,
+                                        const std::string &queue,
+                                        std::map<std::string, Queue> &queues)
+{
+    auto qit = queues.find (queue);
+    if (qit == queues.end ())
+        // queue is unknown to flux-accounting; skip check
+        return true;
+    const int max_sched_cores = qit->second.max_sched_cores_per_assoc;
+
+    // look up current per-queue sched core usage for the association
+    int cur_sched_cores_in_queue = 0;
+    auto uit = queue_usage.find (queue);
+    if (uit != queue_usage.end ())
+        cur_sched_cores_in_queue = uit->second.cur_sched_cores;
+
+    return (cur_sched_cores_in_queue + job.ncores) <= max_sched_cores;
+}
+
+bool Association::under_queue_max_sched_cores (
+                                        const Job &job,
+                                        const std::string &queue,
+                                        std::map<std::string, Queue> &queues,
+                                        int pending)
+{
+    auto qit = queues.find (queue);
+    if (qit == queues.end ())
+        // queue is unknown to flux-accounting; skip check
+        return true;
+    const int max_sched_cores = qit->second.max_sched_cores_per_assoc;
+
+    // look up current per-queue sched core usage for the association
+    int cur_sched_cores_in_queue = 0;
+    auto uit = queue_usage.find (queue);
+    if (uit != queue_usage.end ())
+        cur_sched_cores_in_queue = uit->second.cur_sched_cores;
+
+    return (cur_sched_cores_in_queue + job.ncores + pending)
+            <= max_sched_cores;
+}
+
 
 json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
 {

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -419,7 +419,8 @@ json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
         const Queue &q = kv.second;
 
         json_t *qobj = json_pack (
-                                "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
+                                "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i, "
+                                "s:i, s:i}",
                                 "name", q.name.c_str (),
                                 "min_nodes_per_job", q.min_nodes_per_job,
                                 "max_nodes_per_job", q.max_nodes_per_job,
@@ -427,7 +428,9 @@ json_t* convert_queues_to_json (const std::map<std::string, Queue> &queues)
                                 "priority", q.priority,
                                 "max_running_jobs", q.max_running_jobs,
                                 "max_nodes_per_assoc", q.max_nodes_per_assoc,
-                                "max_sched_jobs", q.max_sched_jobs);
+                                "max_sched_jobs", q.max_sched_jobs,
+                                "max_sched_nodes_per_assoc", q.max_sched_nodes_per_assoc,
+                                "max_sched_cores_per_assoc", q.max_sched_cores_per_assoc);
         if (!qobj) {
             json_decref (root);
             return nullptr;
@@ -542,6 +545,7 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
     char *queue = NULL;
     int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority;
     int max_running_jobs, max_nodes_per_assoc, max_sched_jobs;
+    int max_sched_nodes_per_assoc, max_sched_cores_per_assoc;
     json_error_t error;
     int num_data = 0;
 
@@ -559,7 +563,8 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
         json_t *el = json_array_get(data, i);
 
         if (json_unpack_ex (el, &error, 0,
-                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
+                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i, "
+                            "s:i, s:i}",
                             "queue", &queue,
                             "min_nodes_per_job", &min_nodes_per_job,
                             "max_nodes_per_job", &max_nodes_per_job,
@@ -567,7 +572,9 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
                             "priority", &priority,
                             "max_running_jobs", &max_running_jobs,
                             "max_nodes_per_assoc", &max_nodes_per_assoc,
-                            "max_sched_jobs", &max_sched_jobs) < 0) {
+                            "max_sched_jobs", &max_sched_jobs,
+                            "max_sched_nodes_per_assoc", &max_sched_nodes_per_assoc,
+                            "max_sched_cores_per_assoc", &max_sched_cores_per_assoc) < 0) {
             if (errmsg)
                 *errmsg = error.text;
             return -1;
@@ -584,6 +591,8 @@ int load_queues (json_t *data, std::map<std::string, Queue> &queues,
         q->max_running_jobs = max_running_jobs;
         q->max_nodes_per_assoc = max_nodes_per_assoc;
         q->max_sched_jobs = max_sched_jobs;
+        q->max_sched_nodes_per_assoc = max_sched_nodes_per_assoc;
+        q->max_sched_cores_per_assoc = max_sched_cores_per_assoc;
     }
 
     return 0;

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -80,6 +80,8 @@ public:
     int max_running_jobs = std::numeric_limits<int>::max ();
     int max_nodes_per_assoc = 2147483647;
     int max_sched_jobs = 2147483647;
+    int max_sched_nodes_per_assoc = std::numeric_limits<int>::max ();
+    int max_sched_cores_per_assoc = std::numeric_limits<int>::max ();
 };
 
 // a class to track an association's usage in a particular queue

--- a/src/plugins/accounting.hpp
+++ b/src/plugins/accounting.hpp
@@ -54,6 +54,8 @@ extern "C" {
 #define D_QUEUE_MRES "max-resources-queue"
 #define D_ASSOC_MSJ  "max-sched-jobs-user-limit"
 #define D_QUEUE_MSJ  "max-sched-jobs-queue-limit"
+#define D_QUEUE_MSN  "max-sched-nodes-queue-limit"
+#define D_QUEUE_MSC  "max-sched-cores-queue-limit"
 
 // error messages for flux-accounting-specific validation messages
 #define MSG_INVALID_QUEUE \
@@ -90,6 +92,8 @@ public:
     int cur_run_jobs = 0;   // number of running jobs in queue
     int cur_nodes = 0;      // number of nodes across all running jobs in queue
     int cur_sched_jobs = 0; // number of jobs in SCHED state in queue
+    int cur_sched_nodes = 0;// number of nodes in SCHED state in queue
+    int cur_sched_cores = 0;// number of cores in SCHED state in queue
 };
 
 // all attributes are per-user/bank
@@ -148,6 +152,20 @@ public:
     bool under_queue_max_sched_jobs (const std::string &queue,
                                      std::map<std::string, Queue> &queues,
                                      int pending);
+    bool under_queue_max_sched_nodes (const Job &job,
+                                      const std::string &queue,
+                                      std::map<std::string, Queue> &queues);
+    bool under_queue_max_sched_cores (const Job &job,
+                                      const std::string &queue,
+                                      std::map<std::string, Queue> &queues);
+    bool under_queue_max_sched_nodes (const Job &job,
+                                      const std::string &queue,
+                                      std::map<std::string, Queue> &queues,
+                                      int pending);
+    bool under_queue_max_sched_cores (const Job &job,
+                                      const std::string &queue,
+                                      std::map<std::string, Queue> &queues,
+                                      int pending);
 };
 
 class Bank {

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -692,6 +692,7 @@ static void rec_q_cb (flux_t *h,
     char *queue = NULL;
     int min_nodes_per_job, max_nodes_per_job, max_time_per_job, priority;
     int max_running_jobs, max_nodes_per_assoc, max_sched_jobs;
+    int max_sched_nodes_per_assoc, max_sched_cores_per_assoc;
     json_t *data, *jtemp = NULL;
     json_error_t error;
     int num_data = 0;
@@ -714,7 +715,8 @@ static void rec_q_cb (flux_t *h,
         json_t *el = json_array_get(data, i);
 
         if (json_unpack_ex (el, &error, 0,
-                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
+                            "{s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i, "
+                            "s:i, s:i}",
                             "queue", &queue,
                             "min_nodes_per_job", &min_nodes_per_job,
                             "max_nodes_per_job", &max_nodes_per_job,
@@ -722,7 +724,11 @@ static void rec_q_cb (flux_t *h,
                             "priority", &priority,
                             "max_running_jobs", &max_running_jobs,
                             "max_nodes_per_assoc", &max_nodes_per_assoc,
-                            "max_sched_jobs", &max_sched_jobs) < 0) {
+                            "max_sched_jobs", &max_sched_jobs,
+                            "max_sched_nodes_per_assoc",
+                            &max_sched_nodes_per_assoc,
+                            "max_sched_cores_per_assoc",
+                            &max_sched_cores_per_assoc) < 0) {
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
             goto error;
         }
@@ -738,6 +744,8 @@ static void rec_q_cb (flux_t *h,
         q->max_running_jobs = max_running_jobs;
         q->max_nodes_per_assoc = max_nodes_per_assoc;
         q->max_sched_jobs = max_sched_jobs;
+        q->max_sched_nodes_per_assoc = max_sched_nodes_per_assoc;
+        q->max_sched_cores_per_assoc = max_sched_cores_per_assoc;
     }
 
     if (flux_respond (h, msg, NULL) < 0)

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include <vector>
 #include <sstream>
 #include <cstdint>
+#include <new>
 
 // custom Association class file
 #include "accounting.hpp"
@@ -317,6 +318,8 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
     int released_assoc_sched = 0;
     std::map<std::string, int> released_queue_run;
     std::map<std::string, int> released_queue_sched;
+    std::map<std::string, int> released_queue_sched_nodes;
+    std::map<std::string, int> released_queue_sched_cores;
 
     auto it = b->held_jobs.begin ();
     while (it != b->held_jobs.end ()) {
@@ -329,6 +332,8 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
         int job_assoc_sched = 0;
         int job_queue_run = 0;
         int job_queue_sched = 0;
+        int job_queue_sched_nodes = 0;
+        int job_queue_sched_cores = 0;
 
         // is the association under the max running jobs limit for the
         // queue the held job is submitted under?
@@ -363,6 +368,46 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
             }
             held_job.remove_dep (D_QUEUE_MSJ);
             job_queue_sched++;
+        }
+        // is association under the max SCHED nodes limit for the queue the
+        // held job is submitted under? cur_sched_nodes already reflects any
+        // jobs released earlier in this pass, because each released job's
+        // job.state.sched callback fires synchronously and increments the
+        // counter before we reach the next held job -- so no pending offset
+        // is needed (or correct) here
+        if (b->under_queue_max_sched_nodes (
+                                held_job,
+                                held_job.queue,
+                                queues,
+                                released_queue_sched_nodes[held_job.queue]) &&
+            held_job.contains_dep (D_QUEUE_MSN)) {
+            if (flux_jobtap_dependency_remove (p,
+                                               held_job.id,
+                                               D_QUEUE_MSN) < 0) {
+                dependency = D_QUEUE_MSN;
+                held_job_id = held_job.id;
+                goto error;
+            }
+            held_job.remove_dep (D_QUEUE_MSN);
+            job_queue_sched_nodes += held_job.nnodes;
+        }
+        // is association under the max SCHED cores limit for the queue the
+        // held job is submitted under?
+        if (b->under_queue_max_sched_cores (
+                                held_job,
+                                held_job.queue,
+                                queues,
+                                released_queue_sched_cores[held_job.queue]) &&
+            held_job.contains_dep (D_QUEUE_MSC)) {
+            if (flux_jobtap_dependency_remove (p,
+                                               held_job.id,
+                                               D_QUEUE_MSC) < 0) {
+                dependency = D_QUEUE_MSC;
+                held_job_id = held_job.id;
+                goto error;
+            }
+            held_job.remove_dep (D_QUEUE_MSC);
+            job_queue_sched_cores += held_job.ncores;
         }
         // is the association under the max nodes limit for the queue the
         // held job is submitted under?
@@ -432,6 +477,8 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
                 // counter
                 released_assoc_sched += job_assoc_sched;
                 released_queue_sched[held_job.queue] += job_queue_sched;
+                released_queue_sched_nodes[held_job.queue] += job_queue_sched_nodes;
+                released_queue_sched_cores[held_job.queue] += job_queue_sched_cores;
             }
             // the Job no longer has any flux-accounting dependencies on it and
             // is now actually being released to SCHED state; commit this job's
@@ -478,6 +525,12 @@ std::string join_strings (const std::vector<std::string> &vec,
         first = false;
     }
     return result;
+}
+
+
+static void free_job (void *arg)
+{
+    delete static_cast<Job *> (arg);
 }
 
 
@@ -907,16 +960,20 @@ static int priority_cb (flux_plugin_t *p,
     const char *project = NULL;
     int64_t priority;
     Association *b;
+    json_t *jobspec;
+    long int id;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s:i, s:i, s{s{s{s?s, s?s, s?s}}}}",
+                                "{s:i, s:i, s{s{s{s?s, s?s, s?s}}}, s:o, s:I}",
                                 "urgency", &urgency,
                                 "userid", &userid,
                                 "jobspec", "attributes", "system",
                                 "bank", &bank, "queue", &queue,
-                                "project", &project) < 0) {
+                                "project", &project,
+                                "jobspec", &jobspec,
+                                "id", &id) < 0) {
         flux_log (h,
                   LOG_ERR,
                   "flux_plugin_arg_unpack: %s",
@@ -1007,6 +1064,52 @@ static int priority_cb (flux_plugin_t *p,
                     return -1;
                 }
             }
+        }
+    }
+
+    Job *j = static_cast<Job *> (flux_jobtap_job_aux_get (
+                                                    p,
+                                                    FLUX_JOBTAP_CURRENT_JOB,
+                                                    "mf_priority:job_info"));
+    if (j == nullptr) {
+        // if the plugin was reloaded, we need to re-attach the Job aux item
+        // so later callbacks don't have to re-parse jobspec
+        j = new (std::nothrow) Job ();
+        if (j == nullptr) {
+            flux_jobtap_raise_exception (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "mf_priority",
+                                         0,
+                                         "%s: failed to allocate Job",
+                                         topic);
+            return -1;
+        }
+        if (j->count_resources (jobspec) < 0) {
+            delete j;
+            flux_jobtap_raise_exception (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "mf_priority",
+                                         0,
+                                         "%s: unable to count resources for "
+                                         "job",
+                                         topic);
+            return -1;
+        }
+        j->queue = queue ? queue : "";
+        j->id = id;
+        if (flux_jobtap_job_aux_set (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority:job_info",
+                                     j,
+                                     free_job) < 0) {
+            delete j;
+            flux_jobtap_raise_exception (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "mf_priority",
+                                         0,
+                                         "%s: failed to set Job aux item",
+                                         topic);
+            return -1;
         }
     }
 
@@ -1211,17 +1314,19 @@ static int new_cb (flux_plugin_t *p,
     flux_job_state_t state;
     json_t *jobspec = NULL;
     std::string queue_str;
+    long int id;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s:i, s:i, s{s{s{s?s, s?s, s?s}}}, s:o}",
+                                "{s:i, s:i, s{s{s{s?s, s?s, s?s}}}, s:o, s:I}",
                                 "userid", &userid,
                                 "state", &state,
                                 "jobspec", "attributes", "system",
                                 "bank", &bank, "queue", &queue,
                                 "project", &project,
-                                "jobspec", &jobspec) < 0) {
+                                "jobspec", &jobspec,
+                                "id", &id) < 0) {
         return flux_jobtap_reject_job (p, args, "unable to unpack bank arg");
     }
 
@@ -1306,6 +1411,41 @@ static int new_cb (flux_plugin_t *p,
     if (queue != NULL)
         queue_str = queue;
 
+    // attach a Job object so that callbacks can reference the job's properties
+    // without having to re-parse jobspec
+    Job *j = new (std::nothrow) Job ();
+    if (j == nullptr) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority",
+                                     0,
+                                     "%s: failed to allocate Job",
+                                     topic);
+        return -1;
+    }
+
+    if (j->count_resources (jobspec) < 0) {
+        delete j;
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority",
+                                     0,
+                                     "%s: unable to count resources",
+                                     topic);
+        return -1;
+    }
+    j->queue = queue_str;
+    j->id = id;
+    if (flux_jobtap_job_aux_set (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "mf_priority:job_info",
+                                 j,
+                                 free_job) < 0) {
+        delete j;
+        flux_log_error (h, "job.new: flux_jobtap_job_aux_set (job_info)");
+        return -1;
+    }
+
     if (state == FLUX_JOB_STATE_RUN) {
         // this job was already running; increment the association's running
         // jobs and resource counts
@@ -1335,6 +1475,9 @@ static int new_cb (flux_plugin_t *p,
         // jobs count
         b->cur_sched_jobs++;
         b->queue_usage[queue_str].cur_sched_jobs++;
+        // increment cur_sched_nodes/cores count for association in this queue
+        b->queue_usage[queue_str].cur_sched_nodes += j->nnodes;
+        b->queue_usage[queue_str].cur_sched_cores += j->ncores;
     }
 
     return 0;
@@ -1418,6 +1561,20 @@ static int depend_cb (flux_plugin_t *p,
                 goto error;
             job.add_dep (D_QUEUE_MSJ);
         }
+        if (!b->under_queue_max_sched_nodes (job, queue_str, queues)) {
+            // association is already at their max nodes in SCHED state limit
+            // across their running jobs in this queue; add a dependency
+            if (flux_jobtap_dependency_add (p, id, D_QUEUE_MSN) < 0)
+                goto error;
+            job.add_dep (D_QUEUE_MSN);
+        }
+        if (!b->under_queue_max_sched_cores (job, queue_str, queues)) {
+            // association is already at their max cores in SCHED state limit
+            // across their running jobs in this queue; add a dependency
+            if (flux_jobtap_dependency_add (p, id, D_QUEUE_MSC) < 0)
+                goto error;
+            job.add_dep (D_QUEUE_MSC);
+        }
         if (!b->under_queue_max_resources (job, queue_str, queues)) {
             // association is already at their max nodes limit across their
             // running jobs in this queue; add a dependency
@@ -1477,6 +1634,7 @@ static int sched_cb (flux_plugin_t *p,
 {
     Association *a;
     char *queue = NULL;
+    Job *j;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1507,10 +1665,26 @@ static int sched_cb (flux_plugin_t *p,
         return -1;
     }
 
+    j = static_cast<Job *> (
+            flux_jobtap_job_aux_get (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority:job_info"));
+    if (j == NULL) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority",
+                                     0,
+                                     "%s: job info missing",
+                                     topic);
+        return -1;
+    }
+
     // increment association's current SCHED jobs count
     a->cur_sched_jobs++;
     std::string queue_str = queue ? queue : "";
     a->queue_usage[queue_str].cur_sched_jobs++;
+    a->queue_usage[queue_str].cur_sched_nodes += j->nnodes;
+    a->queue_usage[queue_str].cur_sched_cores += j->ncores;
 
     return 0;
 }
@@ -1526,6 +1700,7 @@ static int run_cb (flux_plugin_t *p,
     json_t *jobspec = NULL;
     char *queue = NULL;
     std::string queue_str;
+    Job *j;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1551,6 +1726,20 @@ static int run_cb (flux_plugin_t *p,
                                      0, "job.state.run: bank info is " \
                                      "missing");
 
+        return -1;
+    }
+
+    j = static_cast<Job *> (
+            flux_jobtap_job_aux_get (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority:job_info"));
+    if (j == NULL) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority",
+                                     0,
+                                     "%s: job info missing",
+                                     topic);
         return -1;
     }
 
@@ -1585,8 +1774,10 @@ static int run_cb (flux_plugin_t *p,
 
     // decrement the association's current SCHED jobs count
     b->cur_sched_jobs--;
-    queue_str = queue ? queue : "";
     b->queue_usage[queue_str].cur_sched_jobs--;
+    // decrement the association's current SCHED resources in queue
+    b->queue_usage[queue_str].cur_sched_nodes -= j->nnodes;
+    b->queue_usage[queue_str].cur_sched_cores -= j->ncores;
     // check to see if any jobs held due to max_sched_jobs limit can now
     // have their dependency removed
     if (!b->held_jobs.empty ()) {
@@ -1817,6 +2008,7 @@ static int inactive_cb (flux_plugin_t *p,
     char *queue = NULL;
     std::string queue_str;
     flux_jobid_t jobid;
+    Job *j;
 
     flux_t *h = flux_jobtap_get_flux (p);
     if (flux_plugin_arg_unpack (args,
@@ -1846,6 +2038,19 @@ static int inactive_cb (flux_plugin_t *p,
 
         return -1;
     }
+
+    j = static_cast<Job *> (
+            flux_jobtap_job_aux_get (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority:job_info"));
+    if (j == NULL) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "mf_priority",
+                                     0,
+                                     "%s: job info missing", topic);
+        return -1;
+    }
     // if a queue cannot be found, just set it to ""
     queue_str = queue ? queue : "";
 
@@ -1868,6 +2073,8 @@ static int inactive_cb (flux_plugin_t *p,
             // contributing to since it never ran
             b->cur_sched_jobs--;
             b->queue_usage[queue_str].cur_sched_jobs--;
+            b->queue_usage[queue_str].cur_sched_nodes -= j->nnodes;
+            b->queue_usage[queue_str].cur_sched_cores -= j->ncores;
             // check to see if any jobs held due to the limits above can now
             // have their dependency removed
             if (!b->held_jobs.empty ()) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -97,6 +97,7 @@ TESTSCRIPTS = \
 	t1092-mf-priority-afterany-partial-release.t \
 	t1093-config-table-commands.t \
 	t1094-edit-user-properties.t \
+	t1095-max-sched-resources-queue-dependency.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -92,7 +92,9 @@ test_expect_success 'create fake_payload.py' '
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -46,7 +46,9 @@ test_expect_success 'add a default queue and send it to the plugin' '
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -46,7 +46,9 @@ test_expect_success 'add a default queue and send it to the plugin' '
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -46,7 +46,9 @@ test_expect_success 'add a default queue and send it to the plugin' '
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -82,7 +82,9 @@ test_expect_success 'add a default queue and send it to the plugin' '
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -81,7 +81,9 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1015-mf-priority-urgency.t
+++ b/t/t1015-mf-priority-urgency.t
@@ -41,7 +41,9 @@ test_expect_success 'add a default queue and send it to the plugin' '
 				"priority": 0,
 				"max_running_jobs": 2147483647,
 				"max_nodes_per_assoc": 2147483647,
-				"max_sched_jobs": 2147483647
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1095-max-sched-resources-queue-dependency.t
+++ b/t/t1095-max-sched-resources-queue-dependency.t
@@ -1,0 +1,482 @@
+#!/bin/bash
+
+test_description='test limiting number of resources in SCHED per-queue'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+# Setting max-sched-nodes and max-sched-cores to 4 means that an association
+# can have up to 4 nodes and 4 cores in SCHED state in the "pdebug" queue at
+# any given time.
+test_expect_success 'add a queue to DB' '
+	flux account add-queue pdebug \
+		--max-sched-nodes-per-assoc=4 \
+		--max-sched-cores-per-assoc=4
+'
+
+test_expect_success 'add banks to DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to DB' '
+	flux account add-user \
+		--username=user1 \
+		--bank=A \
+		--userid=50001 \
+		--queues=pdebug \
+		--max-active-jobs=10000 \
+		--max-running-jobs=1000
+'
+
+test_expect_success 'load and initialize priority plugin' '
+	flux jobtap load -r .priority-default \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+test_expect_success 'configure flux with queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'queue is properly configured in plugin internal data structure' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".queues.pdebug.max_sched_nodes_per_assoc == 4" <query.json &&
+	jq -e \
+		".queues.pdebug.max_sched_cores_per_assoc == 4" <query.json
+'
+
+# This job will proceed to RUN immediately but take up all current resources
+# of this instance, so any job submitted while this job is running will be
+# placed in SCHED state.
+test_expect_success 'first job proceeds to RUN immediately' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc
+'
+
+# Since the first job is currently running, this job is placed in SCHED state
+# until enough resources are freed up for this job to run.
+test_expect_success 'second job gets placed in SCHED state' '
+	job2=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority
+'
+
+test_expect_success 'association has 4 nodes and 4 cores in SCHED state' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_nodes == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_cores == 4" <query.json
+'
+
+# Since the association already has 4 nodes and 4 cores in SCHED state, this
+# job has dependencies placed on it.
+test_expect_success 'third submitted job has SCHED-state-related dependency' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${job3} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${job3} dependency-add
+'
+
+# When the first job gets cancelled, the second job can proceed to run because
+# enough resources are freed.
+test_expect_success 'second job receives alloc event' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job2} alloc
+'
+
+# When the second job proceeds to run, the job.state.run callback checks to see
+# if any other jobs held due to the max_sched_nodes and max_sched_cores
+# per-queue limit can have their dependency removed.
+test_expect_success 'third job has max-sched-nodes and max-sched-cores dependencies removed' '
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${job3} dependency-remove &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${job3} dependency-remove
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job2} ${job3} &&
+	flux job wait-event -t 5 ${job2} clean &&
+	flux job wait-event -t 5 ${job3} clean
+'
+
+test_expect_success 'association job counts are correct' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_run_jobs == 0" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_sched_jobs == 0" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_sched_nodes == 0" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_sched_cores == 0" <query.json
+'
+
+# In this set of tests, we make sure that with two queues, a job held in queue
+# A due to a max SCHED limit is not released when a job in B transitions to RUN
+# state.
+test_expect_success 'edit pdebug limits' '
+	flux account edit-queue pdebug \
+		--max-sched-nodes-per-assoc=2 \
+		--max-sched-cores-per-assoc=2
+'
+
+test_expect_success 'add another queue and give association access to that queue' '
+	flux account add-queue pbatch \
+		--max-sched-nodes-per-assoc=2 \
+		--max-sched-cores-per-assoc=2
+	flux account edit-user user1 --queues=pdebug,pbatch &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'update flux with the new queue' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	[queues.pbatch]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'association hits limits in both queues' '
+	pdebug_job1=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	 flux job wait-event -t 5 ${pdebug_job1} alloc &&
+	pbatch_job1=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pbatch sleep inf) &&
+	 flux job wait-event -t 5 ${pbatch_job1} alloc &&
+	pdebug_job2=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	 flux job wait-event -t 5 ${pdebug_job2} priority &&
+	pbatch_job2=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pbatch sleep inf) &&
+	 flux job wait-event -t 5 ${pbatch_job2} priority
+'
+
+test_expect_success 'jobs have dependencies placed on them after limits are hit' '
+	pdebug_job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	 flux job wait-event -t 5 \
+		 --match-context=description="max-sched-nodes-queue-limit" \
+		 ${pdebug_job3} dependency-add &&
+	 flux job wait-event -t 5 \
+		 --match-context=description="max-sched-cores-queue-limit" \
+		 ${pdebug_job3} dependency-add &&
+	pbatch_job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pbatch sleep inf) &&
+	 flux job wait-event -t 5 \
+		 --match-context=description="max-sched-nodes-queue-limit" \
+		 ${pbatch_job3} dependency-add &&
+	 flux job wait-event -t 5 \
+		 --match-context=description="max-sched-cores-queue-limit" \
+		 ${pbatch_job3} dependency-add
+'
+
+test_expect_success 'ensure job counts for association are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 6" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 2" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_run_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pbatch\"].cur_run_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pdebug\"].cur_sched_jobs == 1" <query.json &&
+	jq -e ".mf_priority_map[] | \
+		select(.userid == 50001) | \
+		.banks[0].queue_usage[\"pbatch\"].cur_sched_jobs == 1" <query.json
+'
+
+test_expect_success 'job1 in pdebug is cancelled; job2 in pdebug can now run' '
+	flux cancel ${pdebug_job1} &&
+	flux job wait-event -t 5 ${pdebug_job2} alloc
+'
+
+test_expect_success 'held job in pbatch is still not released' '
+	pbatch_job3_dec=$(flux job id -t dec ${pbatch_job3}) &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 5" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${pbatch_job3_dec}\"].deps \
+			| length == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${pbatch_job3_dec}\"].deps[0] \
+			== \"max-sched-nodes-queue-limit\"" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${pbatch_job3_dec}\"].deps[1] \
+			== \"max-sched-cores-queue-limit\"" <query.json
+'
+
+test_expect_success 'job2 in pdebug cancelled; job2 in pbatch can run' '
+	flux cancel ${pdebug_job2} &&
+	flux job wait-event -t 5 ${pbatch_job2} alloc
+'
+
+test_expect_success 'dependency removed from job3 in pbatch now that job2 in pbatch runs' '
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${pbatch_job3} dependency-remove &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${pbatch_job3} dependency-remove &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${pbatch_job1} ${pbatch_job2} ${pdebug_job3} ${pbatch_job3} &&
+	flux job wait-event -t 5 ${pbatch_job1} clean &&
+	flux job wait-event -t 5 ${pbatch_job2} clean &&
+	flux job wait-event -t 5 ${pdebug_job3} clean &&
+	flux job wait-event -t 5 ${pbatch_job3} clean
+'
+
+test_expect_success 'edit properties of pdebug queue' '
+	flux account edit-queue pdebug \
+		--max-sched-nodes-per-assoc=4 \
+		--max-sched-cores-per-assoc=4 &&
+	flux account-priority-update -p ${DB}
+'
+
+# This set of tests ensures that an association's cur_sched_nodes and
+# cur_sched_cores counts are correctly counted after a plugin restart.
+test_expect_success 'submit enough jobs to keep one in SCHED state' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority
+'
+
+test_expect_success 'association has 4 nodes and 4 cores in SCHED state' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_nodes == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_cores == 4" <query.json
+'
+
+test_expect_success 'reload plugin' '
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load ${MULTI_FACTOR_PRIORITY} \
+		"config=$(flux account export-json)"
+'
+
+test_expect_success 'association still has 4 nodes and 4 cores in SCHED state after reload' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_nodes == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_cores == 4" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} ${job2} &&
+	flux job wait-event -t 5 ${job1} clean &&
+	flux job wait-event -t 5 ${job2} clean
+'
+
+# Verify that when a SCHED job transitions out of SCHED, the freed per-queue
+# sched-node/core headroom is accurate when compared to a subsequent held job
+test_expect_success 'reset pdebug to 4 sched nodes/cores' '
+	flux account edit-queue pdebug \
+		--max-sched-nodes-per-assoc=4 \
+		--max-sched-cores-per-assoc=4 &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'running job occupies all resources' '
+	rjob=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${rjob} alloc
+'
+
+# ssjob sits in SCHED and consumes all resources available to be in SCHED
+test_expect_success 'sched job consumes all per-queue sched headroom' '
+	ssjob=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${ssjob} priority
+'
+
+# both jobs here will have both SCHED-related resource limits applied to them
+test_expect_success 'heldA and heldB both pick up node and core dependencies' '
+	heldA=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${heldA} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${heldA} dependency-add &&
+	heldB=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${heldB} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${heldB} dependency-add
+'
+
+# Cancel the running job. ssjob transitions to RUN, freeing all 4 sched
+# nodes/cores. In the resulting check_and_release_held_jobs () pass, heldA
+# is released first; its job.state.sched callback fires synchronously and bumps
+# cur_sched_nodes/cores to 2 before heldB is evaluated. heldB must then release
+# because cur_sched_nodes (2) + heldB.nnodes (2) == 4, which is <= 4
+test_expect_success 'cancel running job; sched job runs and both held jobs release' '
+	flux cancel ${rjob} &&
+	flux job wait-event -t 5 ${ssjob} alloc &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${heldA} dependency-remove &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${heldA} dependency-remove &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-nodes-queue-limit" \
+		${heldB} dependency-remove &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-cores-queue-limit" \
+		${heldB} dependency-remove
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${ssjob} ${heldA} ${heldB} &&
+	flux job wait-event -t 5 ${ssjob} clean &&
+	flux job wait-event -t 5 ${heldA} clean &&
+	flux job wait-event -t 5 ${heldB} clean
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

As mentioned in #864, the priority plugin does not enforce a limit on the max number of resources (nodes or cores) an association can have in SCHED state across all of their active jobs in a queue.

---

This PR adds support for such a limit. To do this, it unpacks both the `max_sched_nodes_per_assoc` and `max_sched_cores_per_assoc` properties for each queue in the plugin and stores it in each Queue object. New methods to check an association's current number of resources in SCHED state in a particular queue and whether a new job would put them over this limit are added and called when a job enters `job.state.depend`. These counters are incremented and subsequently decremented in `job.state.sched` and `job.state.run`, respectively. New members to keep track of the association's *current* number of resources in SCHED state in a particular queue are added to the QueueUsage class.

Some tests that work through hitting certain resource limits in one queue and multiple queues are also added.