### PR TITLE
user_subcommands: don't catch and re-raise `ValueError` for `validate_queue()`, `validate_project()`

### DIFF
--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -32,7 +32,7 @@ def validate_queue(cur, queues):
         cur.execute("SELECT queue FROM queue_table WHERE queue=?", (queue,))
         result = cur.fetchone()
         if result is None:
-            raise ValueError(queue)
+            raise ValueError(f"queue {queue} does not exist in queue_table")
 
 
 def validate_project(cur, projects):
@@ -426,10 +426,7 @@ def add_user(
 
     # validate the queue(s) specified if any were passed in
     if queues != "":
-        try:
-            validate_queue(cur, queues=queues)
-        except ValueError as bad_queue:
-            raise ValueError(f"queue {bad_queue} does not exist in queue_table")
+        validate_queue(cur, queues=queues)
 
     # validate the project(s) specified if any were passed in;
     # add default project name ('*') to project(s) specified if
@@ -647,10 +644,7 @@ def edit_user(conn, cur, username, bank=None, **kwargs):
                 continue
 
             if field == "queues":
-                try:
-                    validate_queue(cur, queues=value)
-                except ValueError as bad_queue:
-                    raise ValueError(f"queue {bad_queue} does not exist in queue_table")
+                validate_queue(cur, queues=value)
             elif field == "projects":
                 try:
                     updates[field] = validate_project(cur, projects=value)

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -43,7 +43,7 @@ def validate_project(cur, projects):
         cur.execute("SELECT project FROM project_table WHERE project=?", (project,))
         result = cur.fetchone()
         if result is None:
-            raise ValueError(project)
+            raise ValueError(f"project {project} does not exist in project_table")
 
     return ",".join(project_list)
 
@@ -432,10 +432,7 @@ def add_user(
     # add default project name ('*') to project(s) specified if
     # any were passed in
     if projects != "*":
-        try:
-            projects = validate_project(cur, projects=projects)
-        except ValueError as bad_project:
-            raise ValueError(f"project {bad_project} does not exist in project_table")
+        projects = validate_project(cur, projects=projects)
 
     # Determine the default project for user. If no projects were specified, use '*' as
     # the default. If projects were specified and a default project name was not passed,
@@ -646,12 +643,7 @@ def edit_user(conn, cur, username, bank=None, **kwargs):
             if field == "queues":
                 validate_queue(cur, queues=value)
             elif field == "projects":
-                try:
-                    updates[field] = validate_project(cur, projects=value)
-                except ValueError as bad_project:
-                    raise ValueError(
-                        f"project {bad_project} does not exist in project_table"
-                    )
+                updates[field] = validate_project(cur, projects=value)
 
             update_stmt = f"UPDATE association_table SET {field}=? WHERE username=?"
             tup = (updates[field], username)


### PR DESCRIPTION
#### Problem

The `validate_queue()` and `validate_project()` helper functions raises a `ValueError` when it cannot find a specified queue or project in the flux-accounting database, but the callers of these helper functions also wrap their respective calls in a `try/except` just to re-raise a `ValueError` with a more specific error message.

---

This PR moves the specific error message to the `validate_queue()` and `validate_project()` helpers and removes the `try/except` block around the various calls to `validate_queue()` throughout `user_subcommands.py`.