### PR TITLE
commands: add missing shebangs

### DIFF
--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ###############################################################
 # Copyright 2022 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ###############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)


### PR DESCRIPTION
Problem: `flux-account.py` and `flux-account-service.py` are executable but have no shebangs. This can lead to the exceutable bit being stripped during RPM builds.

Add shebangs to match other Python command scripts.

Unless there is a reason why all of the Python scripts in `src/cmd/` have shebangs except for these two?