### PR TITLE
NEWS: add release notes for `v0.58.0`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,41 @@
+flux-accounting version 0.58.0 - 2026-06-02
+-------------------------------------------
+
+#### Features
+
+* `view-bank`: add `active` column, optional argument to filter for only
+active users (#862)
+
+* database: add new per-queue property for max resources in SCHED state (#869)
+
+#### Fixes
+
+* `view-job-records`: add dynamic width sizing for columns (#857)
+
+* python: use `INTEGER_MAX` in bindings in place of raw value (#870)
+
+* commands: add missing shebangs (#873)
+
+* plugin: add pending-offset limit checks when potentially releasing jobs
+(#875)
+
+* plugin: `goto error` on unpack fail instead of continuing to initialize
+`queues` map (#876)
+
+* `data_reader_db`: fix job usage overflow on very large job usage values
+(#879)
+
+* plugin: miscellaneous fixes to releasing jobs in SCHED state (#880)
+
+#### Testsuite
+
+* `docker-run-checks.sh`: use `el10` by default
+
+* github: bump the github-actions group with 2 updates (#863)
+
+* github: bump crate-ci/typos from 1.46.0 to 1.47.0 in the github-actions
+group (#877)
+
 flux-accounting version 0.57.2 - 2026-04-16
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.58.0`.

---

This PR adds some release notes. Once this lands, I will create an annotated tag with the following:

```console
git tag -a v0.58.0 -m "Tag v0.58.0" && git push upstream v0.58.0
```

Note that this PR assumes landing of #880 first.