### PR TITLE
job usage: use new table for usage calculation, decay

### DIFF
--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -588,15 +588,9 @@ def clear_usage_period_columns(cur, bank):
         cur: The SQLite Cursor object.
         bank: The bank being cleared.
     """
-    cur.execute("PRAGMA table_info('job_usage_factor_table')")
-    result = cur.fetchall()
-    for column in result:
-        # column[1] accesses just the column name
-        if column[1].startswith("usage_factor_period_"):
-            cur.execute(
-                f"UPDATE job_usage_factor_table SET {column[1]}=0 WHERE bank=?", (bank,)
-            )
-    # clear last_job_timestamp
+    cur.execute(
+        "UPDATE job_usage_per_association_table SET value=0.0 WHERE bank=?", (bank,)
+    )
     cur.execute(
         "UPDATE job_usage_factor_table SET last_job_timestamp=0 WHERE bank=?", (bank,)
     )

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -59,65 +59,83 @@ def update_hist_usg_col(acct_conn, usg_h, user, bank):
     )
 
 
-def update_curr_usg_col(acct_conn, usg_h, user, bank):
+def update_curr_usg_col(acct_conn, usg_h, user, bank, userid):
     """
     Write the current job usage factor for the association to the
     job_usage_factor_table.
     """
-    u_usg_factor = """
-        UPDATE job_usage_factor_table SET usage_factor_period_0=? WHERE username=? AND bank=?
-        """
     acct_conn.execute(
-        u_usg_factor,
-        (
-            usg_h,
-            user,
-            bank,
-        ),
+        """
+        INSERT INTO job_usage_per_association_table (username, userid, bank, period, value)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT (username, bank, period) DO UPDATE SET value=excluded.value
+        """,
+        (user, userid, bank, 0, usg_h),
     )
 
 
-def apply_decay_factor(decay, acct_conn, user, bank, usage_factors):
+def apply_decay_factor(acct_conn, user, bank, userid):
     """
     Apply a decay factor to an association's job usage period values. Since this helper
     issues a write to the flux-accounting DB and does not have a .commit() call after the
     update, this function should be called inside of a SQLite TRANSACTION.
 
     Args:
-        decay: The decay factor to be applied to every job usage period.
         acct_conn: The SQLite Connection object.
         user: The username of the association.
         bank: The bank name of the association.
+        userid: The userid of the association.
     """
-    usg_past_decay = []
+    cur = acct_conn.cursor()
+    cur.execute("SELECT value FROM config_table WHERE key='decay_factor'")
+    row = cur.fetchone()
+    # if decay_factor is not configured, fall back to 0.5
+    decay = float(row[0]) if row else 0.5
 
-    # apply decay factor to past usage periods of a user's jobs
-    for usage_factor in usage_factors:
-        usg_past_decay.append(usage_factor * decay)
+    # fetch all periods ordered from oldest to most recent so we can shift
+    # values forward without overwriting anything we haven't read yet
+    cur.execute(
+        """
+        SELECT period, value FROM job_usage_per_association_table
+        WHERE username=? AND bank=?
+        ORDER BY period DESC
+        """,
+        (user, bank),
+    )
+    periods = cur.fetchall()
 
-    # update job_usage_factor_table with new values, starting with the second usage
-    # period and working back to the oldest usage period since the most recent usage
-    # period is updated separately
-    period = 1
-    for usage_factor in usg_past_decay[0:-1]:
-        update_stmt = (
-            "UPDATE job_usage_factor_table SET usage_factor_period_"
-            + str(period)
-            + "=? WHERE username=? AND bank=?"
+    for period, value in periods:
+        # the oldest period just gets dropped off the end since it no longer affects
+        # historical usage
+        next_period = period + 1
+        cur.execute(
+            """
+            UPDATE job_usage_per_association_table SET value=?
+            WHERE username=? AND userid=? AND bank=? AND period=?
+            """,
+            (value * decay, user, userid, bank, next_period),
         )
-        acct_conn.execute(
-            update_stmt,
-            (
-                str(usage_factor),
-                user,
-                bank,
-            ),
-        )
-        period += 1
 
-    # only return the usage factors up to but not including the oldest one
-    # since it no longer affects a user's historical usage factor
-    return sum(usg_past_decay[:-1])
+    # period 0 will be written with the current period's usage
+    cur.execute(
+        """
+        UPDATE job_usage_per_association_table SET value=0.0
+        WHERE username=? AND userid=? AND bank=? AND period=0
+        """,
+        (user, userid, bank),
+    )
+
+    # return the sum of all periods excluding period 0 since that will be
+    # written separately
+    cur.execute(
+        """
+        SELECT SUM(value) FROM job_usage_per_association_table
+        WHERE username=? AND userid=? AND bank=? AND period > 0
+        """,
+        (user, userid, bank),
+    )
+    result = cur.fetchone()
+    return result[0] if result[0] is not None else 0.0
 
 
 def calc_usage_factor(
@@ -125,10 +143,23 @@ def calc_usage_factor(
     pdhl,
     user,
     bank,
+    userid,
     end_hl,
-    usage_factors,
     user_jobs,
 ):
+    cur = conn.cursor()
+
+    # fetch all current period values for this association
+    cur.execute(
+        """
+        SELECT period, value FROM job_usage_per_association_table
+        WHERE username=? AND bank=?
+        ORDER BY period ASC
+        """,
+        (user, bank),
+    )
+    period_rows = cur.fetchall()
+    usage_factors = [row[1] for row in period_rows]
 
     # hl_period represents the number of seconds that represent one usage bin
     hl_period = pdhl * 604800
@@ -155,9 +186,15 @@ def calc_usage_factor(
     elif len(user_jobs) == 0 and (float(end_hl) < (time.time() - hl_period)):
         # no new jobs in the new half-life period; previous job usage periods need
         # to have a half-life decay applied to them
-        usg_historical = apply_decay_factor(0.5, conn, user, bank, usage_factors)
+        usg_historical = apply_decay_factor(conn, user, bank, userid)
 
-        update_curr_usg_col(conn, usg_current, user, bank)
+        update_curr_usg_col(
+            conn,
+            usg_current,
+            user,
+            bank,
+            userid,
+        )
         update_hist_usg_col(conn, usg_historical, user, bank)
     elif (last_t_inactive - float(end_hl)) < hl_period:
         # found new jobs in the current half-life period; we need to 1) add the
@@ -166,15 +203,15 @@ def calc_usage_factor(
         usg_current += usage_factors[0]
         usg_historical = usg_current + sum(usage_factors[1:])
 
-        update_curr_usg_col(conn, usg_current, user, bank)
+        update_curr_usg_col(conn, usg_current, user, bank, userid)
         update_hist_usg_col(conn, usg_historical, user, bank)
     else:
         # found new jobs in the new half-life period
         # apply decay factor to past usage periods of a user's jobs
-        usg_past = apply_decay_factor(0.5, conn, user, bank, usage_factors)
+        usg_past = apply_decay_factor(conn, user, bank, userid)
         usg_historical = usg_current + usg_past
 
-        update_curr_usg_col(conn, usg_historical, user, bank)
+        update_curr_usg_col(conn, usg_historical, user, bank, userid)
         update_hist_usg_col(conn, usg_historical, user, bank)
 
     return usg_historical
@@ -274,7 +311,7 @@ def update_job_usage(acct_conn, pdhl=1):
         # begin transaction for all of the updates in the DB
         acct_conn.execute("BEGIN TRANSACTION")
         s_assoc = """
-            SELECT a.username, a.bank, a.default_bank, j.*
+            SELECT a.username, a.userid, a.bank, a.default_bank, j.last_job_timestamp
             FROM association_table a
             LEFT JOIN job_usage_factor_table j
             ON a.username = j.username AND a.bank = j.bank
@@ -304,18 +341,13 @@ def update_job_usage(acct_conn, pdhl=1):
 
         # update the job usage for every user in the association_table
         for row in result:
-            # add all of the job_usage_factor_period_* columns to dictionary
-            usage_factors = []
-            for key in row.keys():
-                if key.startswith("usage_factor_period_"):
-                    usage_factors.append(row[key])
             calc_usage_factor(
                 conn=acct_conn,
                 pdhl=pdhl,
                 user=row["username"],
                 bank=row["bank"],
+                userid=row["userid"],
                 end_hl=end_hl,
-                usage_factors=usage_factors,
                 user_jobs=association_jobs[(row["userid"], row["bank"])],
             )
 

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -275,7 +275,9 @@ def view_user(
     if job_usage:
         # only return a breakdown of the association's job usage factors that make up
         # their historical usage
-        cur.execute("SELECT * FROM job_usage_factor_table WHERE username=?", (user,))
+        cur.execute(
+            "SELECT * FROM job_usage_per_association_table WHERE username=?", (user,)
+        )
         formatter = fmt.AccountingFormatter(cur)
     else:
         sql.validate_columns(cols, fluxacct.accounting.ASSOCIATION_TABLE)

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -11,7 +11,6 @@
 ###############################################################
 import sqlite3
 import time
-import math
 
 from flux.constants import FLUX_USERID_UNKNOWN
 import fluxacct.accounting
@@ -230,7 +229,7 @@ def insert_per_assoc_usage_rows(conn, cur, username, uid, bank):
     half_life = cur.fetchone()
 
     if reset_period and half_life:
-        num_periods = math.ceil(float(reset_period[0]) / float(half_life[0]))
+        num_periods = int(float(reset_period[0]) / float(half_life[0]))
         if num_periods <= 0:
             # if the number of periods is not > 0, fall back to default behavior
             num_periods = 4

--- a/t/python/t1001_db.py
+++ b/t/python/t1001_db.py
@@ -16,6 +16,8 @@ import sys
 import time
 
 from fluxacct.accounting import create_db as c
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import bank_subcommands as b
 
 
 class TestDB(unittest.TestCase):
@@ -119,25 +121,26 @@ class TestDB(unittest.TestCase):
     # are not specified, the job_usage_factor_table will have
     # 4 bins, each representing 1 week's worth of jobs
     def test_06_job_usage_factor_table_default(self):
+        # for each association, 4 periods will be inserted into
+        # job_usage_per_association_table since int(30d / 7d) = 4
         c.create_db(
             "flux_accounting_test_1.db",
             priority_usage_reset_period="30d",
             priority_decay_half_life="7d",
         )
-        columns_query = "PRAGMA table_info(job_usage_factor_table)"
-        test_conn = sqlite3.connect("flux_accounting_test_1.db")
-        expected = [
-            "usage_factor_period_0",
-            "usage_factor_period_1",
-            "usage_factor_period_2",
-            "usage_factor_period_3",
-        ]
-        test = []
-        cursor = test_conn.cursor()
-        for row in cursor.execute(columns_query):
-            if "usage_factor" in row[1]:
-                test.append(row[1])
-        self.assertEqual(test, expected)
+        test_conn = sqlite3.connect(
+            f"file:flux_accounting_test_1.db?mode=rw", uri=True, timeout=60
+        )
+        test_conn.row_factory = sqlite3.Row
+        cur = test_conn.cursor()
+        # add association to automatically populate job_usage_per_association_table
+        b.add_bank(test_conn, bank="root", shares=1)
+        b.add_bank(test_conn, parent_bank="root", bank="A", shares=1)
+        u.add_user(test_conn, username="user1", uid=50001, bank="A")
+        test = cur.execute(
+            "SELECT * FROM job_usage_per_association_table WHERE username='user1'"
+        ).fetchall()
+        self.assertEqual(len(test), 4)
 
     # PriorityDecayHalfLife and PriorityUsageResetPeriod should be configurable
     # to create a custom table spanning a customizable period of time
@@ -147,26 +150,19 @@ class TestDB(unittest.TestCase):
             priority_usage_reset_period="70d",
             priority_decay_half_life="7d",
         )
-        columns_query = "PRAGMA table_info(job_usage_factor_table)"
-        test_conn = sqlite3.connect("flux_accounting_test_2.db")
-        expected = [
-            "usage_factor_period_0",
-            "usage_factor_period_1",
-            "usage_factor_period_2",
-            "usage_factor_period_3",
-            "usage_factor_period_4",
-            "usage_factor_period_5",
-            "usage_factor_period_6",
-            "usage_factor_period_7",
-            "usage_factor_period_8",
-            "usage_factor_period_9",
-        ]
-        test = []
-        cursor = test_conn.cursor()
-        for row in cursor.execute(columns_query):
-            if "usage_factor" in row[1]:
-                test.append(row[1])
-        self.assertEqual(test, expected)
+        test_conn = sqlite3.connect(
+            f"file:flux_accounting_test_2.db?mode=rw", uri=True, timeout=60
+        )
+        test_conn.row_factory = sqlite3.Row
+        cur = test_conn.cursor()
+        # add association to automatically populate job_usage_per_association_table
+        b.add_bank(test_conn, bank="root", shares=1)
+        b.add_bank(test_conn, parent_bank="root", bank="A", shares=1)
+        u.add_user(test_conn, username="user1", uid=50001, bank="A")
+        test = cur.execute(
+            "SELECT * FROM job_usage_per_association_table WHERE username='user1'"
+        ).fetchall()
+        self.assertEqual(len(test), 10)
 
     def test_08_configure_decay_factor(self):
         c.create_db(

--- a/t/python/t1002_user_cmds.py
+++ b/t/python/t1002_user_cmds.py
@@ -332,29 +332,26 @@ class TestAccountingCLI(unittest.TestCase):
 
     # set job_usage to True to get breakdown of job usage
     def test_20_view_user_job_usage_no_usage(self):
-        result = u.view_user(acct_conn, user="test_user5", job_usage=True)
+        result = u.view_user(acct_conn, user="test_user1", job_usage=True)
 
         self.assertIn("username", result)
         self.assertIn("bank", result)
-        self.assertIn("last_job_timestamp", result)
-        self.assertIn("usage_factor_period_0", result)
-        self.assertIn("usage_factor_period_1", result)
-        self.assertIn("usage_factor_period_2", result)
-        self.assertIn("usage_factor_period_3", result)
-        self.assertIn("test_user5", result)
-        self.assertIn("A", result)
-        self.assertIn("0.0", result)
+        self.assertIn('"period": 0', result)
+        self.assertIn('"period": 1', result)
+        self.assertIn('"period": 2', result)
+        self.assertIn('"period": 3', result)
+        self.assertIn("test_user1", result)
 
     # edit the job usage columns and make suer they are populated in result
     def test_21_view_user_job_usage_usage(self):
         cur = acct_conn.cursor()
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=1.23 "
-            "WHERE username='test_user5'"
+            "UPDATE job_usage_per_association_table SET value=1.23 "
+            "WHERE username='test_user5' AND bank='A' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_1=4.56 "
-            "WHERE username='test_user5'"
+            "UPDATE job_usage_per_association_table SET value=4.56 "
+            "WHERE username='test_user5' AND bank='A' AND period=1"
         )
         acct_conn.commit()
         result = u.view_user(acct_conn, user="test_user5", job_usage=True)

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -270,13 +270,26 @@ class TestAccountingCLI(unittest.TestCase):
     def test_11_calc_usage_factor_many_jobs(self):
         user = "1002"
         bank = "C"
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_0=256 WHERE username='1002' AND bank='C'"
+        userid = 1002
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=256 "
+            "WHERE username='1002' AND userid=1002 AND bank='C' AND period=0"
+        )
         acct_conn.execute(update_stmt)
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_1=64 WHERE username='1002' AND bank='C'"
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=64 "
+            "WHERE username='1002' AND userid=1002 AND bank='C' AND period=1"
+        )
         acct_conn.execute(update_stmt)
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_2=16 WHERE username='1002' AND bank='C'"
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=16 "
+            "WHERE username='1002' AND userid=1002 AND bank='C' AND period=2"
+        )
         acct_conn.execute(update_stmt)
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_3=8 WHERE username='1002' AND bank='C'"
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=8 "
+            "WHERE username='1002' AND userid=1002 AND bank='C' AND period=3"
+        )
         acct_conn.execute(update_stmt)
         acct_conn.commit()
 
@@ -285,8 +298,8 @@ class TestAccountingCLI(unittest.TestCase):
             pdhl=1,
             user=user,
             bank=bank,
+            userid=userid,
             end_hl=9900000,
-            usage_factors=[256, 64, 16, 8],
             user_jobs=user_jobs[(1002, "C")],
         )
         self.assertEqual(usage_factor, 17044.0)
@@ -297,13 +310,26 @@ class TestAccountingCLI(unittest.TestCase):
     def test_12_calc_usage_factor_few_jobs(self):
         user = "1001"
         bank = "C"
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_0=4096 WHERE username='1001' AND bank='C'"
+        userid = 1001
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=4096 "
+            "WHERE username='1001' AND userid=1001 AND bank='C' AND period=0"
+        )
         acct_conn.execute(update_stmt)
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_1=256 WHERE username='1001' AND bank='C'"
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=256 "
+            "WHERE username='1001' AND userid=1001 AND bank='C' AND period=1"
+        )
         acct_conn.execute(update_stmt)
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_2=32 WHERE username='1001' AND bank='C'"
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=32 "
+            "WHERE username='1001' AND userid=1001 AND bank='C' AND period=2"
+        )
         acct_conn.execute(update_stmt)
-        update_stmt = "UPDATE job_usage_factor_table SET usage_factor_period_3=16 WHERE username='1001' AND bank='C'"
+        update_stmt = (
+            "UPDATE job_usage_per_association_table SET value=16 "
+            "WHERE username='1001' AND userid=1001 AND bank='C' AND period=3"
+        )
         acct_conn.execute(update_stmt)
         acct_conn.commit()
 
@@ -312,8 +338,8 @@ class TestAccountingCLI(unittest.TestCase):
             pdhl=1,
             user=user,
             bank=bank,
+            userid=userid,
             end_hl=9900000,
-            usage_factors=[4096, 256, 32, 16],
             user_jobs=user_jobs[(1001, "C")],
         )
         self.assertEqual(usage_factor, 8500.0)
@@ -321,7 +347,7 @@ class TestAccountingCLI(unittest.TestCase):
     # make sure update_t_inactive() updates the last seen job timestamp
     def test_13_update_t_inactive_success(self):
         s_ts = (
-            "SELECT last_job_timestamp,usage_factor_period_0 FROM "
+            "SELECT last_job_timestamp FROM "
             "job_usage_factor_table WHERE username='1003' AND bank='D'"
         )
         cur.execute(s_ts)
@@ -335,8 +361,8 @@ class TestAccountingCLI(unittest.TestCase):
             pdhl=1,
             user="1003",
             bank="D",
+            userid=1003,
             end_hl=0,
-            usage_factors=[result[0]["usage_factor_period_0"], 0.0, 0.0, 0.0],
             user_jobs=user_jobs[(1003, "D")],
         )
 
@@ -348,7 +374,7 @@ class TestAccountingCLI(unittest.TestCase):
     # make sure current usage factor was written to job_usage_factor_table, but
     # historical usage factor was written to association_table
     def test_14_check_usage_factor_in_tables(self):
-        select_stmt = "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='1002' AND bank='C'"
+        select_stmt = "SELECT value FROM job_usage_per_association_table WHERE username='1002' AND bank='C' AND period=0"
         cur.execute(select_stmt)
         usage_factor = cur.fetchone()[0]
         self.assertEqual(usage_factor, 16956.0)
@@ -368,6 +394,7 @@ class TestAccountingCLI(unittest.TestCase):
     def test_15_append_jobs_in_diff_half_life_period(self, *_):
         user = "1001"
         bank = "C"
+        userid = 1001
 
         try:
             acct_conn.execute(
@@ -409,26 +436,13 @@ class TestAccountingCLI(unittest.TestCase):
             j.get_jobs(acct_conn, user="1001", bank="C", after_start_time=time.time())
         )
 
-        # re-calculate usage factor for user1001
-        cur.execute(
-            "SELECT last_job_timestamp,usage_factor_period_0,usage_factor_period_1, "
-            "usage_factor_period_2,usage_factor_period_3 FROM job_usage_factor_table "
-            "WHERE username='1001' AND bank='C'"
-        )
-        result = cur.fetchall()
-        ts = result[0]["last_job_timestamp"]
         usage_factor = jobs.calc_usage_factor(
             acct_conn,
             pdhl=1,
             user=user,
             bank=bank,
+            userid=userid,
             end_hl=0,
-            usage_factors=[
-                result[0]["usage_factor_period_0"],
-                result[0]["usage_factor_period_1"],
-                result[0]["usage_factor_period_2"],
-                result[0]["usage_factor_period_3"],
-            ],
             user_jobs=job_records,
         )
         self.assertEqual(usage_factor, 4442.0)
@@ -439,35 +453,21 @@ class TestAccountingCLI(unittest.TestCase):
     def test_16_recalculate_usage_after_half_life_period(self):
         user = "1001"
         bank = "C"
-        cur.execute(
-            "SELECT last_job_timestamp,usage_factor_period_0,usage_factor_period_1, "
-            "usage_factor_period_2,usage_factor_period_3 FROM job_usage_factor_table "
-            "WHERE username='1001' AND bank='C'"
-        )
-        result = cur.fetchall()
-        ts = result[0]["last_job_timestamp"]
+        userid = 1001
 
         usage_factor = jobs.calc_usage_factor(
             acct_conn,
             pdhl=1,
             user=user,
             bank=bank,
+            userid=userid,
             end_hl=0,
-            usage_factors=[
-                result[0]["usage_factor_period_0"],
-                result[0]["usage_factor_period_1"],
-                result[0]["usage_factor_period_2"],
-                result[0]["usage_factor_period_3"],
-            ],
             user_jobs=[],
         )
 
         self.assertEqual(usage_factor, 4334.0)
 
-        select_stmt = (
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table"
-            " WHERE username='1001'"
-        )
+        select_stmt = "SELECT value FROM job_usage_per_association_table WHERE username='1001' AND bank='C' AND period=0"
         cur.execute(select_stmt)
         curr_job_usage = cur.fetchone()[0]
         self.assertEqual(curr_job_usage, 0.0)

--- a/t/python/t1010_issue631.py
+++ b/t/python/t1010_issue631.py
@@ -77,25 +77,32 @@ class TestAccountingCLI(unittest.TestCase):
 
         # manually set current job usage factor all associations in the DB
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=20 WHERE username='user1'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=20 WHERE username='user1' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=20 WHERE username='user2'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=20 WHERE username='user2' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=10 WHERE username='user3'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=10 WHERE username='user3' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=13 WHERE username='user4'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=13 WHERE username='user4' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=12 WHERE username='user5'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=12 WHERE username='user5' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=25 WHERE username='user6'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=25 WHERE username='user6' AND period=0"
         )
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=10 WHERE username='user7'"
+            "UPDATE job_usage_per_association_table "
+            "SET value=10 WHERE username='user7' AND period=0"
         )
 
         conn.commit()
@@ -159,7 +166,8 @@ class TestAccountingCLI(unittest.TestCase):
         # since no new jobs were submitted in this new half-life period, the current
         # usage should be 0
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND period=0"
         )
         current_usage = cur.fetchone()[0]
         self.assertEqual(current_usage, 0.0)
@@ -167,7 +175,8 @@ class TestAccountingCLI(unittest.TestCase):
         # the current usage from the previous half-life period should now be written to
         # the second slot in job_usage_factor_table
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND period=1"
         )
         usage_last_half_life = cur.fetchone()[0]
         self.assertEqual(usage_last_half_life, 10.0)
@@ -178,13 +187,15 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 10.0)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user2'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user2' AND period=0"
         )
         current_usage = cur.fetchone()[0]
         self.assertEqual(current_usage, 0.0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user2'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user2' AND period=1"
         )
         usage_last_half_life = cur.fetchone()[0]
         self.assertEqual(usage_last_half_life, 10.0)
@@ -195,13 +206,15 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 5.0)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user3'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user3' AND period=0"
         )
         current_usage = cur.fetchone()[0]
         self.assertEqual(current_usage, 0.0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user3'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user3' AND period=1"
         )
         usage_last_half_life = cur.fetchone()[0]
         self.assertEqual(usage_last_half_life, 5.0)
@@ -212,13 +225,15 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 6.5)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user4'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user4' AND period=0"
         )
         current_usage = cur.fetchone()[0]
         self.assertEqual(current_usage, 0.0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user4'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user4' AND period=1"
         )
         usage_last_half_life = cur.fetchone()[0]
         self.assertEqual(usage_last_half_life, 6.5)
@@ -229,13 +244,15 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 6.0)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user5'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user5' AND period=0"
         )
         current_usage = cur.fetchone()[0]
         self.assertEqual(current_usage, 0.0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user5'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user5' AND period=1"
         )
         usage_last_half_life = cur.fetchone()[0]
         self.assertEqual(usage_last_half_life, 6.0)
@@ -246,13 +263,15 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 12.5)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user6'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user6' AND period=0"
         )
         current_usage = cur.fetchone()[0]
         self.assertEqual(current_usage, 0.0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user6'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user6' AND period=1"
         )
         usage_last_half_life = cur.fetchone()[0]
         self.assertEqual(usage_last_half_life, 12.5)

--- a/t/python/t1014_clear_usage.py
+++ b/t/python/t1014_clear_usage.py
@@ -109,8 +109,8 @@ class TestAccountingCLI(unittest.TestCase):
         cur.execute("SELECT job_usage FROM association_table WHERE username='user1'")
         usage_assoc_user1 = cur.fetchone()[0]
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table "
-            "WHERE username='user1'"
+            "SELECT VALUE FROM job_usage_per_association_table "
+            "WHERE username='user1' AND period=0"
         )
         usage_factor_period_0 = cur.fetchone()[0]
         cur.execute(

--- a/t/python/t1015_issue815.py
+++ b/t/python/t1015_issue815.py
@@ -54,7 +54,8 @@ class TestAccountingCLI(unittest.TestCase):
         cur.execute("UPDATE association_table SET job_usage=100 WHERE username='user1'")
         # manually set current job usage factor all associations in the DB
         cur.execute(
-            "UPDATE job_usage_factor_table SET usage_factor_period_0=100 WHERE username='user1'"
+            "UPDATE job_usage_per_association_table SET value=100 "
+            "WHERE username='user1' AND userid=50001 AND bank='A' AND period=0"
         )
 
         conn.commit()
@@ -90,28 +91,32 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 100.0)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=0"
         )
         usage_period_0 = cur.fetchone()[0]
         self.assertEqual(usage_period_0, 100.0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=1"
         )
-        usage_period_1 = cur.fetchone()[0]
-        self.assertEqual(usage_period_1, 0)
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=2"
         )
-        usage_period_2 = cur.fetchone()[0]
-        self.assertEqual(usage_period_2, 0)
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=3"
         )
-        usage_period_3 = cur.fetchone()[0]
-        self.assertEqual(usage_period_3, 0)
+        usage_period_0 = cur.fetchone()[0]
+        self.assertEqual(usage_period_0, 0)
 
     # simulate a half-period further; ensure that the half-life decay is applied properly
     # across all usage period columns
@@ -130,25 +135,29 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 50.0)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=0"
         )
         usage_period_0 = cur.fetchone()[0]
         self.assertEqual(usage_period_0, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=1"
         )
         usage_period_1 = cur.fetchone()[0]
         self.assertEqual(usage_period_1, 50.0)
 
         cur.execute(
-            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=2"
         )
         usage_period_2 = cur.fetchone()[0]
-        self.assertEqual(usage_period_2, 0)
+        self.assertEqual(usage_period_2, 0.0)
 
         cur.execute(
-            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=3"
         )
         usage_period_3 = cur.fetchone()[0]
         self.assertEqual(usage_period_3, 0)
@@ -169,25 +178,29 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 25.0)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=0"
         )
         usage_period_0 = cur.fetchone()[0]
         self.assertEqual(usage_period_0, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=1"
         )
         usage_period_1 = cur.fetchone()[0]
         self.assertEqual(usage_period_1, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=2"
         )
         usage_period_2 = cur.fetchone()[0]
         self.assertEqual(usage_period_2, 25.0)
 
         cur.execute(
-            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=3"
         )
         usage_period_3 = cur.fetchone()[0]
         self.assertEqual(usage_period_3, 0)
@@ -208,25 +221,29 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(historical_usage, 12.5)
 
         cur.execute(
-            "SELECT usage_factor_period_0 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=0"
         )
         usage_period_0 = cur.fetchone()[0]
         self.assertEqual(usage_period_0, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_1 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=1"
         )
         usage_period_1 = cur.fetchone()[0]
         self.assertEqual(usage_period_1, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_2 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=2"
         )
         usage_period_2 = cur.fetchone()[0]
         self.assertEqual(usage_period_2, 0)
 
         cur.execute(
-            "SELECT usage_factor_period_3 FROM job_usage_factor_table WHERE username='user1'"
+            "SELECT value FROM job_usage_per_association_table "
+            "WHERE username='user1' AND bank='A' AND period=3"
         )
         usage_period_3 = cur.fetchone()[0]
         self.assertEqual(usage_period_3, 12.5)

--- a/t/t1011-job-archive-interface.t
+++ b/t/t1011-job-archive-interface.t
@@ -204,8 +204,8 @@ test_expect_success 'call view-job-records -o with an invalid field' '
 test_expect_success 'call view-user -J/--job-usage' '
 	flux account view-user -J ${username} > job_usage_breakdown.json &&
 	test_debug "jq -S . <job_usage_breakdown.json" &&
-	jq -e ".[0].usage_factor_period_0 >= 4" job_usage_breakdown.json &&
-	jq -e ".[1].usage_factor_period_0 >= 4" job_usage_breakdown.json
+	jq -e ".[0].value >= 4" job_usage_breakdown.json &&
+	jq -e ".[4].value >= 4" job_usage_breakdown.json
 '
 
 test_expect_success 'pass both -J and --fields; ensure ValueError is raised' '


### PR DESCRIPTION
#### Problem

The code that touches job usage calculation and its decay still reference `job_usage_factor_table` when it needs to use the new `job_usage_per_association_table`.

---

This PR reworks the job usage calculation and decay code to use the new `job_usage_per_association_table`. The job usage calculation pipeline has been refactored in the following ways:

* `update_job_usage()` now fetches userid from `association_table` at the start of each update cycle (because it is required as a key in the new table) and passes it through to downstream functions
* Removed the old logic that fetched job usage bins from `job_usage_factor_table`, as this data is now retrieved later in the pipeline from the new table.
* `calc_usage_factor()` is refactored to query job usage bins (the per-period usage values) from `job_usage_per_association_table` at the beginning of the calculation, replacing the previous approach where bins were passed in from the caller.
* `update_curr_usage_col()` is updated to `INSERT`/`UPDATE` rows in `job_usage_per_association_table` using the `(username, userid, bank, period)` schema instead of updating specific columns in the old table.
* `apply_decay_factor()` is refactored to fetch existing period values from the new table, apply decay calculations, and update the corresponding rows (by username, bank, and period) rather than updating multiple columns in a single row.

The `-J/--job-usage` optional argument for the `view-user` command has also been modified to refer to the new `job_usage_per_association_table` instead of the old one. The same modification has been made to the `clear-usage` command.

Existing tests that check job usage values only needed to be modified to query the new `job_usage_per_association_table`, and no changes to their actual expected values have needed to be made in this PR.

Closes #867