### PR TITLE
add bindings, commands for interacting with `config_table`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -13,7 +13,11 @@ import csv
 import sqlite3
 import json
 
+import fluxacct
 from fluxacct.accounting.util import with_cursor
+from fluxacct.accounting import formatter as fmt
+from fluxacct.accounting import sql_util as sql
+from flux.util import parse_fsd
 
 
 def export_db_info(conn):
@@ -202,3 +206,115 @@ def export_as_json(conn, cursor):
 
     # return a single JSON object containing the above DB information
     return json.dumps(config)
+
+
+@with_cursor
+def add_config(conn, cursor, key_value_string):
+    """
+    Add a key-value pair to config_table.
+
+    Args:
+        conn: The SQLite Connection object.
+        cursor: The SQLite Cursor object.
+        key_value_string: A key=value string to add to config_table.
+    """
+    if key_value_string.count("=") != 1:
+        raise ValueError('key-value string must contain exactly one "="')
+    key, value = key_value_string.split("=")
+    cursor.execute(
+        "INSERT INTO config_table (key, value) VALUES (?, ?)",
+        (
+            key,
+            value,
+        ),
+    )
+
+    return 0
+
+
+@with_cursor
+def edit_config(conn, cursor, key_value_strings):
+    """
+    Edit one or more key-value pairs in config_table.
+
+    Args:
+        conn: The SQLite Connection object.
+        cursor: The SQLite Cursor object.
+        key_value_strings: A list of key=value strings to update in config_table.
+    """
+    bin_config_keys = {"priority_usage_reset_period", "priority_decay_half_life"}
+
+    for key_value_string in key_value_strings:
+        key, value = key_value_string.split("=")
+
+        if key in bin_config_keys:
+            # parse value as Flux Standard Duration (FSD)
+            value = parse_fsd(str(value))
+        if key == "decay_factor":
+            if (float(value) < 0) or (float(value) > 1):
+                raise ValueError(
+                    "decay_factor must be a floating-point value between 0 and 1"
+                )
+        cursor.execute(
+            "UPDATE config_table SET value=? WHERE key=?",
+            (value, key),
+        )
+        if cursor.rowcount == 0:
+            raise ValueError(f"key {key} not found in config_table")
+
+    return 0
+
+
+@with_cursor
+def delete_config(conn, cursor, key):
+    """
+    Delete a key-value pair from config_table.
+    """
+    if key in [
+        "priority_usage_reset_period",
+        "priority_decay_half_life",
+        "decay_factor",
+    ]:
+        raise ValueError(
+            "key-value pair is not allowed to be removed from config_table"
+        )
+
+    cursor.execute("DELETE FROM config_table WHERE key=?", (key,))
+
+    return 0
+
+
+@with_cursor
+def view_config(conn, cursor, key, json_fmt=False, format_string=""):
+    """
+    View a key-value pair from config_table.
+    """
+    cursor.execute("SELECT * FROM config_table WHERE key=?", (key,))
+    formatter = fmt.KeyValueFormatter(cursor, key)
+    if format_string != "":
+        return formatter.as_format_string(format_string)
+    if json_fmt:
+        return formatter.as_json()
+    return formatter.as_table()
+
+
+@with_cursor
+def list_configs(conn, cursor, cols=None, json_fmt=False, format_string=""):
+    """
+    List all of the key-value pairs in config_table.
+    """
+    # use all column names if none are passed in
+    cols = cols or fluxacct.accounting.CONFIG_TABLE
+
+    sql.validate_columns(cols, fluxacct.accounting.CONFIG_TABLE)
+    # construct SELECT statement
+    select_stmt = f"SELECT {', '.join(cols)} FROM config_table"
+    cursor.execute(select_stmt)
+
+    # initialize AccountingFormatter object
+    formatter = fmt.AccountingFormatter(cursor)
+    if format_string != "":
+        return formatter.as_format_string(format_string)
+    if json_fmt:
+        return formatter.as_json()
+    return formatter.as_table()

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -506,3 +506,23 @@ class PriorityFactorFormatter(AccountingFormatter):
             cursor,
             error_msg=f"factor {self.factor} not found in priority_factor_weight_table",
         )
+
+
+class KeyValueFormatter(AccountingFormatter):
+    """
+    Subclass of AccountingFormatter that includes a custom error message in the
+    case where a key-value pair does not exist in config_table.
+    """
+
+    def __init__(self, cursor, key):
+        """
+        Initialize a KeyValueFormatter object with a SQLite cursor.
+        Args:
+            cursor: a SQLite Cursor object that has the results of a SQL query.
+            key: the key of the key-value pair.
+        """
+        self.key = key
+        super().__init__(
+            cursor,
+            error_msg=f"key {self.key} not found in config_table",
+        )

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -93,6 +93,8 @@ class AccountingService:
             "jobs",
             "show_usage",
             "view_usage_report",
+            "view_config",
+            "list_configs",
         ]
 
         privileged_endpoints = [
@@ -117,6 +119,9 @@ class AccountingService:
             "sync_userids",
             "export_json",
             "clear_usage",
+            "add_config",
+            "edit_config",
+            "delete_config",
         ]
 
         for name in general_endpoints:
@@ -802,6 +807,84 @@ class AccountingService:
             handle.respond_error(msg, 0, f"clear-usage: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(msg, 0, f"clear-usage: {type(exc).__name__}: {exc}")
+
+    def add_config(self, handle, watcher, msg, arg):
+        try:
+            val = d.add_config(
+                conn=self.conn, key_value_string=msg.payload["key_value_string"]
+            )
+
+            payload = {"add_config": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"add-config: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"add-config: {type(exc).__name__}: {exc}")
+
+    def view_config(self, handle, watcher, msg, arg):
+        try:
+            val = d.view_config(
+                conn=self.conn,
+                key=msg.payload["key"],
+                json_fmt=msg.payload.get("json"),
+                format_string=msg.payload.get("format"),
+            )
+
+            payload = {"view_config": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"view-config: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"view-config: {type(exc).__name__}: {exc}")
+
+    def edit_config(self, handle, watcher, msg, arg):
+        try:
+            val = d.edit_config(
+                conn=self.conn, key_value_strings=msg.payload["key_value_strings"]
+            )
+
+            payload = {"edit_config": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"edit-config: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"edit-config: {type(exc).__name__}: {exc}")
+
+    def delete_config(self, handle, watcher, msg, arg):
+        try:
+            val = d.delete_config(conn=self.conn, key=msg.payload["key"])
+
+            payload = {"delete_config": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(
+                msg, 0, f"delete-config: missing key in payload: {exc}"
+            )
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"delete-config: {type(exc).__name__}: {exc}")
+
+    def list_configs(self, handle, watcher, msg, arg):
+        try:
+            val = d.list_configs(
+                conn=self.conn,
+                cols=msg.payload["fields"].split(",")
+                if msg.payload.get("fields")
+                else None,
+                json_fmt=msg.payload.get("json"),
+                format_string=msg.payload.get("format"),
+            )
+
+            payload = {"list_configs": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"list-configs: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"list-configs: {type(exc).__name__}: {exc}")
 
 
 LOGGER = logging.getLogger("flux-uri")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -1462,6 +1462,105 @@ def add_clear_usage_arg(subparsers):
     )
 
 
+def add_add_config_arg(subparsers):
+    subparsers_add_config = subparsers.add_parser(
+        "add-config",
+        help="add a key-value pair to config_table",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparsers_add_config.set_defaults(func="add_config")
+    subparsers_add_config.add_argument(
+        "key_value_string",
+        help="the key-value string to be added to config_table",
+        metavar="KEY=VALUE",
+    )
+
+
+def add_view_config_arg(subparsers):
+    subparsers_view_config = subparsers.add_parser(
+        "view-config",
+        help="view a key-value pair from config_table",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparsers_view_config.set_defaults(func="view_config")
+    subparsers_view_config.add_argument(
+        "key",
+        help="the key of the key-value pair in config_table",
+        metavar="KEY",
+    )
+    subparsers_view_config.add_argument(
+        "--json",
+        action="store_true",
+        help="print output in JSON format",
+    )
+    subparsers_view_config.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="specify output format using Python's string format syntax",
+        metavar="FORMAT",
+    )
+
+
+def add_edit_config_arg(subparsers):
+    subparsers_edit_config = subparsers.add_parser(
+        "edit-config",
+        help="edit one or more key-value pairs in config_table",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparsers_edit_config.set_defaults(func="edit_config")
+    subparsers_edit_config.add_argument(
+        "key_value_strings",
+        help="the key-value strings to be edited in config_table",
+        metavar="KEY1=VALUE1 KEY2=VALUE2 ...",
+        nargs="+",
+    )
+
+
+def add_delete_config_arg(subparsers):
+    subparsers_delete_config = subparsers.add_parser(
+        "delete-config",
+        help="delete a key-value pair from config_table",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparsers_delete_config.set_defaults(func="delete_config")
+    subparsers_delete_config.add_argument(
+        "key",
+        help="the key-value string to be removed from config_table",
+        metavar="KEY",
+    )
+
+
+def add_list_configs(subparsers):
+    subparser_list_configs = subparsers.add_parser(
+        "list-configs",
+        help="list all priority configs in the flux-accounting DB",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_list_configs.set_defaults(func="list_configs")
+    subparser_list_configs.add_argument(
+        "--fields",
+        type=str,
+        help="list of fields to include in output",
+        default=None,
+        metavar="KEY,VALUE",
+    )
+    subparser_list_configs.add_argument(
+        "--json",
+        action="store_true",
+        help="print output in JSON format",
+    )
+    subparser_list_configs.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="",
+        help="specify output format using Python's string format syntax",
+        metavar="FORMAT",
+    )
+
+
 def add_arguments_to_parser(parser, subparsers):
     add_path_arg(parser)
     add_view_user_arg(subparsers)
@@ -1500,6 +1599,11 @@ def add_arguments_to_parser(parser, subparsers):
     add_export_json_arg(subparsers)
     view_usage_report(subparsers)
     add_clear_usage_arg(subparsers)
+    add_add_config_arg(subparsers)
+    add_view_config_arg(subparsers)
+    add_edit_config_arg(subparsers)
+    add_delete_config_arg(subparsers)
+    add_list_configs(subparsers)
 
 
 def set_db_location(args):
@@ -1547,6 +1651,11 @@ def select_accounting_function(args, parser):
         "export_json": "accounting.export_json",
         "view_usage_report": "accounting.view_usage_report",
         "clear_usage": "accounting.clear_usage",
+        "add_config": "accounting.add_config",
+        "view_config": "accounting.view_config",
+        "edit_config": "accounting.edit_config",
+        "delete_config": "accounting.delete_config",
+        "list_configs": "accounting.list_configs",
     }
 
     if args.func in func_map:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -112,7 +112,8 @@ TESTSCRIPTS = \
 	python/t1013_issue802.py \
 	python/t1014_clear_usage.py \
 	python/t1015_issue815.py \
-	python/t1016_issue853.py
+	python/t1016_issue853.py \
+	python/t1017_config_cmds.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -95,6 +95,7 @@ TESTSCRIPTS = \
 	t1090-mf-priority-assoc-partial-release.t \
 	t1091-mf-priority-queue-partial-release.t \
 	t1092-mf-priority-afterany-partial-release.t \
+	t1093-config-table-commands.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/python/t1017_config_cmds.py
+++ b/t/python/t1017_config_cmds.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import time
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import db_info_subcommands as d
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
+        global conn
+        global cur
+
+        conn = sqlite3.connect(self.dbname, timeout=60)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+    # add a key-value pair to config_table
+    def test_01_add_config(self):
+        d.add_config(conn, key_value_string="foo=bar")
+        test = cur.execute("SELECT * FROM config_table WHERE key='foo'").fetchone()
+        self.assertEqual(test["key"], "foo")
+        self.assertEqual(test["value"], "bar")
+
+    # trying to add an already-existing key will raise a sqlite3.IntegrityError
+    def test_02_add_config_duplicate_key(self):
+        with self.assertRaises(sqlite3.IntegrityError):
+            d.add_config(conn, key_value_string="priority_decay_half_life=foo")
+
+    # edit a key-value pair in config_table
+    def test_03_edit_config(self):
+        d.edit_config(conn, key_value_strings=["foo=baz"])
+        test = cur.execute("SELECT value FROM config_table WHERE key='foo'").fetchone()
+        self.assertEqual(test["value"], "baz")
+
+    # trying to set PriorityUsageResetPeriod to a non-integer will raise a ValueError
+    def test_04_edit_priority_usage_reset_period_bad(self):
+        with self.assertRaises(ValueError):
+            d.edit_config(conn, key_value_strings=["priority_usage_reset_period=foo"])
+
+    # successfully edit PriorityUsageResetPeriod
+    def test_05_edit_priority_usage_reset_period_success(self):
+        d.edit_config(conn, key_value_strings=["priority_usage_reset_period=1234"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
+        ).fetchone()
+        self.assertEqual(test["value"], "1234.0")
+
+    # edit PriorityUsageResetPeriod using a Flux Standard Duration value
+    def test_06_edit_priority_usage_reset_period_fsd_success(self):
+        d.edit_config(conn, key_value_strings=["priority_usage_reset_period=1d"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
+        ).fetchone()
+        self.assertEqual(test["value"], "86400.0")
+
+    # trying to set PriorityDecayHalfLife to a non-integer will raise a ValueError
+    def test_07_edit_priority_decay_half_life_bad(self):
+        with self.assertRaises(ValueError):
+            d.edit_config(conn, key_value_strings=["priority_decay_half_life=foo"])
+
+    # successfully edit PriorityDecayHalfLife
+    def test_08_edit_priority_decay_half_life_success(self):
+        d.edit_config(conn, key_value_strings=["priority_decay_half_life=1234"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
+        ).fetchone()
+        self.assertEqual(test["value"], "1234.0")
+
+    # edit PriorityDecayHalfLife using a Flux Standard Duration value
+    def test_09_edit_priority_decay_half_life_fsd_success(self):
+        d.edit_config(conn, key_value_strings=["priority_decay_half_life=1h"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
+        ).fetchone()
+        self.assertEqual(test["value"], "3600.0")
+
+    # trying to set decay_factor to a non-float will raise a ValueError
+    def test_10_edit_decay_factor_bad_1(self):
+        with self.assertRaises(ValueError):
+            d.edit_config(conn, key_value_strings=["decay_factor=foo"])
+
+    # trying to set decay_factor to a float not between 0 and 1 will raise a ValueError
+    def test_11_edit_decay_factor_bad_2(self):
+        with self.assertRaises(ValueError):
+            d.edit_config(conn, key_value_strings=["decay_factor=-0.1"])
+        with self.assertRaises(ValueError):
+            d.edit_config(conn, key_value_strings=["decay_factor=1.1"])
+
+    # successfully edit decay_factor
+    def test_12_edit_decay_factor_success(self):
+        d.edit_config(conn, key_value_strings=["decay_factor=0.9"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='decay_factor'"
+        ).fetchone()
+        self.assertEqual(test["value"], "0.9")
+
+    # remove a key-value pair from config_table
+    def test_13_delete_config(self):
+        d.add_config(conn, key_value_string="hello=world")
+        test = cur.execute("SELECT * FROM config_table WHERE key='hello'").fetchone()
+        self.assertEqual(test["value"], "world")
+
+        d.delete_config(conn, key="hello")
+        with self.assertRaises(ValueError):
+            d.view_config(conn, key="hello")
+
+    # trying to remove PriorityUsageResetPeriod will raise a ValueError
+    def test_14_delete_priority_usage_reset_period(self):
+        with self.assertRaises(ValueError):
+            d.delete_config(conn, key="priority_usage_reset_period")
+
+    # trying to remove PriorityDecayHalfLife will raise a ValueError
+    def test_15_delete_priority_decay_half_life(self):
+        with self.assertRaises(ValueError):
+            d.delete_config(conn, key="priority_decay_half_life")
+
+    # trying to remove decay_factor will raise a ValueError
+    def test_16_delete_decay_factor(self):
+        with self.assertRaises(ValueError):
+            d.delete_config(conn, key="decay_factor")
+
+    # trying to view a key-value pair that does not exist will raise a ValueError
+    def test_17_view_config_bad(self):
+        with self.assertRaises(ValueError):
+            d.view_config(conn, key="noexist")
+
+    # view information about a key-value pair
+    def test_18_view_config(self):
+        test = d.view_config(conn, key="priority_usage_reset_period")
+        self.assertIn("priority_usage_reset_period", test)
+        self.assertIn("86400.0", test)
+
+    # view information about a key-value pair in JSON format
+    def test_19_view_config_json(self):
+        test = d.view_config(conn, key="priority_usage_reset_period", json_fmt=True)
+        self.assertIn('"key": "priority_usage_reset_period"', test)
+        self.assertIn('"value": "86400.0"', test)
+
+    def test_20_view_config_format_string(self):
+        test = d.view_config(
+            conn, key="priority_usage_reset_period", format_string="{key}||{value}"
+        )
+        self.assertIn("priority_usage_reset_period||86400.0", test)
+
+    def test_21_list_configs(self):
+        test = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 86400.0", test)
+        self.assertIn("priority_decay_half_life    | 3600.0", test)
+        self.assertIn("decay_factor                | 0.9", test)
+
+    def test_22_list_configs_json(self):
+        test = d.list_configs(conn, json_fmt=True)
+        self.assertIn('"key": "priority_usage_reset_period"', test)
+        self.assertIn('"value": "86400.0"', test)
+        self.assertIn('"key": "priority_decay_half_life"', test)
+        self.assertIn('"value": "3600.0"', test)
+        self.assertIn('"key": "decay_factor"', test)
+        self.assertIn('"value": "0.9"', test)
+
+    def test_23_list_configs_format_string(self):
+        test = d.list_configs(conn, format_string="{key} -> {value}")
+        self.assertIn("priority_usage_reset_period -> 86400.0", test)
+        self.assertIn("priority_decay_half_life -> 3600.0", test)
+        self.assertIn("decay_factor -> 0.9", test)
+
+    def test_24_add_config_bad_format(self):
+        with self.assertRaises(ValueError):
+            d.add_config(conn, key_value_string="bad=format=foo")
+
+    def test_25_add_config_bad_format_2(self):
+        with self.assertRaises(ValueError):
+            d.add_config(conn, key_value_string="foobar")
+
+    def test_26_edit_config_nonexistent_key(self):
+        with self.assertRaises(ValueError):
+            d.edit_config(conn, key_value_strings=["i_dont_exist=foo"])
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove(self.dbname)
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t1026-flux-account-perms.t
+++ b/t/t1026-flux-account-perms.t
@@ -167,6 +167,33 @@ test_expect_success 'clear-usage should not be accessible by all users' '
 	)
 '
 
+test_expect_success 'add-config should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account add-config foo=bar > no_access_add_config.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_add_config.out
+	)
+'
+
+test_expect_success 'edit-config should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account edit-config decay_factor=0.75 > no_access_edit_config.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_edit_config.out
+	)
+'
+
+test_expect_success 'delete-config should not be accessible by all users' '
+	newid=$(($(id -u)+1)) &&
+	( export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  export FLUX_HANDLE_USERID=$newid &&
+		test_must_fail flux account delete-config decay_factor > no_access_delete_config.out 2>&1 &&
+		grep "Request requires owner credentials" no_access_delete_config.out
+	)
+'
+
 test_expect_success 'remove flux-accounting DB' '
 	rm $(pwd)/FluxAccountingTest.db
 '

--- a/t/t1093-config-table-commands.t
+++ b/t/t1093-config-table-commands.t
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+test_description='test commands interacting with config_table'
+
+. `dirname $0`/sharness.sh
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -Slog-stderr-level=1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add-config --help works' '
+	flux account add-config --help
+'
+
+test_expect_success 'add a key-value pair to config_table' '
+	flux account add-config foo=bar
+'
+
+test_expect_success 'trying to add a duplicate key raises IntegrityError' '
+	test_must_fail flux account add-config foo=bar > duplicate_key.out 2>&1 &&
+	grep "IntegrityError: UNIQUE constraint failed: config_table.key" duplicate_key.out
+'
+
+test_expect_success 'key-value pair with a bad format raises ValueError' '
+	test_must_fail flux account add-config bad=format=foo > bad_format.out 2>&1 &&
+	grep "ValueError: key-value string must contain exactly one \"=\"" bad_format.out
+'
+
+test_expect_success 'view a key-value pair from config_table' '
+	flux account view-config foo > view_config_test1.out &&
+	grep "key | value" view_config_test1.out &&
+	grep "foo | bar " view_config_test1.out
+'
+
+test_expect_success 'view a key-value pair from config_table with JSON' '
+	flux account view-config foo --json > view_config_test2.out &&
+	grep "\"key\": \"foo\"" view_config_test2.out &&
+	grep "\"value\": \"bar\"" view_config_test2.out
+'
+
+test_expect_success 'view a key-value pair from config_table with format string' '
+	flux account view-config foo -o "{key}->{value}"> view_config_test3.out &&
+	grep "key->value" view_config_test3.out &&
+	grep "foo->bar" view_config_test3.out
+'
+
+test_expect_success 'editing priority_usage_reset_period with a bad value raises error' '
+	test_must_fail flux account edit-config \
+		priority_usage_reset_period=foo > edit_config_bad.out 2>&1 &&
+	grep "edit-config: ValueError: invalid Flux standard duration" edit_config_bad.out
+'
+
+test_expect_success 'editing a key-value pair that does not exist raises error' '
+	test_must_fail flux account \
+		edit-config i_dont_exist=foo > edit_config_bad_2.out 2>&1 &&
+	grep "edit-config: ValueError: key i_dont_exist not found in config_table" edit_config_bad_2.out
+'
+
+test_expect_success 'edit both job usage parameters at the same time' '
+	flux account edit-config priority_decay_half_life=15m priority_usage_reset_period=1h &&
+	flux account list-configs > edited_configs.out &&
+	grep "priority_usage_reset_period | 3600.0" edited_configs.out &&
+	grep "priority_decay_half_life    | 900.0" edited_configs.out
+'
+
+test_expect_success 'delete a key from config_table' '
+	flux account delete-config foo &&
+	test_must_fail flux account view-config foo > view_config_noexist.err 2>&1 &&
+	grep "ValueError: key foo not found in config_table" view_config_noexist.err
+'
+
+test_expect_success 'trying to delete priority_usage_reset_period does not work' '
+	test_must_fail flux account \
+		delete-config priority_usage_reset_period > no_delete1.err 2>&1 &&
+	grep "ValueError: key-value pair is not allowed to be removed from config_table" no_delete1.err
+'
+
+test_expect_success 'trying to delete priority_decay_half_life does not work' '
+	test_must_fail flux account \
+		delete-config priority_decay_half_life > no_delete2.err 2>&1 &&
+	grep "ValueError: key-value pair is not allowed to be removed from config_table" no_delete2.err
+'
+
+test_expect_success 'trying to delete decay_factor does not work' '
+	test_must_fail flux account \
+		delete-config decay_factor > no_delete3.err 2>&1 &&
+	grep "ValueError: key-value pair is not allowed to be removed from config_table" no_delete3.err
+'
+
+test_expect_success 'list all configs in config_table' '
+	flux account list-configs > list_configs.test &&
+	cat <<-EOF >list_configs.expected &&
+	key                         | value 
+	----------------------------+-------
+	priority_usage_reset_period | 3600.0
+	priority_decay_half_life    | 900.0 
+	decay_factor                | 0.5   
+	EOF
+	test_cmp list_configs.test list_configs.expected
+'
+
+test_expect_success 'list all configs in config_table in JSON format' '
+	flux account list-configs --json > list_configs_json.test &&
+	grep "\"key\": \"priority_usage_reset_period\"" list_configs_json.test &&
+	grep "\"value\": \"3600.0\"" list_configs_json.test &&
+	grep "\"key\": \"priority_decay_half_life\"" list_configs_json.test &&
+	grep "\"value\": \"900.0\"" list_configs_json.test &&
+	grep "\"key\": \"decay_factor\"" list_configs_json.test &&
+	grep "\"value\": \"0.5\"" list_configs_json.test
+'
+
+test_expect_success 'list all configs with --fields' '
+	flux account list-configs --fields=key > keys.test &&
+	cat keys.test &&
+	cat <<-EOF >keys.expected &&
+	key                        
+	---------------------------
+	decay_factor               
+	priority_decay_half_life   
+	priority_usage_reset_period
+	EOF
+	test_cmp keys.test keys.expected
+'
+
+test_expect_success 'list all configs with format string' '
+	flux account list-configs -o "{key}->{value}" > list_configs_format.test &&
+	cat list_configs_format.test &&
+	cat <<-EOF >list_configs_format.expected &&
+	key->value
+	priority_usage_reset_period->3600.0
+	priority_decay_half_life->900.0
+	decay_factor->0.5
+	EOF
+	test_cmp list_configs_format.test list_configs_format.expected
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

There is no way to interact with `config_table` to view, add, edit, or remove key-value pairs.

---

This PR adds Python bindings and commands to add, edit, view, and remove key-value pairs from `config_table`. Some basic unit and sharness tests are also added for each of the functions as well as their front-end callers.

Closes #865 