### PR TITLE
plugin: miscellaneous fixes to releasing jobs in SCHED state

### DIFF
--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -303,6 +303,16 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
     // fire, so without this local counter, a second held job would observe the
     // same headroom as the first and be released even though the limit no
     // longer permits it.
+    //
+    // A held job may carry more than one flux-accounting dependency, and it is
+    // only truly released to SCHED state once *all* of them are removed. We
+    // must therefore not reserve headroom for a job that had one dependency
+    // removed but still retains another: doing so would consume limit headroom
+    // on behalf of a job that is not actually entering SCHED state, wrongly
+    // keeping subsequent eligible jobs held. To avoid this, each iteration
+    // accumulates this job's would-be contributions into per-job temporaries
+    // and only folds them into the pass-wide counters below once the job is
+    // confirmed to have no remaining dependencies.
     int released_assoc_run = 0;
     int released_assoc_sched = 0;
     std::map<std::string, int> released_queue_run;
@@ -312,6 +322,11 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
     while (it != b->held_jobs.end ()) {
         // grab held Job object
         Job &held_job = *it;
+
+        // per-job pending contributions, which are only committed to the
+        // pass-wide counters if this job ends up fully released
+        int job_assoc_run = 0;
+        int job_queue_run = 0;
 
         // is the association under the max running jobs limit for the
         // queue the held job is submitted under?
@@ -327,7 +342,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
                 goto error;
             }
             held_job.remove_dep (D_QUEUE_MRJ);
-            released_queue_run[held_job.queue]++;
+            job_queue_run++;
         }
         // is association under the max SCHED jobs limit for the queue the
         // held job is submitted under, accounting for jobs already released
@@ -370,7 +385,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
                 goto error;
             }
             held_job.remove_dep (D_ASSOC_MRJ);
-            released_assoc_run++;
+            job_assoc_run++;
         }
         // is association under their max SCHED jobs limit, accounting for
         // jobs already released in this pass?
@@ -400,14 +415,20 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
             held_job.remove_dep (D_ASSOC_MRES);
         }
 
-        if (held_job.deps.empty ())
-            // the Job no longer has any flux-accounting dependencies on
-            // it; remove it from the Association's vector of held jobs
-            // (erase () will return the next valid iterator)
+        if (held_job.deps.empty ()) {
+            // the Job no longer has any flux-accounting dependencies on it and
+            // is now actually being released to SCHED state; commit this job's
+            // pending contributions to the pass-wide counters so subsequent
+            // held jobs see the correct, headroom for each limit
+            released_assoc_run += job_assoc_run;
+            released_queue_run[held_job.queue] += job_queue_run;
+            // remove it from the Association's vector of held jobs (erase ()
+            // will return the next valid iterator)
             it = b->held_jobs.erase (it);
-        else
-            // the job did not meet all requirements to be released;
-            // move onto the next Job
+        } else
+            // the job did not meet all requirements to be released; move onto
+            // the next Job without reserving any headroom on its behalf, since
+            // it is not actually entering SCHED state
             ++it;
     }
     return 0;

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -326,7 +326,9 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
         // per-job pending contributions, which are only committed to the
         // pass-wide counters if this job ends up fully released
         int job_assoc_run = 0;
+        int job_assoc_sched = 0;
         int job_queue_run = 0;
+        int job_queue_sched = 0;
 
         // is the association under the max running jobs limit for the
         // queue the held job is submitted under?
@@ -347,9 +349,10 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
         // is association under the max SCHED jobs limit for the queue the
         // held job is submitted under, accounting for jobs already released
         // in this pass?
-        if (b->under_queue_max_sched_jobs (held_job.queue,
-                                           queues,
-                                           released_queue_sched[held_job.queue])
+        if (b->under_queue_max_sched_jobs (
+                                        held_job.queue,
+                                        queues,
+                                        released_queue_sched[held_job.queue])
             && held_job.contains_dep (D_QUEUE_MSJ)) {
             if (flux_jobtap_dependency_remove (p,
                                                held_job.id,
@@ -359,7 +362,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
                 goto error;
             }
             held_job.remove_dep (D_QUEUE_MSJ);
-            released_queue_sched[held_job.queue]++;
+            job_queue_sched++;
         }
         // is the association under the max nodes limit for the queue the
         // held job is submitted under?
@@ -399,7 +402,7 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
                 goto error;
             }
             held_job.remove_dep (D_ASSOC_MSJ);
-            released_assoc_sched++;
+            job_assoc_sched++;
         }
         // will association stay under or at their overall max resources limit
         // by releasing this job?
@@ -416,6 +419,20 @@ static int check_and_release_held_jobs (flux_plugin_t *p, Association *b)
         }
 
         if (held_job.deps.empty ()) {
+            // the job no longer has any flux-accounting dependencies on it;
+            // check the state to see if it has any other dependencies, and if
+            // so, use a speculative counter as to not wrongly release more
+            // jobs than are eligible
+            flux_plugin_arg_t *job_info = flux_jobtap_job_lookup (p, held_job.id);
+            int state;
+            flux_plugin_arg_unpack (job_info, FLUX_PLUGIN_ARG_IN,
+                                    "{s:i}", "state", &state);
+            if (state != FLUX_JOB_STATE_SCHED) {
+                // the job is not actually in SCHED state, so use a speculative
+                // counter
+                released_assoc_sched += job_assoc_sched;
+                released_queue_sched[held_job.queue] += job_queue_sched;
+            }
             // the Job no longer has any flux-accounting dependencies on it and
             // is now actually being released to SCHED state; commit this job's
             // pending contributions to the pass-wide counters so subsequent

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1816,6 +1816,23 @@ static int inactive_cb (flux_plugin_t *p,
                             cancelled_job),
             b->held_jobs.end ()
         );
+        if (flux_jobtap_job_event_posted (p, FLUX_JOBTAP_CURRENT_JOB, "priority")) {
+            // this job was actually in SCHED state, so we need to decrement
+            // the SCHED counts for the association that this job is
+            // contributing to since it never ran
+            b->cur_sched_jobs--;
+            b->queue_usage[queue_str].cur_sched_jobs--;
+            // check to see if any jobs held due to the limits above can now
+            // have their dependency removed
+            if (!b->held_jobs.empty ()) {
+                if (check_and_release_held_jobs (p, b) < 0) {
+                    flux_log_error (h,
+                                    "%s: error checking and releasing held "
+                                    "jobs for association",
+                                    topic);
+                }
+            }
+        }
         return 0;
     }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -94,6 +94,7 @@ TESTSCRIPTS = \
 	t1089-update-fshare-large-usage.t \
 	t1090-mf-priority-assoc-partial-release.t \
 	t1091-mf-priority-queue-partial-release.t \
+	t1092-mf-priority-afterany-partial-release.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -92,6 +92,8 @@ TESTSCRIPTS = \
 	t1087-max-sched-resources-queue-basic.t \
 	t1088-issue874.t \
 	t1089-update-fshare-large-usage.t \
+	t1090-mf-priority-assoc-partial-release.t \
+	t1091-mf-priority-queue-partial-release.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1090-mf-priority-assoc-partial-release.t
+++ b/t/t1090-mf-priority-assoc-partial-release.t
@@ -1,0 +1,355 @@
+#!/bin/bash
+
+test_description='test partial release of held jobs in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+test_expect_success 'add a queue to DB' '
+	flux account add-queue pdebug
+'
+
+test_expect_success 'add banks to DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user \
+		--username=user1 \
+		--bank=A \
+		--userid=50001 \
+		--queues=pdebug \
+		--max-active-jobs=10000 \
+		--max-running-jobs=9999
+'
+
+test_expect_success 'configure flux with queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'load and initialize priority plugin' '
+	flux jobtap load -r .priority-default \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+# This set of tests makes sure that if an association has held jobs due to
+# max_sched_jobs, their counters for current SCHED jobs are accurate as jobs
+# are released
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json
+'
+
+test_expect_success 'edit max_sched_jobs to 2' '
+	flux account edit-user user1 --max-sched-jobs=2 &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'submit enough jobs to take up max_sched_jobs limit' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority &&
+	job3=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job3} priority
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in SCHED' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json
+'
+
+test_expect_success 'jobs are held with max-sched-jobs-user-limit' '
+	job4=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job4} dependency-add &&
+	job5=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job5} dependency-add &&
+	job6=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job6} dependency-add
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in SCHED, 3 jobs in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 6" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 3" <query.json
+'
+
+# If the two jobs in SCHED state are cancelled, then job4 and job5 (the first
+# two held jobs due to the max_sched_jobs limit) can be released and held in
+# SCHED, but job6 will still be held in DEPEND
+test_expect_success 'cancel job2 and job3; job4 and job5 proceed to SCHED' '
+	flux cancel ${job2} ${job3} &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job4} dependency-remove && 
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job5} dependency-remove
+'
+
+test_expect_success 'job6 still held in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json &&
+	job6_dec=$(flux job id -t dec ${job6}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job6_dec}\"].deps[0] \
+			== \"max-sched-jobs-user-limit\"" <query.json
+'
+
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json
+'
+
+test_expect_success 'if another job in SCHED state is cancelled, job6 can proceed to SCHED' '
+	flux cancel ${job4} &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job6} dependency-remove
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in SCHED' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} ${job5} ${job6} &&
+	flux job wait-event -t 5 ${job1} clean &&
+	flux job wait-event -t 5 ${job5} clean &&
+	flux job wait-event -t 5 ${job6} clean
+'
+
+test_expect_success 'association has 0 jobs in RUN, 0 jobs in SCHED' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 0" <query.json
+'
+
+# This next set of tests replicates the same scenario but with the
+# max-running-jobs limit.
+test_expect_success 'reset max_sched_jobs, set max_running_jobs to 1' '
+	flux account edit-user user1 --max-sched-jobs=-1 --max-running-jobs=1 &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'new limits for association are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].max_sched_jobs == 2147483647" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].max_run_jobs == 1" <query.json
+'
+
+test_expect_success 'submit 3 jobs; 1 will proceed to RUN, 2 will be held in DEPEND' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-running-jobs-user-limit" \
+		${job2} dependency-add
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-running-jobs-user-limit" \
+		${job3} dependency-add
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 2" <query.json &&
+	job2_dec=$(flux job id -t dec ${job2}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job2_dec}\"].deps[0] \
+			== \"max-running-jobs-user-limit\"" <query.json &&
+	job3_dec=$(flux job id -t dec ${job3}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job3_dec}\"].deps[0] \
+			== \"max-running-jobs-user-limit\"" <query.json
+'
+
+test_expect_success 'job2 can proceed to RUN after job1 is cancelled' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job1} clean &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-running-jobs-user-limit" \
+		${job2} dependency-remove
+'
+
+test_expect_success 'association has 1 job in RUN, 1 job in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job3_dec}\"].deps[0] \
+			== \"max-running-jobs-user-limit\"" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job2} ${job3} &&
+	flux job wait-event -t 5 ${job2} clean &&
+	flux job wait-event -t 5 ${job3} clean
+'
+
+test_expect_success 'association has 0 jobs across all their counts' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 0" <query.json
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done

--- a/t/t1091-mf-priority-queue-partial-release.t
+++ b/t/t1091-mf-priority-queue-partial-release.t
@@ -1,0 +1,339 @@
+#!/bin/bash
+
+test_description='test partial release of held jobs in a queue in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+test_expect_success 'add a queue to DB' '
+	flux account add-queue pdebug
+'
+
+test_expect_success 'add banks to DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user \
+		--username=user1 \
+		--bank=A \
+		--userid=50001 \
+		--queues=pdebug \
+		--max-active-jobs=10000 \
+		--max-running-jobs=9999
+'
+
+test_expect_success 'configure flux with queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'load and initialize priority plugin' '
+	flux jobtap load -r .priority-default \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+# This set of tests makes sure that if an association has held jobs due to
+# max_sched_jobs, their counters for current SCHED jobs are accurate as jobs
+# are released
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json
+'
+
+test_expect_success 'edit max_sched_jobs of the queue to 2' '
+	flux account edit-queue pdebug --max-sched-jobs=2 &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'submit enough jobs to take up max_sched_jobs limit' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority &&
+	job3=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job3} priority
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in SCHED' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json
+'
+
+test_expect_success 'jobs are held with max-sched-jobs-queue-limit' '
+	job4=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job4} dependency-add &&
+	job5=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job5} dependency-add &&
+	job6=$(flux python ${SUBMIT_AS} 50001 -N2 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job6} dependency-add
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in SCHED, 3 jobs in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 6" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 3" <query.json
+'
+
+# If the two jobs in SCHED state are cancelled, then job4 and job5 (the first
+# two held jobs due to the max_sched_jobs limit) can be released and held in
+# SCHED, but job6 will still be held in DEPEND
+test_expect_success 'cancel job2 and job3; job4 and job5 proceed to SCHED' '
+	flux cancel ${job2} ${job3} &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job4} dependency-remove && 
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job5} dependency-remove
+'
+
+test_expect_success 'job6 still held in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json &&
+	job6_dec=$(flux job id -t dec ${job6}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job6_dec}\"].deps[0] \
+			== \"max-sched-jobs-queue-limit\"" <query.json
+'
+
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json
+'
+
+test_expect_success 'if another job in SCHED state is cancelled, job6 can proceed to SCHED' '
+	flux cancel ${job4} &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job6} dependency-remove
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in SCHED' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 2" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job1} ${job5} ${job6} &&
+	flux job wait-event -t 5 ${job1} clean &&
+	flux job wait-event -t 5 ${job5} clean &&
+	flux job wait-event -t 5 ${job6} clean
+'
+
+test_expect_success 'association has 0 jobs in RUN, 0 jobs in SCHED' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 0" <query.json
+'
+
+# This next set of tests replicates the same scenario but with the
+# per-queue max-running-jobs limit.
+test_expect_success 'set queue max-running-jobs limit' '
+	flux account edit-queue pdebug --max-sched-jobs=-1 --max-running-jobs=1 &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'new limits for association are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".queues.pdebug.max_running_jobs == 1" <query.json
+'
+
+test_expect_success 'submit 3 jobs; 1 will proceed to RUN, 2 will be held in DEPEND' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-run-jobs-queue" \
+		${job2} dependency-add
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-run-jobs-queue" \
+		${job3} dependency-add
+'
+
+test_expect_success 'association has 1 job in RUN, 2 jobs in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 3" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 2" <query.json &&
+	job2_dec=$(flux job id -t dec ${job2}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job2_dec}\"].deps[0] \
+			== \"max-run-jobs-queue\"" <query.json &&
+	job3_dec=$(flux job id -t dec ${job3}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job3_dec}\"].deps[0] \
+			== \"max-run-jobs-queue\"" <query.json
+'
+
+test_expect_success 'job2 can proceed to RUN after job1 is cancelled' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job1} clean &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-run-jobs-queue" \
+		${job2} dependency-remove
+'
+
+test_expect_success 'association has 1 job in RUN, 1 job in DEPEND' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job3_dec}\"].deps[0] \
+			== \"max-run-jobs-queue\"" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job2} ${job3} &&
+	flux job wait-event -t 5 ${job2} clean &&
+	flux job wait-event -t 5 ${job3} clean
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done

--- a/t/t1092-mf-priority-afterany-partial-release.t
+++ b/t/t1092-mf-priority-afterany-partial-release.t
@@ -1,0 +1,384 @@
+#!/bin/bash
+
+test_description='test partial release of held jobs in priority plugin'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+test_expect_success 'add a queue to DB' '
+	flux account add-queue pdebug
+'
+
+test_expect_success 'add banks to DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user \
+		--username=user1 \
+		--bank=A \
+		--userid=50001 \
+		--queues=pdebug \
+		--max-active-jobs=10000 \
+		--max-running-jobs=9999 \
+		--max-sched-jobs=1
+'
+
+test_expect_success 'configure flux with queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'load and initialize priority plugin' '
+	flux jobtap load -r .priority-default \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+# This set of tests makes sure that if an association has held jobs due to
+# max_sched_jobs, their counters for current SCHED jobs are accurate as jobs
+# are released
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].max_sched_jobs == 1" <query.json
+'
+
+test_expect_success 'submit enough jobs to take up max_sched_jobs limit' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority
+'
+
+test_expect_success 'jobs are held with both afterany dependency and max-sched-jobs limit' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -N4 --dependency=afterany:${job1} --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job3} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="after-finish=${job1}" \
+		${job3} dependency-add &&
+	job4=$(flux python ${SUBMIT_AS} 50001 -N4 --dependency=afterany:${job1} --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job4} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="after-finish=${job1}" \
+		${job4} dependency-add
+'
+
+test_expect_success 'association has 1 job in RUN, 1 in SCHED, and 2 in DEPEND'  '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 2" <query.json
+'
+
+test_expect_success 'held jobs have correct accounting dependencies' '
+	job3_dec=$(flux job id -t dec ${job3}) &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job3_dec}\"].deps[0] \
+			== \"max-sched-jobs-user-limit\"" <query.json &&
+	job4_dec=$(flux job id -t dec ${job4}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job4_dec}\"].deps[0] \
+			== \"max-sched-jobs-user-limit\"" <query.json
+'
+
+test_expect_success 'cancel job2 in SCHED; job3 has its accounting dependency removed' '
+	flux cancel ${job2} &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-user-limit" \
+		${job3} dependency-remove
+'
+
+test_expect_success 'job4 still has its max-sched-jobs dependency' '
+	job4_dec=$(flux job id -t dec ${job4}) &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job4_dec}\"].deps[0] \
+			== \"max-sched-jobs-user-limit\"" <query.json
+'
+
+test_expect_success 'cancel job1; job3 can now proceed to RUN' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job3} alloc
+'
+
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job3} ${job4} &&
+	flux job wait-event -t 5 ${job3} clean &&
+	flux job wait-event -t 5 ${job4} clean
+'
+
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json
+'
+
+# This set of tests repeat the same scenario as above, but with the per-queue
+# max-sched-jobs limit.
+test_expect_success 'update queue max-sched-jobs limit to 1' '
+	flux account edit-user user1 --max-sched-jobs=-1 &&
+	flux account edit-queue pdebug --max-sched-jobs=1 &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'submit enough jobs to take up max_sched_jobs limit' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc &&
+	job2=$(flux python ${SUBMIT_AS} 50001 -N4 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job2} priority
+'
+
+test_expect_success 'jobs are held with both afterany dependency and max-sched-jobs limit' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -N4 --dependency=afterany:${job1} --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="after-finish=${job1}" \
+		${job3} dependency-add &&
+	job4=$(flux python ${SUBMIT_AS} 50001 -N4 --dependency=afterany:${job1} --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job4} dependency-add &&
+	flux job wait-event -t 5 \
+		--match-context=description="after-finish=${job1}" \
+		${job4} dependency-add
+'
+
+test_expect_success 'association has 1 job in RUN, 1 in SCHED, and 2 in DEPEND'  '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 4" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_jobs == 1" <query.json
+
+'
+
+test_expect_success 'held jobs have correct accounting dependencies' '
+	job3_dec=$(flux job id -t dec ${job3}) &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job3_dec}\"].deps[0] \
+			== \"max-sched-jobs-queue-limit\"" <query.json &&
+	job4_dec=$(flux job id -t dec ${job4}) &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job4_dec}\"].deps[0] \
+			== \"max-sched-jobs-queue-limit\"" <query.json
+'
+
+test_expect_success 'cancel job2 in SCHED; job3 has its accounting dependency removed' '
+	flux cancel ${job2} &&
+	flux job wait-event -t 5 \
+		--match-context=description="max-sched-jobs-queue-limit" \
+		${job3} dependency-remove
+'
+
+test_expect_success 'job4 still has its max-sched-jobs dependency' '
+	job4_dec=$(flux job id -t dec ${job4}) &&
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs[\"${job4_dec}\"].deps[0] \
+			== \"max-sched-jobs-queue-limit\"" <query.json
+'
+
+test_expect_success 'cancel job1; job3 can now proceed to RUN' '
+	flux cancel ${job1} &&
+	flux job wait-event -t 5 ${job3} alloc
+'
+
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 2" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_run_jobs == 1" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_jobs == 1" <query.json
+'
+
+test_expect_success 'cancel jobs' '
+	flux cancel ${job3} ${job4} &&
+	flux job wait-event -t 5 ${job3} clean &&
+	flux job wait-event -t 5 ${job4} clean
+'
+
+test_expect_success 'association job counts are accurate' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_active_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].cur_sched_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].held_jobs | length == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_run_jobs == 0" <query.json &&
+	jq -e \
+		".mf_priority_map[] |
+		 select(.userid == 50001) |
+		 .banks[0].queue_usage.pdebug.cur_sched_jobs == 0" <query.json
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

If a job is cancelled before it ever runs, the association's overall `cur_sched_jobs` and `cur_sched_jobs` for that queue are never
decremented.

The priority plugin currently keeps track of SCHED-related dependencies removed from jobs in `check_and_release_held_jobs ()` by
using a speculative counter to bump the number of jobs whose dependencies have been removed. However, jobs that are held by SCHED-related dependencies increment the association's number of jobs in SCHED state synchronously (i.e. the `job.state.sched` callback is called synchronously in the case where there is more than one held job), and thus, using a speculative counter double-counts the total number of current jobs in SCHED state, which can incorrectly hold a job from being released of its dependencies.

In a similar vein, the speculative counters for the running job limits (both per-association and per-queue) are bumped regardless of whether a job is fully eligible to be released or not (i.e. it has had all of its dependencies cleared or not), which can result in incorrectly holding jobs when they should be released.

---

The first thing this PR does is add decrements in the callback for `job.state.inactive` for jobs that were in SCHED state but never ran.

This PR adds a check for the state of the job when it no longer has any flux-accounting dependencies placed on it to see if it is in SCHED state or not. If it is not, *then* use speculative counters to keep track of the job that was released so that other jobs do not incorrectly get released due to limits that may not have been updated yet.

Lastly, it moves the bump of the speculative counters for the running job limits to a conditional where they are only bumped *if* the job has met all requirements to be released to SCHED state; if not, it does not bump the speculative counter and move onto the next eligible job.

Tests are added for accurately checking and working through multiple held jobs due to max-sched-jobs and max-running-jobs limits (both per-association and per-queue).