### PR TITLE
job usage: add reconfiguration support

### DIFF
--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -21,35 +21,6 @@ from flux.util import parse_fsd
 LOGGER = logging.getLogger(__name__)
 
 
-def add_usage_columns_to_table(
-    conn, table_name, priority_usage_reset_period=None, priority_decay_half_life=None
-):
-    # the number of columns (or 'bins') holding usage factors is determined by
-    # the following:
-    #
-    # PriorityUsageResetPeriod / PriorityDecayHalfLife
-    #
-    # each parameter represents a number of weeks by which to hold usage
-    # factors up to the time period where jobs no longer play a factor in
-    # calculating a usage factor
-    column_name = "usage_factor_period_0"
-    if priority_decay_half_life is not None and priority_usage_reset_period is not None:
-        num_columns = int(priority_usage_reset_period / priority_decay_half_life)
-    else:
-        num_columns = 4
-    for i in range(num_columns):
-        alter_stmt = (
-            "ALTER TABLE "
-            + table_name
-            + " ADD COLUMN "
-            + column_name
-            + " REAL DEFAULT 0.0"
-        )
-        conn.execute(alter_stmt)
-        conn.commit()
-        column_name = "usage_factor_period_" + str(i + 1)
-
-
 def set_half_life_period_end(conn, priority_decay_half_life=None):
     if priority_decay_half_life is not None:
         # convert number of weeks to seconds; this will be appended
@@ -152,16 +123,6 @@ def create_db(
                 last_job_timestamp  real        DEFAULT 0.0,
                 PRIMARY KEY (username, bank)
         );"""
-    )
-    add_usage_columns_to_table(
-        conn,
-        "job_usage_factor_table",
-        parse_fsd(str(priority_usage_reset_period))
-        if priority_usage_reset_period is not None
-        else (4 * 604800),
-        parse_fsd(str(priority_decay_half_life))
-        if priority_decay_half_life is not None
-        else 604800,
     )
     LOGGER.info("Created job_usage_factor_table successfully")
 

--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -12,12 +12,98 @@
 import csv
 import sqlite3
 import json
+import math
+import time
 
 import fluxacct
 from fluxacct.accounting.util import with_cursor
 from fluxacct.accounting import formatter as fmt
 from fluxacct.accounting import sql_util as sql
 from flux.util import parse_fsd
+
+
+@with_cursor
+def reconfigure_usage_bins(conn, cursor):
+    """
+    Update the usage bin configuration for all associations from scratch. This function
+    should be called *after* the admin has updated priority_decay_half_life,
+    priority_usage_reset_period, and/or decay_factor in config_table.
+
+    Args:
+        conn: The SQLite Connection object.
+        cursor: The SQLite Cursor object.
+    """
+    # read the new configuration from config_table
+    cursor.execute(
+        "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
+    )
+    half_life = cursor.fetchone()
+
+    cursor.execute(
+        "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
+    )
+    reset_period = cursor.fetchone()
+
+    if half_life is None or reset_period is None:
+        raise ValueError(
+            "priority_decay_half_life and priority_usage_reset_period must be set in "
+            "config_table before reconfiguring usage bins"
+        )
+
+    new_half_life = float(half_life[0])
+    new_reset_period = float(reset_period[0])
+    new_num_periods = math.ceil(new_reset_period / new_half_life)
+
+    # fetch all associations
+    cursor.execute(
+        "SELECT DISTINCT username, userid, bank FROM job_usage_per_association_table"
+    )
+    associations = cursor.fetchall()
+
+    try:
+        # delete all existing period rows for every association
+        cursor.execute("DELETE FROM job_usage_per_association_table")
+
+        # re-insert the correct number of period rows for every association
+        # initialized to 0.0 under the new configuration
+        for username, userid, bank in associations:
+            for period in range(new_num_periods):
+                cursor.execute(
+                    """
+                    INSERT INTO job_usage_per_association_table
+                    (username, userid, bank, period, value)
+                    VALUES (?, ?, ?, ?, 0.0)
+                    """,
+                    (username, userid, bank, period),
+                )
+
+        # reset last_job_timestamp for all associations so that update_job_usage()
+        # replays all jobs from scratch
+        cursor.execute("UPDATE job_usage_factor_table SET last_job_timestamp=0")
+
+        # reset the half-life period end timestamp so that update_job_usage() starts
+        # a fresh half-life window
+        cursor.execute(
+            """
+            UPDATE t_half_life_period_table
+            SET end_half_life_period=?
+            WHERE cluster='cluster'
+            """,
+            (str(time.time() + new_half_life),),
+        )
+        cursor.execute(
+            "INSERT INTO config_table (key, value) "
+            "VALUES ('reconfigure_time', ?) ON CONFLICT(key)"
+            "DO UPDATE SET value = excluded.value",
+            (time.time(),),
+        )
+
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        raise RuntimeError(
+            f"failed to reconfigure usage bins, rolled back all changes: {exc}"
+        )
 
 
 def export_db_info(conn):
@@ -243,6 +329,7 @@ def edit_config(conn, cursor, key_value_strings):
         key_value_strings: A list of key=value strings to update in config_table.
     """
     bin_config_keys = {"priority_usage_reset_period", "priority_decay_half_life"}
+    requires_rebin = False
 
     for key_value_string in key_value_strings:
         key, value = key_value_string.split("=")
@@ -250,11 +337,13 @@ def edit_config(conn, cursor, key_value_strings):
         if key in bin_config_keys:
             # parse value as Flux Standard Duration (FSD)
             value = parse_fsd(str(value))
+            requires_rebin = True
         if key == "decay_factor":
             if (float(value) < 0) or (float(value) > 1):
                 raise ValueError(
                     "decay_factor must be a floating-point value between 0 and 1"
                 )
+            requires_rebin = True
         cursor.execute(
             "UPDATE config_table SET value=? WHERE key=?",
             (value, key),
@@ -262,6 +351,26 @@ def edit_config(conn, cursor, key_value_strings):
         if cursor.rowcount == 0:
             raise ValueError(f"key {key} not found in config_table")
 
+    if requires_rebin:
+        choice = (
+            input(
+                "WARNING: changing one or more of priority_usage_reset_period, "
+                "priority_decay_half_life, or decay_factor requires re-binning all "
+                "of the job usage bins for every association in the flux-accounting "
+                "database and will reset the usage for every association to 0.0; are "
+                "you sure you want to continue? [y/n] "
+            )
+            .strip()
+            .lower()
+        )
+        if choice != "y":
+            # roll back the config_table updates
+            conn.rollback()
+            return 0
+        # pylint: disable=no-value-for-parameter
+        reconfigure_usage_bins(conn)
+
+    conn.commit()
     return 0
 
 

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -162,7 +162,7 @@ def calc_usage_factor(
     usage_factors = [row[1] for row in period_rows]
 
     # hl_period represents the number of seconds that represent one usage bin
-    hl_period = pdhl * 604800
+    hl_period = pdhl
 
     last_t_inactive = 0.0
     usg_current = 0.0
@@ -218,7 +218,7 @@ def calc_usage_factor(
 
 
 def check_end_hl(acct_conn, pdhl):
-    hl_period = pdhl * 604800
+    hl_period = pdhl
 
     cur = acct_conn.cursor()
 

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -291,7 +291,7 @@ def calc_parent_bank_usage(acct_conn, cur, bank):
     return total_usage
 
 
-def update_job_usage(acct_conn, pdhl=1):
+def update_job_usage(acct_conn):
     LOGGER.info(
         "beginning job-usage update for flux-accounting DB; "
         "slow response times may occur"
@@ -338,6 +338,13 @@ def update_job_usage(acct_conn, pdhl=1):
         for job in new_job_records:
             key = (job.userid, job.bank)
             association_jobs[key].append(job)
+
+        # get PriorityDecayHalfLife
+        pdhl = float(
+            cur.execute(
+                "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
+            ).fetchone()[0]
+        )
 
         # update the job usage for every user in the association_table
         for row in result:

--- a/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
+++ b/src/bindings/python/fluxacct/accounting/job_usage_calculation.py
@@ -319,6 +319,15 @@ def update_job_usage(acct_conn):
         cur.execute(s_assoc)
         result = cur.fetchall()
 
+        # fetch the last time the job_usage_per_association_table was reconfigured
+        # (if at all)
+        last_reconfigured = cur.execute(
+            "SELECT value FROM config_table WHERE key='reconfigure_time'"
+        ).fetchone()
+        last_reconfigured = (
+            last_reconfigured[0] if last_reconfigured is not None else 0.0
+        )
+
         # fetch new jobs for every association based on their last completed job
         s_new_jobs = """
             SELECT r.userid,r.id,r.t_submit,r.t_run,r.t_inactive,r.ranks,r.R,r.jobspec,
@@ -328,8 +337,9 @@ def update_job_usage(acct_conn):
             LEFT JOIN bank_table b
             ON r.bank = b.bank WHERE r.t_inactive > j.last_job_timestamp
             AND r.t_inactive > b.ignore_older_than
+            AND r.t_inactive > ?
         """
-        cur.execute(s_new_jobs)
+        cur.execute(s_new_jobs, (last_reconfigured,))
         new_jobs = cur.fetchall()
         new_job_records = j.convert_to_obj(new_jobs)
         # convert new jobs to a dictionary where they key is a tuple of the user ID and bank

--- a/src/cmd/flux-account-update-usage.py
+++ b/src/cmd/flux-account-update-usage.py
@@ -65,13 +65,6 @@ def main():
         "-p", "--path", dest="path", help="specify location of database file"
     )
     parser.add_argument(
-        "--priority-decay-half-life",
-        default=1,
-        type=int,
-        help="number of weeks for a job's usage contribution to a half-life decay",
-        metavar="PRIORITY_DECAY_HALF_LIFE",
-    )
-    parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -85,7 +78,7 @@ def main():
     conn = est_sqlite_conn(path)
 
     try:
-        job_usage.update_job_usage(conn, args.priority_decay_half_life)
+        job_usage.update_job_usage(conn)
     except sqlite3.OperationalError as exc:
         LOGGER.exception(
             "SQLite operational error during job-usage update; rolled back. "

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -794,13 +794,6 @@ def add_update_usage_arg(subparsers):
         formatter_class=flux.util.help_formatter(),
     )
     subparser_update_usage.set_defaults(func="update_usage")
-    subparser_update_usage.add_argument(
-        "--priority-decay-half-life",
-        default=1,
-        type=int,
-        help="number of weeks for a job's usage contribution to a half-life decay",
-        metavar="PRIORITY DECAY HALF LIFE",
-    )
 
 
 def add_add_queue_arg(subparsers):
@@ -1719,8 +1712,6 @@ def main():
                     "account-update-usage",
                     "-p",
                     path,
-                    "--priority-decay-half-life",
-                    str(args.priority_decay_half_life),
                 ],
                 check=True,
             )

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -115,7 +115,8 @@ TESTSCRIPTS = \
 	python/t1015_issue815.py \
 	python/t1016_issue853.py \
 	python/t1017_config_cmds.py \
-	python/t1018_job_usage_custom_bins.py
+	python/t1018_job_usage_custom_bins.py \
+	python/t1019_recalculate_usage.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -114,7 +114,8 @@ TESTSCRIPTS = \
 	python/t1014_clear_usage.py \
 	python/t1015_issue815.py \
 	python/t1016_issue853.py \
-	python/t1017_config_cmds.py
+	python/t1017_config_cmds.py \
+	python/t1018_job_usage_custom_bins.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/python/t1006_job_archive.py
+++ b/t/python/t1006_job_archive.py
@@ -521,7 +521,7 @@ class TestAccountingCLI(unittest.TestCase):
 
         self.assertEqual(job_usage, 17044.0)
 
-        jobs.update_job_usage(acct_conn, pdhl=1)
+        jobs.update_job_usage(acct_conn)
 
         cur.execute(s_stmt)
         job_usage = cur.fetchone()[0]

--- a/t/python/t1017_config_cmds.py
+++ b/t/python/t1017_config_cmds.py
@@ -13,6 +13,7 @@ import unittest
 import os
 import sqlite3
 import time
+from unittest.mock import patch
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import db_info_subcommands as d
@@ -55,7 +56,8 @@ class TestAccountingCLI(unittest.TestCase):
             d.edit_config(conn, key_value_strings=["priority_usage_reset_period=foo"])
 
     # successfully edit PriorityUsageResetPeriod
-    def test_05_edit_priority_usage_reset_period_success(self):
+    @patch("builtins.input", return_value="y")
+    def test_05_edit_priority_usage_reset_period_success(self, mock_input):
         d.edit_config(conn, key_value_strings=["priority_usage_reset_period=1234"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
@@ -63,7 +65,8 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(test["value"], "1234.0")
 
     # edit PriorityUsageResetPeriod using a Flux Standard Duration value
-    def test_06_edit_priority_usage_reset_period_fsd_success(self):
+    @patch("builtins.input", return_value="y")
+    def test_06_edit_priority_usage_reset_period_fsd_success(self, mock_input):
         d.edit_config(conn, key_value_strings=["priority_usage_reset_period=1d"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
@@ -76,7 +79,8 @@ class TestAccountingCLI(unittest.TestCase):
             d.edit_config(conn, key_value_strings=["priority_decay_half_life=foo"])
 
     # successfully edit PriorityDecayHalfLife
-    def test_08_edit_priority_decay_half_life_success(self):
+    @patch("builtins.input", return_value="y")
+    def test_08_edit_priority_decay_half_life_success(self, mock_input):
         d.edit_config(conn, key_value_strings=["priority_decay_half_life=1234"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
@@ -84,7 +88,8 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(test["value"], "1234.0")
 
     # edit PriorityDecayHalfLife using a Flux Standard Duration value
-    def test_09_edit_priority_decay_half_life_fsd_success(self):
+    @patch("builtins.input", return_value="y")
+    def test_09_edit_priority_decay_half_life_fsd_success(self, mock_input):
         d.edit_config(conn, key_value_strings=["priority_decay_half_life=1h"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
@@ -104,7 +109,8 @@ class TestAccountingCLI(unittest.TestCase):
             d.edit_config(conn, key_value_strings=["decay_factor=1.1"])
 
     # successfully edit decay_factor
-    def test_12_edit_decay_factor_success(self):
+    @patch("builtins.input", return_value="y")
+    def test_12_edit_decay_factor_success(self, mock_input):
         d.edit_config(conn, key_value_strings=["decay_factor=0.9"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='decay_factor'"

--- a/t/python/t1018_job_usage_custom_bins.py
+++ b/t/python/t1018_job_usage_custom_bins.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import time
+import ast
+from unittest.mock import patch
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import db_info_subcommands as d
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
+        global conn
+        global cur
+
+        conn = sqlite3.connect(self.dbname, timeout=60)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        # add banks, associations to database
+        b.add_bank(conn, bank="root", shares=1)
+        b.add_bank(conn, parent_bank="root", bank="A", shares=1)
+        u.add_user(conn, username="user1", uid=50001, bank="A")
+
+    # check parameters of config_table
+    def test_01_check_config(self):
+        result = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 2419200", result)
+        self.assertIn("priority_decay_half_life    | 604800", result)
+        self.assertIn("decay_factor                | 0.5", result)
+
+    def test_02_check_job_usage_per_association(self):
+        result = u.view_user(conn, user="user1", job_usage=True)
+        # evaluate the string as a Python list of dictionaries
+        self.assertEqual(len(ast.literal_eval(result)), 4)
+
+    # change the configuration of the bins to have a half-life period of 2 weeks
+    # instead of 1 week and a usage reset period of 6 weeks instead of 4 weeks, which
+    # will result in a total of 3 bins per-association
+    @patch("builtins.input", return_value="y")
+    def test_03_edit_configs_1(self, mock_input):
+        d.edit_config(conn, ["priority_usage_reset_period=42d"])
+        d.edit_config(conn, ["priority_decay_half_life=14d"])
+        result = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 3628800", result)
+        self.assertIn("priority_decay_half_life    | 1209600", result)
+
+    def test_04_reconfigure_bins_1(self):
+        result = u.view_user(conn, user="user1", job_usage=True)
+        # evaluate the string as a Python list of dictionaries
+        self.assertEqual(len(ast.literal_eval(result)), 3)
+
+    # change the configuration of the bins to have a half-life period of 8 hours and
+    # a usage reset period of 16 hours
+    @patch("builtins.input", return_value="y")
+    def test_05_edit_configs_2(self, mock_input):
+        d.edit_config(conn, ["priority_usage_reset_period=16h"])
+        d.edit_config(conn, ["priority_decay_half_life=8h"])
+        result = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 57600", result)
+        self.assertIn("priority_decay_half_life    | 28800", result)
+
+    def test_06_reconfigure_bins_2(self):
+        result = u.view_user(conn, user="user1", job_usage=True)
+        # evaluate the string as a Python list of dictionaries
+        self.assertEqual(len(ast.literal_eval(result)), 2)
+
+    # change the configuration of the bins to have a half-life period of 15 minutes and
+    # a usage reset period of 1 hour
+    @patch("builtins.input", return_value="y")
+    def test_07_edit_configs_3(self, mock_input):
+        d.edit_config(conn, ["priority_usage_reset_period=1h"])
+        d.edit_config(conn, ["priority_decay_half_life=15m"])
+        result = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 3600", result)
+        self.assertIn("priority_decay_half_life    | 900", result)
+
+    def test_08_reconfigure_bins_3(self):
+        result = u.view_user(conn, user="user1", job_usage=True)
+        # evaluate the string as a Python list of dictionaries
+        self.assertEqual(len(ast.literal_eval(result)), 4)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove(self.dbname)
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t1019_recalculate_usage.py
+++ b/t/python/t1019_recalculate_usage.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import time
+import json
+import ast
+from collections import defaultdict
+
+from unittest import mock
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import job_usage_calculation as jobs
+from fluxacct.accounting import jobs_table_subcommands as j
+from fluxacct.accounting import db_info_subcommands as d
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @staticmethod
+    def insert_job(job_id, userid, bank, t_submit, t_run, t_inactive):
+        R = json.dumps(
+            {
+                "version": 1,
+                "execution": {
+                    "R_lite": [{"rank": "0", "children": {"core": "0-3", "gpu": "0"}}],
+                    "starttime": 0,
+                    "expiration": 0,
+                    "nodelist": ["fluke[0]"],
+                },
+            }
+        )
+        jobspec = json.dumps({"attributes": {"system": {"bank": bank}}})
+        conn.execute(
+            "INSERT INTO jobs "
+            "(id, userid, t_submit, t_run, t_inactive, ranks, R, jobspec, bank) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (job_id, userid, t_submit, t_run, t_inactive, "0", R, jobspec, bank),
+        )
+        conn.commit()
+
+    @classmethod
+    @mock.patch("time.time", mock.MagicMock(return_value=0))
+    def setUpClass(self):
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        # the database is set up with the following parameters:
+        # Priority Decay Half-Life: 15 minutes (900 seconds)
+        # Priority Usage Reset Period: 1 hour (3600 seconds)
+        # So, for each association, a total of 4 rows will be inserted into
+        # job_usage_per_association_table where each row represents a 15-minute period.
+        # For the sake of these tests, time starts at 0, which means that each row
+        # represents the following number of seconds:
+        #
+        # p0    | p1       | p2         | p3
+        # -----------------------------------------
+        # 0-900 | 901-1800 | 1801-2700  | 2701-3600
+        c.create_db(
+            self.dbname,
+            priority_decay_half_life="15m",
+            priority_usage_reset_period="1h",
+        )
+        global conn
+        global cursor
+
+        conn = sqlite3.connect(self.dbname, timeout=60)
+        cursor = conn.cursor()
+
+        b.add_bank(conn, "root", 1)
+        b.add_bank(conn, "A", 1, "root")
+        u.add_user(conn, username="user1", bank="A", uid=50001)
+
+        # insert 1 1-node, 100-second-long job into DB
+        self.insert_job(1, 50001, "A", 1, 499, 599)
+
+        job_records = j.convert_to_obj(j.get_jobs(conn))
+        # convert jobs to dictionary to be referenced in unit tests below
+        user_jobs = defaultdict(list)
+        for job in job_records:
+            key = (job.userid, job.bank)
+            user_jobs[key].append(job)
+
+        conn.commit()
+
+    # If job usage is updated in the same period as the job above got completed, then it
+    # will show up in the first usage bin
+    @mock.patch("time.time", mock.MagicMock(return_value=600))
+    def test_01_update_usage(self):
+        jobs.update_job_usage(conn)
+        total_usage = u.view_user(conn, user="user1", format_string="{job_usage}")
+        # association as a total job usage of 100.0
+        self.assertIn("100.0", total_usage)
+        # association has the following job usage breakdown:
+        #
+        # p0  | p1 | p2 | p3
+        # ------------------
+        # 100 | 0  | 0  | 0
+        job_usage_breakdown = ast.literal_eval(
+            u.view_user(conn, user="user1", job_usage=True)
+        )
+        self.assertEqual(len(job_usage_breakdown), 4)
+        self.assertEqual(job_usage_breakdown[0]["value"], 100.0)
+        self.assertEqual(job_usage_breakdown[1]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[3]["value"], 0.0)
+
+    # Reconfigure job_usage_per_association_table to have the following parameters:
+    # Priority Decay Half-Life: 400 seconds
+    # Priority Usage Reset Period: 1200 seconds
+    # So, for each association, a total of 3 rows will be inserted into
+    # job_usage_per_association_table where each row represents a 400-second period:
+    #
+    # The usage for every association will be reset to 0.0 and job usage will be
+    # calculated from a fresh start.
+    @mock.patch("builtins.input", return_value="y")
+    @mock.patch("time.time", mock.MagicMock(return_value=1600))
+    def test_02_reconfigure_bins(self, mock_input):
+        d.edit_config(
+            conn, ["priority_usage_reset_period=1200s", "priority_decay_half_life=400s"]
+        )
+        result = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 1200", result)
+        self.assertIn("priority_decay_half_life    | 400", result)
+
+        # make sure association has a total of 3 rows in job_usage_per_association_table
+        num_rows = cursor.execute(
+            "SELECT * FROM job_usage_per_association_table WHERE username='user1'"
+        ).fetchall()
+        self.assertEqual(len(num_rows), 3)
+
+        total_usage = u.view_user(conn, user="user1", format_string="{job_usage}")
+        self.assertIn("0.0", total_usage)
+        # association has the following job usage breakdown:
+        #
+        # p0  | p1 | p2 |
+        # ---------------
+        # 0   | 0  | 0  |
+        job_usage_breakdown = ast.literal_eval(
+            u.view_user(conn, user="user1", job_usage=True)
+        )
+        self.assertEqual(len(job_usage_breakdown), 3)
+        self.assertEqual(job_usage_breakdown[0]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[1]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
+
+    # The total usage for the association will include all jobs seen since last
+    # reconfiguration
+    @mock.patch("time.time", mock.MagicMock(return_value=2500))
+    def test_03_insert_new_job(self):
+        # insert another 1-node, 1-second-long job
+        self.insert_job(2, 50001, "A", 100, 2300, 2400)
+        jobs.update_job_usage(conn)
+
+        total_usage = u.view_user(conn, user="user1", format_string="{job_usage}")
+        self.assertIn("100.0", total_usage)
+        job_usage_breakdown = ast.literal_eval(
+            u.view_user(conn, user="user1", job_usage=True)
+        )
+        self.assertEqual(len(job_usage_breakdown), 3)
+        self.assertEqual(job_usage_breakdown[0]["value"], 100.0)
+        self.assertEqual(job_usage_breakdown[1]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
+
+    # If "n" is input after editing some of the configuration parameters, the changes are
+    # not committed and rolled back
+    @mock.patch("builtins.input", return_value="n")
+    @mock.patch("time.time", mock.MagicMock(return_value=1600))
+    def test_04_reconfigure_bins_deny_confirm(self, mock_input):
+        d.edit_config(
+            conn, ["priority_usage_reset_period=6h", "priority_decay_half_life=1h"]
+        )
+        # make sure parameters remain the same as before the above edit_config() call
+        result = d.list_configs(conn)
+        self.assertIn("priority_usage_reset_period | 1200", result)
+        self.assertIn("priority_decay_half_life    | 400", result)
+
+    # decay_factor can be changed and the amount of decay applied to past jobs will be
+    # different
+    @mock.patch("builtins.input", return_value="y")
+    @mock.patch("time.time", mock.MagicMock(return_value=2600))
+    def test_05_edit_decay_factor(self, mock_input):
+        d.edit_config(conn, ["decay_factor=0.1"])
+        result = d.list_configs(conn)
+        print(result)
+        self.assertIn("decay_factor                | 0.1", result)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=3200))
+    def test_06_insert_new_job(self):
+        # insert another 1-node, 1000-second-long job
+        self.insert_job(3, 50001, "A", 100, 2100, 3100)
+        jobs.update_job_usage(conn)
+
+        total_usage = u.view_user(conn, user="user1", format_string="{job_usage}")
+        self.assertIn("1000.0", total_usage)
+        job_usage_breakdown = ast.literal_eval(
+            u.view_user(conn, user="user1", job_usage=True)
+        )
+        self.assertEqual(len(job_usage_breakdown), 3)
+        self.assertEqual(job_usage_breakdown[0]["value"], 1000.0)
+        self.assertEqual(job_usage_breakdown[1]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=3600))
+    def test_07_update_usage_new_decay_factor(self):
+        jobs.update_job_usage(conn)
+        total_usage = u.view_user(conn, user="user1", format_string="{job_usage}")
+        self.assertIn("100.0", total_usage)
+        job_usage_breakdown = ast.literal_eval(
+            u.view_user(conn, user="user1", job_usage=True)
+        )
+        self.assertEqual(len(job_usage_breakdown), 3)
+        self.assertEqual(job_usage_breakdown[0]["value"], 0.0)
+        self.assertEqual(job_usage_breakdown[1]["value"], 100.0)
+        self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove(self.dbname)
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t1093-config-table-commands.t
+++ b/t/t1093-config-table-commands.t
@@ -65,11 +65,13 @@ test_expect_success 'editing a key-value pair that does not exist raises error' 
 	grep "edit-config: ValueError: key i_dont_exist not found in config_table" edit_config_bad_2.out
 '
 
-test_expect_success 'edit both job usage parameters at the same time' '
-	flux account edit-config priority_decay_half_life=15m priority_usage_reset_period=1h &&
+test_expect_success 'edit multiple key-value pairs at the same time' '
+	flux account add-config key1=value1 &&
+	flux account add-config key2=value2 &&
+	flux account edit-config key1=foo1 key2=foo2 &&
 	flux account list-configs > edited_configs.out &&
-	grep "priority_usage_reset_period | 3600.0" edited_configs.out &&
-	grep "priority_decay_half_life    | 900.0" edited_configs.out
+	grep "key1                        | foo1" edited_configs.out &&
+	grep "key2                        | foo2" edited_configs.out
 '
 
 test_expect_success 'delete a key from config_table' '
@@ -99,11 +101,13 @@ test_expect_success 'trying to delete decay_factor does not work' '
 test_expect_success 'list all configs in config_table' '
 	flux account list-configs > list_configs.test &&
 	cat <<-EOF >list_configs.expected &&
-	key                         | value 
-	----------------------------+-------
-	priority_usage_reset_period | 3600.0
-	priority_decay_half_life    | 900.0 
-	decay_factor                | 0.5   
+	key                         | value  
+	----------------------------+--------
+	priority_usage_reset_period | 2419200
+	priority_decay_half_life    | 604800 
+	decay_factor                | 0.5    
+	key1                        | foo1   
+	key2                        | foo2   
 	EOF
 	test_cmp list_configs.test list_configs.expected
 '
@@ -111,9 +115,9 @@ test_expect_success 'list all configs in config_table' '
 test_expect_success 'list all configs in config_table in JSON format' '
 	flux account list-configs --json > list_configs_json.test &&
 	grep "\"key\": \"priority_usage_reset_period\"" list_configs_json.test &&
-	grep "\"value\": \"3600.0\"" list_configs_json.test &&
+	grep "\"value\": \"2419200\"" list_configs_json.test &&
 	grep "\"key\": \"priority_decay_half_life\"" list_configs_json.test &&
-	grep "\"value\": \"900.0\"" list_configs_json.test &&
+	grep "\"value\": \"604800\"" list_configs_json.test &&
 	grep "\"key\": \"decay_factor\"" list_configs_json.test &&
 	grep "\"value\": \"0.5\"" list_configs_json.test
 '
@@ -125,6 +129,8 @@ test_expect_success 'list all configs with --fields' '
 	key                        
 	---------------------------
 	decay_factor               
+	key1                       
+	key2                       
 	priority_decay_half_life   
 	priority_usage_reset_period
 	EOF
@@ -136,9 +142,11 @@ test_expect_success 'list all configs with format string' '
 	cat list_configs_format.test &&
 	cat <<-EOF >list_configs_format.expected &&
 	key->value
-	priority_usage_reset_period->3600.0
-	priority_decay_half_life->900.0
+	priority_usage_reset_period->2419200
+	priority_decay_half_life->604800
 	decay_factor->0.5
+	key1->foo1
+	key2->foo2
 	EOF
 	test_cmp list_configs_format.test list_configs_format.expected
 '


### PR DESCRIPTION
#### Problem

If an admin decides to change how flux-accounting applies decay to jobs as they get older or how long to keep jobs relevant towards calculating total usage (i.e. changing any of the `priority_usage_reset_period`, `priority_decay_half_life`, or `decay_factor` parameters), the usage bins per-association need to also be changed to reflect the new sizes of the bins.

---

This PR adds a helper function that will reconstruct the `job_usage_per_association_table` according to the new parameters that are defined in `config_table`. If any of the `priority_usage_reset_period`, `priority_decay_half_life`, or `decay_factor` parameters are changed, this function is called (with a warning message that requires additional input
since it is completely reconstructing the table according to brand new parameters) and the table is reconstructed to use the new parameters.

Once the update to `job_usage_per_association_table` is complete, a `reconfigure_time` key-value pair in `config_table` is inserted or updated with a timestamp that represents when `job_usage_per_association_table` was last reconfigured. This key-value pair will potentially be referenced during a job usage update to know which jobs to ignore and which ones to include in job usage calculation.

Some minor cleanup of the now soon-to-be-retired `job_usage_factor_table` is also included in this PR. I've also added some unit tests for the new helper function as well as for calculating job usage in general after a reconfiguration.

Closes #868