### PR TITLE
NEWS: add release notes for v0.59.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+flux-accounting version 0.59.0 - 2026-07-06
+-------------------------------------------
+
+#### Features
+
+* add bindings, commands for interacting with config_table (#881)
+
+* database: add new table to store job usage factors (#882)
+
+* job usage: use new table for usage calculation, decay (#883)
+
+* job usage: add reconfiguration support (#887)
+
+* edit-user: add incremental queue management to command (#892)
+
+* plugin: add per-association dependency for max resources in SCHED state in a
+queue (#871)
+
+#### Fixes
+
+* user_subcommands: don't catch and re-raise `ValueError` for
+`validate_queue()`, `validate_project()` (#891)
+
+#### Testsuite
+
+* t1011: improve job usage check in tests (#886)
+
+* github: bump the github-actions group with 4 updates (#888)
+
 flux-accounting version 0.58.0 - 2026-06-02
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.59.0`.

---

This PR adds some. Once this lands, I'll go ahead and create an annotated tag with the following:

```console
git tag -a v0.59.0 -m "Tag v0.59.0" && git push upstream v0.59.0
```