### PR TITLE
edit-user: add incremental queue management to command

### DIFF
--- a/doc/man1/flux-account-edit-user.rst
+++ b/doc/man1/flux-account-edit-user.rst
@@ -80,6 +80,14 @@ The list of modifiable fields for an association are as follows:
     The max number of jobs in SCHED state an association can have at any given
     time.
 
+.. option:: --add-queue
+
+    Add a single queue to the association's list of permissible queues.
+
+.. option:: --delete-queue
+
+    Remove a single queue from the association's list of permissible queues.
+
 All of the attributes able to be modified can be reset to their default value
 by passing ``-1`` as the value for the field. Multiple fields can be edited at
 the same time by passing them on the command line.

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -207,6 +207,54 @@ def clear_projects(conn, cur, username, bank=None):
     return 0
 
 
+def modify_queues(conn, cur, username, bank, add_queue=None, delete_queue=None):
+    """
+    Incrementally add or remove a queue from a user's existing queues.
+
+    Args:
+        conn: The SQLite Connection object.
+        cur: The SQLite Cursor object.
+        username: The username of the association.
+        bank: The bank the association belongs to (if None, will apply to all banks).
+        add_queue: A queue to add to the user's existing queues.
+        delete_queue: A queue to remove from the user's existing queues.
+    """
+    select_stmt = "SELECT queues, bank FROM association_table WHERE username=?"
+    params = [username]
+    if bank is not None:
+        select_stmt += " AND bank=?"
+        params.append(bank)
+
+    cur.execute(select_stmt, tuple(params))
+    rows = cur.fetchall()
+
+    if not rows:
+        raise ValueError(f"user {username} not found in association_table")
+
+    for row in rows:
+        current_queues = row["queues"] if row["queues"] else ""
+        row_bank = row["bank"]
+        queue_list = [q.strip() for q in current_queues.split(",") if q.strip()]
+
+        if add_queue:
+            validate_queue(cur, queues=add_queue)
+            if add_queue not in queue_list:
+                queue_list.append(add_queue)
+        if delete_queue:
+            if delete_queue in queue_list:
+                queue_list.remove(delete_queue)
+
+        # update the "queues" property for the row
+        new_queues = ",".join(queue_list)
+        update_stmt = (
+            "UPDATE association_table SET queues=? WHERE username=? AND bank=?"
+        )
+        update_params = [new_queues, username, row_bank]
+        cur.execute(update_stmt, tuple(update_params))
+
+    return 0
+
+
 def insert_per_assoc_usage_rows(conn, cur, username, uid, bank):
     """
     Insert a row for each job usage period into job_usage_per_association_table for a

--- a/src/bindings/python/fluxacct/accounting/user_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/user_subcommands.py
@@ -586,6 +586,7 @@ def delete_user(conn, cur, username, bank, force=False):
     return 0
 
 
+# pylint: disable=too-many-statements
 @with_cursor
 def edit_user(conn, cur, username, bank=None, **kwargs):
     """
@@ -612,6 +613,8 @@ def edit_user(conn, cur, username, bank=None, **kwargs):
             running jobs.
         queues: A comma-separated list of all of the queues an association can run jobs
             under.
+        add_queue: A single queue to add to the user's existing queues.
+        delete_queue: A single queue to remove from the user's existing queues.
         projects: A comma-separated list of all of the projects an association can run jobs
             under.
         default_project: The association's default project.
@@ -624,6 +627,7 @@ def edit_user(conn, cur, username, bank=None, **kwargs):
             * the default bank for an association is attempted to be reset with -1
             * a queue being passed-in cannot be found in queue_table.
             * a project being passed-in cannot be found in project_table.
+            * both queues and add_queue/delete_queue are specified simultaneously.
     """
     editable_fields = {
         "userid",
@@ -643,9 +647,25 @@ def edit_user(conn, cur, username, bank=None, **kwargs):
         field: value for field, value in kwargs.items() if field in editable_fields
     }
 
-    if not updates:
+    add_queue = kwargs.get("add_queue")
+    delete_queue = kwargs.get("delete_queue")
+
+    if not updates and not add_queue and not delete_queue:
         # no editable fields were provided; raise an exception
         raise ValueError("no fields provided for update")
+
+    # validate that queues and add_queue/delete_queue are not used together
+    if updates.get("queues") is not None and (add_queue or delete_queue):
+        raise ValueError(
+            "cannot specify --queues with --add-queue or --delete-queue; "
+            "use either full replacement (--queues) or incremental operations "
+            "(--add-queue/--delete-queue)"
+        )
+
+    if add_queue and delete_queue and add_queue == delete_queue:
+        raise ValueError("cannot pass queue to both --add-queue and --delete-queue")
+    if add_queue or delete_queue:
+        modify_queues(conn, cur, username, bank, add_queue, delete_queue)
 
     for field, value in updates.items():
         if value is not None:

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -270,6 +270,8 @@ class AccountingService:
                 max_nodes=msg.payload.get("max_nodes"),
                 max_cores=msg.payload.get("max_cores"),
                 queues=msg.payload.get("queues"),
+                add_queue=msg.payload.get("add_queue"),
+                delete_queue=msg.payload.get("delete_queue"),
                 projects=msg.payload.get("projects"),
                 default_project=msg.payload.get("default_project"),
                 max_sched_jobs=msg.payload.get("max_sched_jobs"),

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -359,6 +359,18 @@ def add_edit_user_arg(subparsers):
         metavar="QUEUES",
     )
     subparser_edit_user.add_argument(
+        "--add-queue",
+        help="add a queue to the user's existing queues",
+        default=None,
+        metavar="QUEUE",
+    )
+    subparser_edit_user.add_argument(
+        "--delete-queue",
+        help="remove a queue from the user's existing queues",
+        default=None,
+        metavar="QUEUE",
+    )
+    subparser_edit_user.add_argument(
         "-P",
         "--projects",
         help="projects the user is allowed to submit jobs under",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -96,6 +96,7 @@ TESTSCRIPTS = \
 	t1091-mf-priority-queue-partial-release.t \
 	t1092-mf-priority-afterany-partial-release.t \
 	t1093-config-table-commands.t \
+	t1094-edit-user-properties.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \
@@ -116,7 +117,8 @@ TESTSCRIPTS = \
 	python/t1016_issue853.py \
 	python/t1017_config_cmds.py \
 	python/t1018_job_usage_custom_bins.py \
-	python/t1019_recalculate_usage.py
+	python/t1019_recalculate_usage.py \
+	python/t1020_edit_user_properties.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/python/t1020_edit_user_properties.py
+++ b/t/python/t1020_edit_user_properties.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import os
+import sqlite3
+import time
+from unittest.mock import patch
+
+from fluxacct.accounting import create_db as c
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import queue_subcommands as q
+
+
+class TestAccountingCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # create test accounting database
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
+        global conn
+        global cur
+
+        conn = sqlite3.connect(self.dbname, timeout=60)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        # add simple database hierarchy
+        b.add_bank(conn, "root", 1)
+        b.add_bank(conn, "A", 1, "root")
+        u.add_user(conn, username="user1", bank="A", uid=50001)
+
+        # add queues
+        q.add_queue(conn, queue="queue_1")
+        q.add_queue(conn, queue="queue_2")
+        q.add_queue(conn, queue="queue_3")
+
+    def test_01_add_queue_to_user(self):
+        # Add queue_1 to user1
+        u.edit_user(conn, username="user1", bank="A", add_queue="queue_1")
+
+        # verify queue was added
+        cur.execute(
+            "SELECT queues FROM association_table WHERE username=? AND bank=?",
+            ("user1", "A"),
+        )
+        result = cur.fetchone()
+        self.assertEqual(result[0], "queue_1")
+
+    def test_02_add_another_queue(self):
+        u.edit_user(conn, username="user1", bank="A", add_queue="queue_2")
+
+        # verify both queues are present
+        cur.execute(
+            "SELECT queues FROM association_table WHERE username=? AND bank=?",
+            ("user1", "A"),
+        )
+        result = cur.fetchone()
+        queue_list = result[0].split(",")
+        self.assertIn("queue_1", queue_list)
+        self.assertIn("queue_2", queue_list)
+
+    def test_03_add_duplicate_queue(self):
+        # trying to add queue_1 again won't affect existing list
+        u.edit_user(conn, username="user1", bank="A", add_queue="queue_1")
+        cur.execute(
+            "SELECT queues FROM association_table WHERE username=? AND bank=?",
+            ("user1", "A"),
+        )
+        result = cur.fetchone()
+        queue_list = result[0].split(",")
+        self.assertIn("queue_1", queue_list)
+        self.assertIn("queue_2", queue_list)
+
+    def test_04_delete_queue(self):
+        u.edit_user(conn, username="user1", bank="A", delete_queue="queue_1")
+
+        # verify queue_1 is removed but queue_2 remains
+        cur.execute(
+            "SELECT queues FROM association_table WHERE username=? AND bank=?",
+            ("user1", "A"),
+        )
+        result = cur.fetchone()
+        queue_list = result[0].split(",") if result[0] else []
+        self.assertNotIn("queue_1", queue_list)
+        self.assertIn("queue_2", queue_list)
+
+    def test_05_delete_nonexistent_queue(self):
+        # try to delete a queue that user doesn't have won't affect existing list
+        u.edit_user(conn, username="user1", bank="A", delete_queue="queue_3")
+        cur.execute(
+            "SELECT queues FROM association_table WHERE username=? AND bank=?",
+            ("user1", "A"),
+        )
+        result = cur.fetchone()
+        queue_list = result[0].split(",") if result[0] else []
+        self.assertNotIn("queue_1", queue_list)
+        self.assertIn("queue_2", queue_list)
+
+    def test_06_cannot_use_queues_with_add_queue(self):
+        # verify that --queues and --add-queue cannot be used together
+        with self.assertRaisesRegex(
+            ValueError, "cannot specify --queues with --add-queue"
+        ):
+            u.edit_user(
+                conn,
+                username="user1",
+                bank="A",
+                queues="queue_1,queue_2",
+                add_queue="queue_3",
+            )
+
+    def test_07_validate_nonexistent_queue(self):
+        # try to add a queue that doesn't exist in queue_table
+        with self.assertRaisesRegex(ValueError, "does not exist in queue_table"):
+            u.edit_user(conn, username="user1", bank="A", add_queue="nonexistent_queue")
+
+    def test_08_queue_passed_to_both_args(self):
+        # a queue passed to both add_queue and delete_queue raises ValueError
+        with self.assertRaisesRegex(
+            ValueError, "cannot pass queue to both --add-queue and --delete-queue"
+        ):
+            u.edit_user(
+                conn,
+                username="user1",
+                bank="A",
+                add_queue="queue_1",
+                delete_queue="queue_1",
+            )
+
+    # remove database and log file
+    @classmethod
+    def tearDownClass(self):
+        conn.close()
+        os.remove(self.dbname)
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t1094-edit-user-properties.t
+++ b/t/t1094-edit-user-properties.t
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+test_description='test incremental queue operations for associations'
+
+. `dirname $0`/sharness.sh
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -Slog-stderr-level=1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'add a bank to the DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to the DB' '
+	flux account add-user --username=user1 --userid=5001 --bank=A
+'
+
+test_expect_success 'add queues to the DB' '
+	flux account add-queue queue_1 &&
+	flux account add-queue queue_2 &&
+	flux account add-queue queue_3
+'
+
+test_expect_success 'add queue_1 to user1' '
+	flux account edit-user user1 --add-queue=queue_1 &&
+	flux account view-user user1 > user1_queue1.out &&
+	grep "\"queues\": \"queue_1\"" user1_queue1.out
+'
+
+test_expect_success 'add queue_2 to user1' '
+	flux account edit-user user1 --add-queue=queue_2 &&
+	flux account view-user user1 > user1_queue2.out &&
+	grep "\"queues\": \"queue_1,queue_2\"" user1_queue2.out
+'
+
+test_expect_success 'adding duplicate queue will not affect existing list' '
+	flux account edit-user user1 --add-queue=queue_1 &&
+	flux account view-user user1 > no_duplicates.out &&
+	grep "\"queues\": \"queue_1,queue_2\"" no_duplicates.out
+'
+
+test_expect_success 'delete queue_1 from user1' '
+	flux account edit-user user1 --delete-queue=queue_1 &&
+	flux account view-user user1 > user1_deleted_queue1.out &&
+	grep "\"queues\": \"queue_2\"" user1_deleted_queue1.out
+'
+
+test_expect_success 'deleting non-existent queue will not affect existing list' '
+	flux account edit-user user1 --delete-queue=queue_3 &&
+	flux account view-user user1 > deleted_queue2.out
+	grep "\"queues\": \"queue_2\"" deleted_queue2.out
+'
+
+test_expect_success 'cannot use --queues with --add-queue' '
+	test_must_fail flux account edit-user user1 \
+		--queues=queue_1,queue_2 --add-queue=queue_3 > conflict.out 2>&1 &&
+	grep "cannot specify --queues with --add-queue" conflict.out
+'
+
+test_expect_success 'cannot use --queues with --delete-queue' '
+	test_must_fail flux account edit-user user1 \
+		--queues=queue_1,queue_2 --delete-queue=queue_3 > conflict2.out 2>&1 &&
+	grep "cannot specify --queues with --add-queue" conflict2.out
+'
+
+test_expect_success 'adding non-existent queue should fail' '
+	test_must_fail flux account edit-user user1 \
+		--add-queue=nonexistent_queue > bad_queue.out 2>&1 &&
+	grep "does not exist in queue_table" bad_queue.out
+'
+
+test_expect_success 'can still use --queues for full replacement' '
+	flux account edit-user user1 --queues=queue_1,queue_3 &&
+	flux account view-user user1 > user1_replaced_queues.out &&
+	grep "\"queues\": \"queue_1,queue_3\"" user1_replaced_queues.out
+'
+
+test_expect_success 'add queue_2 back using --add-queue' '
+	flux account edit-user user1 --add-queue=queue_2 &&
+	flux account view-user user1 > user1_three_queues.out &&
+	grep "\"queues\": \"queue_1,queue_3,queue_2\"" user1_three_queues.out
+'
+
+test_expect_success 'add another bank so user can belong to more than one bank' '
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-user --username=user1 --bank=B
+'
+
+test_expect_success 'add queue_1 to user1/B association' '
+	flux account edit-user user1 --bank=B --add-queue=queue_1 &&
+	flux account view-user user1 > user1_B_queue2.out &&
+	grep "\"queues\": \"queue_1\"" user1_B_queue2.out
+'
+
+test_expect_success 'add queue_2 across all of their banks' '
+	flux account edit-user user1 --add-queue=queue_2 &&
+	flux account view-user user1 > user1_both_banks.out &&
+	grep "\"queues\": \"queue_1,queue_2\"" user1_both_banks.out &&
+	grep "\"queues\": \"queue_1,queue_3,queue_2\"" user1_both_banks.out
+'
+
+test_expect_success '--add-queue and --delete-queue raise error when same queue is passed' '
+	test_must_fail flux account edit-user user1 \
+		--add-queue=queue_2 --delete-queue=queue_2 > double_queue.out 2>&1 &&
+	grep "cannot pass queue to both --add-queue and --delete-queue" double_queue.out
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Currently, adding a queue to a user's association requires passing the complete list of all queues they should have access to via `--queues`, which requires querying the user's current queues, manually constructing the full comma-delimited list, and passing the entire list to `edit-user`.

---

This PR adds incremental queue operations to the `edit-user` command:

* `--add-queue=<queue>` adds a single queue to existing queues
* `--delete-queue=<queue>` removes a single queue from existing queues

These options work across all of a user's associations when no bank is specified, or on a specific association when used with `--bank`. The existing `--queues` option remains available for full replacement when needed, but cannot be used simultaneously with the new incremental options.

The `edit-user(1)` man page has also been updated to include the new options.

Closes #889 