### PR TITLE
plugin: `goto error` on unpack fail instead of continuing to initialize `queues` map

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -684,8 +684,10 @@ static void rec_q_cb (flux_t *h,
                             "priority", &priority,
                             "max_running_jobs", &max_running_jobs,
                             "max_nodes_per_assoc", &max_nodes_per_assoc,
-                            "max_sched_jobs", &max_sched_jobs) < 0)
+                            "max_sched_jobs", &max_sched_jobs) < 0) {
             flux_log (h, LOG_ERR, "mf_priority unpack: %s", error.text);
+            goto error;
+        }
 
         Queue *q;
         q = &queues[queue];

--- a/t/t1001-mf-priority-basic.t
+++ b/t/t1001-mf-priority-basic.t
@@ -86,10 +86,13 @@ test_expect_success 'create fake_payload.py' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}

--- a/t/t1002-mf-priority-small-no-tie.t
+++ b/t/t1002-mf-priority-small-no-tie.t
@@ -40,10 +40,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}

--- a/t/t1003-mf-priority-small-tie.t
+++ b/t/t1003-mf-priority-small-tie.t
@@ -40,10 +40,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}

--- a/t/t1004-mf-priority-small-tie-all.t
+++ b/t/t1004-mf-priority-small-tie-all.t
@@ -40,10 +40,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}

--- a/t/t1005-max-jobs-limits.t
+++ b/t/t1005-max-jobs-limits.t
@@ -76,10 +76,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}

--- a/t/t1012-mf-priority-load.t
+++ b/t/t1012-mf-priority-load.t
@@ -67,10 +67,15 @@ test_expect_success 'create fake_payload.py' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647,
+				"max_sched_nodes_per_assoc": 2147483647,
+				"max_sched_cores_per_assoc": 2147483647
 			}
 		]
 	}

--- a/t/t1013-mf-priority-queues.t
+++ b/t/t1013-mf-priority-queues.t
@@ -43,6 +43,24 @@ test_expect_success 'add some banks to the DB' '
 	flux account add-bank --parent-bank=root account2 1
 '
 
+test_expect_success 'sending malformed queue information raises error' '
+	cat <<-EOF >fake_payload.py
+	import flux
+	import json
+
+	bulk_queue_data = {
+		"data" : [
+			{
+				"queue": "bad"
+			}
+		]
+	}
+	flux.Flux().rpc("job-manager.mf_priority.rec_q_update", json.dumps(bulk_queue_data)).get()
+	EOF
+	test_must_fail flux python fake_payload.py > bad_queue_data.err 2>&1 &&
+	flux dmesg | grep "mf_priority unpack:"
+'
+
 test_expect_success 'add some queues to the DB' '
 	flux account add-queue standby --priority=0 &&
 	flux account add-queue expedite --priority=10000 &&

--- a/t/t1014-mf-priority-dne.t
+++ b/t/t1014-mf-priority-dne.t
@@ -75,10 +75,13 @@ test_expect_success 'send the user/bank information to the plugin without reprio
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}

--- a/t/t1015-mf-priority-urgency.t
+++ b/t/t1015-mf-priority-urgency.t
@@ -35,10 +35,13 @@ test_expect_success 'add a default queue and send it to the plugin' '
 		"data" : [
 			{
 				"queue": "default",
-				"priority": 0,
 				"min_nodes_per_job": 0,
 				"max_nodes_per_job": 5,
-				"max_time_per_job": 64000
+				"max_time_per_job": 64000,
+				"priority": 0,
+				"max_running_jobs": 2147483647,
+				"max_nodes_per_assoc": 2147483647,
+				"max_sched_jobs": 2147483647
 			}
 		]
 	}


### PR DESCRIPTION
#### Problem

If `json_unpack_ex ()` fails (e.g. due to a protocol version mismatch), then the `queues` map is still viable to be initialized with potentially garbage values.

---

This PR just updates the callback to `goto error` if `json_unpack_ex ()` fails unpacking information from the RPC containing queue data from the flux-accounting database. As a result, some of the tests in the testsuite that generate this payload manually have also been updated to contain the correct information that the flux-accounting database would be sending to the plugin via RPC.