### PR TITLE
add new `bank-info` command for viewing normalized shares, usage on a cluster

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -20,6 +20,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-delete-bank.1 \
 	man1/flux-account-edit-bank.1 \
 	man1/flux-account-list-banks.1 \
+	man1/flux-account-bank-info.1 \
 	man1/flux-account-view-queue.1 \
 	man1/flux-account-add-queue.1 \
 	man1/flux-account-delete-queue.1 \

--- a/doc/components/bank-info.rst
+++ b/doc/components/bank-info.rst
@@ -1,0 +1,200 @@
+.. _bank-info:
+
+#######################################
+Understanding The ``bank-info`` Command
+#######################################
+
+********
+Overview
+********
+
+The ``bank-info`` command provides a comprehensive view of fairshare
+and resource allocation information for banks and users within the
+flux-accounting database. It displays normalized shares, usage
+statistics, and fairshare values in a hierarchical tree structure that
+reflects the organization of banks and their associations.
+
+This command serves multiple purposes:
+
+- **Quick status checks**: View current resource allocation and usage at a
+  glance
+- **Hierarchy visualization**: Understand the relationship between banks and
+  users
+- **Resource analysis**: Compare allocated shares versus actual usage
+
+Unlike :man1:`flux-account-view-bank` and :man1:`flux-account-view-user`
+which display detailed database attributes, ``bank-info`` focuses
+specifically on share distribution and usage metrics that *may* affect job
+scheduling priorities.
+
+*****************
+Command Execution
+*****************
+
+When called without options, ``bank-info`` displays information for the
+current association. To view the entire database hierarchy, pass the ``-t``
+flag along with the name of the root bank:
+
+.. code-block:: console
+
+    $ flux account bank-info -t root
+    Name                     Shares  Norm Shares   Norm Usage   Level FS
+    root                          1     1.000000     1.000000        inf
+    A                             1     0.333333     0.000000         --
+      user1                       1     0.166667     0.000000      0.500
+      user2                       1     0.166667     0.000000      0.500
+    B                             1     0.333333     0.000000         --
+      user3                       1     0.333333     0.000000      0.500
+    C                             1     0.333333     0.000000         --
+      user1                       1     0.333333     0.000000      0.500
+
+************************
+Understanding the Output
+************************
+
+The output columns provide different perspectives on resource
+allocation and usage:
+
+In the example above, the normalized shares calculation proceeds as
+follows:
+
+- ``root`` has a normalized shares value of 1.0 (by definition, this represents
+  a 100% share of all resources)
+- Banks ``A``, ``B``, and ``C`` each have 1 share out of 3 total sibling
+  shares, so each gets :math:`1/3 * 1.0 = 0.333333` normalized shares
+- ``user1`` in bank ``A`` has 1 share out of 2 total shares in that
+  bank, so they get :math:`1/2 * 0.333333 = 0.166667` normalized shares
+- ``user3`` in bank ``B`` is the only user, so they get
+  :math:`1/1 * 0.333333 = 0.33333` normalized shares
+
+Name
+  The bank or username, where the level of indentation represents hierarchical
+  depth within the tree structure. Associations are indented one additional
+  space beyond their parent bank.
+
+Shares
+  The raw share allocation assigned to this bank or user within its
+  parent.
+
+Normalized Shares
+  Normalized shares represent each entity's fraction of total root
+  resources by multiplying share proportions up the bank tree. The
+  calculation propagates from parent to child:
+
+  .. math::
+
+    \text{S}_{normalized_{node}} = \frac{\text{shares}_{node}}{\text{shares}_{node+siblings}} \times \text{S}_{normalized_{parent}}
+
+  The root bank always has normalized shares of 1.0. Each child's
+  normalized shares are computed by taking its fraction of siblings'
+  shares and multiplying by its parent's normalized shares. This
+  multiplicative calculation ensures that normalized shares always sum
+  to the parent's normalized shares and represent the entity's portion
+  of the root allocation.
+
+Usage
+  Total job usage accumulated by this entity (displayed only with
+  ``--verbose``). For associations, this is their individual usage.
+  For banks, this is the sum of all usage by users within that bank.
+
+Norm Usage
+  Normalized usage represents this entity's proportion of total system
+  usage. Calculated as:
+
+  .. math::
+
+    \text{Usage}_{normalized_{node}} = \frac{\text{Usage}_{node}}{\text{Usage}_{root}}
+
+Level FS
+  The fair-share value for the association. For more details on
+  fairshare calculation, see :doc:`fair-share`.
+
+********
+Examples
+********
+
+Monitoring resource consumption
+===============================
+
+We can compare allocated shares against actual usage to identify
+over-consuming or under-utilizing associations:
+
+.. code-block:: console
+
+    $ flux account bank-info -t root -v
+    Name                      Shares  Norm Shares        Usage   Norm Usage  Level FS
+    root                           1     1.000000      10000.0     1.000000       inf
+     A                             7     0.700000       8500.0     0.850000        --
+      user1                        3     0.300000       5000.0     0.500000     0.333
+      user2                        4     0.400000       3500.0     0.350000     0.667
+     B                             3     0.300000       1500.0     0.150000        --
+      user3                        1     0.300000       1500.0     0.150000     1.000
+
+In this example, bank ``A`` has 7 shares out of 10 total, giving it 70% of root
+resources (0.7 normalized shares), and users within it are responsible for 85%
+of the system's total usage. 
+
+Within bank ``A``, ``user1`` has 3 shares out of 7, so it has
+:math:`3/7 \times 0.7 = 0.3` (30% of root resources) normalized shares, and is
+responsible for 50% of the system's total usage. Similarly, ``user2`` gets
+:math:`4/7 * 0.7 = 0.4` (40% of root resources) normalized shares.
+
+Bank ``B`` has 3 shares out of 10 total, giving it 0.3 normalized shares, and
+its sole user ``user3`` is responsible for 15% of the system's total usage.
+
+Analyzing hierarchical share distribution
+=========================================
+
+Shares cascade through multiple levels of banks all the way down to users:
+
+.. code-block:: console
+
+    $ flux account bank-info -t root
+    Name                      Shares  Norm Shares   Norm Usage  Level FS
+    root                           1     1.000000     0.000000       inf
+     A                           100     0.500000     0.000000        --
+      Aa                          60     0.300000     0.000000        --
+       user1                       1     0.100000     0.000000     0.500
+       user2                       2     0.200000     0.000000     0.500
+      Ab                          40     0.200000     0.000000        --
+       user3                       1     0.200000     0.000000     0.500
+     B                           100     0.500000     0.000000        --
+      user4                        1     0.500000     0.000000     0.500
+
+This multi-level hierarchy demonstrates how normalized shares propagate down
+the tree:
+
+- Banks ``A`` and ``B`` each have 100 shares out of 200 total, so they each
+  get: :math:`100/200 * 1.0 = 0.5` normalized shares
+- Bank ``Aa`` has 60 shares out of 100 within ``A``, so it gets:
+  :math:`60/100 * 0.5 = 0.3` normalized shares
+- Bank ``Ab`` has 40 shares out of 100 within ``A``, so it gets:
+  :math:`40/100 * 0.5 = 0.2` normalized shares
+- ``user1`` has 1 share out of 3 total user shares in ``Aa``, so they get:
+  :math:`1/3 * 0.3 = 0.1` normalized shares
+- ``user2`` has 2 shares out of 3 total user shares in ``Aa``, so they get:
+  :math:`2/3 * 0.3 = 0.2` normalized shares
+- ``user3`` is the only user in ``Ab``, so they get: :math:`1/1 * 0.2 = 0.2`
+  normalized shares
+- ``user4`` is the only user in ``B``, so they get: :math:`1/1 * 0.5 = 0.5`
+  normalized shares
+
+Each entity's normalized shares represent its fraction of total root
+resources.
+
+****************
+Related Commands
+****************
+
+- :man1:`flux-account-view-bank` - Display detailed database attributes for a bank
+- :man1:`flux-account-view-user` - Display detailed database attributes for a user
+- :man1:`flux-account-add-bank` - Add a new bank to the hierarchy
+- :man1:`flux-account-add-user` - Add a user association to a bank
+- :man1:`flux-account-edit-bank` - Modify bank attributes including shares
+- :man1:`flux-account-edit-user` - Modify user association attributes including shares
+
+********
+See Also
+********
+
+:doc:`fair-share`, :doc:`job-priorities`, :doc:`database-administration`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,5 +21,6 @@ Table of Contents
    components/projects
    components/limits
    components/job-priorities
+   components/bank-info
    presentations/hpsf
    index_man

--- a/doc/man1/flux-account-bank-info.rst
+++ b/doc/man1/flux-account-bank-info.rst
@@ -1,0 +1,52 @@
+.. flux-help-section: flux account
+
+=========================
+flux-account-bank-info(1)
+=========================
+
+
+SYNOPSIS
+========
+
+**flux** **account** **bank-info** [OPTIONS]
+
+DESCRIPTION
+===========
+
+.. program:: flux account bank-info
+
+:program:`flux account bank-info` displays fair-share and shares information
+for banks and users in the database. By default, if no options are specified,
+it shows information for the current user.
+
+.. option:: -t/--tree <bank>
+
+    Display all children of <bank>, including users.
+
+.. option:: -T/--tree-no-users <bank>
+
+    Display all children of <bank>, excluding users.
+
+.. option:: -r/--to-root <bank>
+
+    Display all parents for <bank> up to the root.
+
+.. option:: -u/--user <user>
+
+    Display all banks for <user>.
+
+.. option:: -v/--verbose
+
+    Display detailed usage information.
+
+.. option:: -P/--parsable
+
+    Output pipe (``|``) delimited columns for easy parsing.
+
+.. option:: -n/--noheader
+
+    Do not display column headers.
+
+.. option:: -x/--exclude <bank>
+
+    Do not display <bank> in output (defaults to 'expired').

--- a/doc/man1/flux-account.rst
+++ b/doc/man1/flux-account.rst
@@ -129,6 +129,13 @@ List all of the banks in the ``bank_table``.
 
 See :man1:`flux-account-list-banks` for more details.
 
+bank-info
+^^^^^^^^^
+
+Display fairshare and priority information for banks and users.
+
+See :man1:`flux-account-bank-info` for more details.
+
 QUEUE ADMINISTRATION
 ====================
 

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -258,4 +258,11 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-bank-info",
+        "flux-account-bank-info",
+        "view shares and fair-share information in the flux-accounting database",
+        [author],
+        1,
+    ),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -561,3 +561,4 @@ nodemin
 nodesec
 msc
 msn
+noheader

--- a/src/bindings/python/fluxacct/accounting/bank_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/bank_subcommands.py
@@ -10,6 +10,8 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import sqlite3
+import os
+import pwd
 
 import fluxacct.accounting
 from fluxacct.accounting import user_subcommands as u
@@ -85,6 +87,115 @@ def reactivate_bank(conn, cur, bank, parent_bank):
 #                   Subcommand Functions                      #
 #                                                             #
 ###############################################################
+
+
+def _build_sharetree(cur):
+    """Build hierarchical sharetree with normalized shares and usage."""
+    sharetree = {}
+
+    # get root bank
+    cur.execute("SELECT bank, shares, job_usage FROM bank_table WHERE parent_bank=''")
+    root = cur.fetchone()
+    if not root:
+        raise ValueError("No root bank found in bank_table")
+
+    root_bank_name, root_shares, root_usage = root
+    fqname = f"/{root_bank_name}/"
+    sharetree[fqname] = {
+        "name": fqname,
+        "shortname": root_bank_name,
+        "parent": "",
+        "children": [],
+        "shares": root_shares,
+        "nshares": 1.0,
+        "usage": root_usage,
+        "nusage": 1.0,
+        "priority": float("nan"),
+        "fshare": float("inf"),
+        "depth": 0,
+        "isuser": False,
+    }
+
+    # recursively build tree
+    def build_tree(parent_name, parent_fqname, depth):
+        # get sub-banks
+        cur.execute(
+            "SELECT bank, shares, job_usage FROM bank_table "
+            "WHERE parent_bank=? ORDER BY bank",
+            (parent_name,),
+        )
+        for row in cur.fetchall():
+            bank_name, shares, usage = row
+            child_fqname = f"{parent_fqname}{bank_name}/"
+            sharetree[parent_fqname]["children"].append(bank_name)
+            sharetree[child_fqname] = {
+                "name": child_fqname,
+                "shortname": bank_name,
+                "parent": parent_fqname,
+                "children": [],
+                "shares": shares,
+                "nshares": 0.0,
+                "usage": usage,
+                "nusage": 0.0,
+                "priority": float("nan"),
+                "fshare": float("nan"),
+                "depth": depth,
+                "isuser": False,
+            }
+            build_tree(bank_name, child_fqname, depth + 1)
+
+        # get users under this bank
+        cur.execute(
+            """SELECT username, shares, job_usage, fairshare
+               FROM association_table WHERE bank=? ORDER BY username""",
+            (parent_name,),
+        )
+        for row in cur.fetchall():
+            username, shares, usage, fshare = row
+            user_fqname = f"{parent_fqname}{username}/"
+            sharetree[parent_fqname]["children"].append(username)
+            sharetree[user_fqname] = {
+                "name": user_fqname,
+                "shortname": username,
+                "parent": parent_fqname,
+                "children": [],
+                "shares": shares,
+                "nshares": 0.0,
+                "usage": usage,
+                "nusage": 0.0,
+                "priority": float("nan"),
+                "fshare": fshare,
+                "depth": depth,
+                "isuser": True,
+            }
+
+    build_tree(root_bank_name, fqname, 1)
+
+    # calculate normalized shares and usage
+    root_node = sharetree[f"/{root_bank_name}/"]
+
+    # calculate normalized shares
+    nodes_by_depth = sorted(sharetree.values(), key=lambda n: n["depth"])
+    for node in nodes_by_depth:
+        if node["shortname"] == root_bank_name or not node["parent"]:
+            continue
+
+        parent = sharetree[node["parent"]]
+        sibling_shares = sum(
+            sharetree[f"{node['parent']}{child}/"]["shares"]
+            for child in parent["children"]
+            if sharetree[f"{node['parent']}{child}/"]["isuser"] == node["isuser"]
+        )
+        if sibling_shares > 0:
+            fraction = node["shares"] / sibling_shares
+            node["nshares"] = fraction * parent["nshares"]
+
+    # calculate normalized usage
+    if root_node["usage"] > 0:
+        for node in sharetree.values():
+            node["nusage"] = node["usage"] / root_node["usage"]
+
+    return sharetree
 
 
 @with_cursor
@@ -348,3 +459,110 @@ def list_banks(
     if json_fmt:
         return formatter.as_json()
     return formatter.as_table()
+
+
+@with_cursor
+def bank_info(
+    conn,
+    cur,
+    tree=None,
+    tree_no_users=None,
+    to_root=None,
+    user=None,
+    verbose=False,
+    parsable=False,
+    noheader=False,
+    exclude=None,
+):
+    """
+    Display fairshare and priority information for banks and users.
+
+    Args:
+        tree: bank name to display all children of, including users
+        tree_no_users: bank name to display all children of, excluding users
+        to_root: bank name to display all parents for up to root
+        user: username to query
+        verbose: display detailed usage info
+        parsable: output "|" delimited columns for easy parsing
+        noheader: do not display headers
+        exclude: do not display this bank in output
+    """
+    # determine which bank/user we're querying
+    bank = tree or tree_no_users or to_root
+
+    # get current user if no user or bank specified
+    if bank is None and user is None:
+        user = pwd.getpwuid(os.getuid()).pw_name
+
+    # if querying a user, get their default bank
+    default_bank = None
+    if user:
+        result = cur.execute(
+            "SELECT default_bank FROM association_table WHERE username=? LIMIT 1",
+            (user,),
+        ).fetchone()
+        if result:
+            default_bank = result["default_bank"]
+
+    # build the tree structure from the database
+    sharetree = _build_sharetree(cur)
+
+    # find the target node(s)
+    target_name = user if user else bank
+    target_nodes = [
+        node for node in sharetree.values() if node["shortname"] == target_name
+    ]
+
+    if not target_nodes:
+        raise ValueError(f'Could not find "{target_name}"')
+
+    output_lines = []
+    if not noheader:
+        output_lines.append(fmt.format_bank_info_header(verbose, parsable))
+
+    # display based on mode
+    if to_root is not None or (
+        user is not None and tree is None and tree_no_users is None
+    ):
+        # display from target up to root (for banks with -r or users with -u)
+        for target in target_nodes:
+            node = target
+            path = []
+            skip_path = False
+            while node["depth"] > 0:
+                if exclude and node["shortname"] == exclude:
+                    skip_path = True
+                path.append(
+                    fmt.format_bank_info_node(node, default_bank, verbose, parsable)
+                )
+                node = sharetree[node["parent"]]
+            if skip_path:
+                continue
+            path.append(
+                fmt.format_bank_info_node(node, default_bank, verbose, parsable)
+            )
+            path.reverse()
+            output_lines.extend(path)
+    elif tree is not None or tree_no_users is not None:
+        # display from target down to leaves
+        def traverse_down(node, include_users):
+            lines = [fmt.format_bank_info_node(node, default_bank, verbose, parsable)]
+            for child_name in sorted(node["children"]):
+                child = sharetree[f"{node['name']}{child_name}/"]
+                if exclude and child["shortname"] == exclude:
+                    continue
+                if child["isuser"]:
+                    if include_users:
+                        lines.append(
+                            fmt.format_bank_info_node(
+                                child, default_bank, verbose, parsable
+                            )
+                        )
+                else:
+                    lines.extend(traverse_down(child, include_users))
+            return lines
+
+        for target in target_nodes:
+            output_lines.extend(traverse_down(target, tree is not None))
+
+    return "\n".join(output_lines)

--- a/src/bindings/python/fluxacct/accounting/formatter.py
+++ b/src/bindings/python/fluxacct/accounting/formatter.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import json
+import math
 import string
 
 import flux.util
@@ -526,3 +527,52 @@ class KeyValueFormatter(AccountingFormatter):
             cursor,
             error_msg=f"key {self.key} not found in config_table",
         )
+
+
+# general helper functions for displaying rows in the bank-info command
+def format_bank_info_header(verbose, parsable):
+    """Format the header line for bank_info output."""
+    if verbose:
+        if parsable:
+            return "Name|Shares|Norm_Shares|Usage|Norm_Usage|Norm_FS|Type"
+        return (
+            f"{'Name':20s} {'Shares':>10s} {'Norm Shares':>12s} "
+            f"{'Usage':>13s} {'Norm Usage':>12s} {'Level FS':>10s} {'Type':>5s}"
+        )
+    if parsable:
+        return "Name|Shares|Norm_Shares|Norm_Usage|Norm_FS"
+    return (
+        f"{'Name':20s} {'Shares':>10s} {'Norm Shares':>12s} "
+        f"{'Norm Usage':>12s} {'Level FS':>10s}"
+    )
+
+
+def format_bank_info_node(node, default_bank, verbose, parsable):
+    """Format a single node for bank_info output."""
+    dname = " " * node["depth"] + node["shortname"]
+    if node["isuser"]:
+        dname = " " + dname
+        typestr = "User"
+    else:
+        typestr = "Bank"
+        if default_bank == node["shortname"]:
+            dname += "*"
+
+    fsstr = "--" if math.isnan(node["fshare"]) else f"{node['fshare']:.3f}"
+
+    if verbose:
+        if parsable:
+            return (
+                f"{dname}|{node['shares']}|{node['nshares']:.6f}|{node['usage']:.1f}|"
+                f"{node['nusage']:.6f}|{node['fshare']:.6f}|{typestr}"
+            )
+        return (
+            f"{dname:20s} {node['shares']:10d} {node['nshares']:12.6f} "
+            f"{node['usage']:13.1f} {node['nusage']:12.6f} {fsstr:>10s} {typestr:>5s}"
+        )
+    if parsable:
+        return f"{dname}|{node['shares']}|{node['nshares']:.6f}|{node['nusage']:.6f}|{fsstr}"
+    return (
+        f"{dname:20s} {node['shares']:10d} {node['nshares']:12.6f} "
+        f"{node['nusage']:12.6f} {fsstr:>10s}"
+    )

--- a/src/cmd/flux-account-service.py
+++ b/src/cmd/flux-account-service.py
@@ -95,6 +95,7 @@ class AccountingService:
             "view_usage_report",
             "view_config",
             "list_configs",
+            "bank_info",
         ]
 
         privileged_endpoints = [
@@ -887,6 +888,28 @@ class AccountingService:
             handle.respond_error(msg, 0, f"list-configs: missing key in payload: {exc}")
         except Exception as exc:
             handle.respond_error(msg, 0, f"list-configs: {type(exc).__name__}: {exc}")
+
+    def bank_info(self, handle, watcher, msg, arg):
+        try:
+            val = b.bank_info(
+                conn=self.conn,
+                tree=msg.payload.get("tree"),
+                tree_no_users=msg.payload.get("tree_no_users"),
+                to_root=msg.payload.get("to_root"),
+                user=msg.payload.get("user"),
+                verbose=msg.payload.get("verbose"),
+                parsable=msg.payload.get("parsable"),
+                noheader=msg.payload.get("noheader"),
+                exclude=msg.payload.get("exclude"),
+            )
+
+            payload = {"bank_info": val}
+
+            handle.respond(msg, payload)
+        except KeyError as exc:
+            handle.respond_error(msg, 0, f"bank-info: missing key in payload: {exc}")
+        except Exception as exc:
+            handle.respond_error(msg, 0, f"bank-info: {type(exc).__name__}: {exc}")
 
 
 LOGGER = logging.getLogger("flux-uri")

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -799,6 +799,65 @@ def add_list_banks_arg(subparsers):
     )
 
 
+def add_bank_info_arg(subparsers):
+    subparser_bank_info = subparsers.add_parser(
+        "bank-info",
+        help="display fairshare and priority information for banks and users",
+        formatter_class=flux.util.help_formatter(),
+    )
+    subparser_bank_info.set_defaults(func="bank_info")
+    subparser_bank_info.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="display detailed usage info",
+    )
+    subparser_bank_info.add_argument(
+        "-P",
+        "--parsable",
+        action="store_true",
+        help='output "|" delimited columns for easy parsing',
+    )
+    subparser_bank_info.add_argument(
+        "-n",
+        "--noheader",
+        action="store_true",
+        help="do not display headers",
+    )
+    subparser_bank_info.add_argument(
+        "-x",
+        "--exclude",
+        metavar="<bank>",
+        default=None,
+        help="do not display <bank> (defaults to 'expired')",
+    )
+    agroup = subparser_bank_info.add_mutually_exclusive_group(required=False)
+    agroup.add_argument(
+        "-t",
+        "--tree",
+        metavar="<bank>",
+        help="display all children of <bank>, including users",
+    )
+    agroup.add_argument(
+        "-T",
+        "--tree-no-users",
+        metavar="<bank>",
+        help="display all children of <bank>, except users",
+    )
+    agroup.add_argument(
+        "-r",
+        "--to-root",
+        metavar="<bank>",
+        help="display all parents for <bank>",
+    )
+    agroup.add_argument(
+        "-u",
+        "--user",
+        metavar="<user>",
+        help="display all banks for <user>",
+    )
+
+
 def add_update_usage_arg(subparsers):
     subparser_update_usage = subparsers.add_parser(
         "update-usage",
@@ -1580,6 +1639,7 @@ def add_arguments_to_parser(parser, subparsers):
     add_delete_bank_arg(subparsers)
     add_edit_bank_arg(subparsers)
     add_list_banks_arg(subparsers)
+    add_bank_info_arg(subparsers)
     add_update_usage_arg(subparsers)
     add_add_queue_arg(subparsers)
     add_view_queue_arg(subparsers)
@@ -1633,6 +1693,7 @@ def select_accounting_function(args, parser):
         "delete_bank": "accounting.delete_bank",
         "edit_bank": "accounting.edit_bank",
         "list_banks": "accounting.list_banks",
+        "bank_info": "accounting.bank_info",
         "add_queue": "accounting.add_queue",
         "view_queue": "accounting.view_queue",
         "delete_queue": "accounting.delete_queue",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -119,7 +119,8 @@ TESTSCRIPTS = \
 	python/t1017_config_cmds.py \
 	python/t1018_job_usage_custom_bins.py \
 	python/t1019_recalculate_usage.py \
-	python/t1020_edit_user_properties.py
+	python/t1020_edit_user_properties.py \
+	python/t1021_bank_info.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -98,6 +98,7 @@ TESTSCRIPTS = \
 	t1093-config-table-commands.t \
 	t1094-edit-user-properties.t \
 	t1095-max-sched-resources-queue-dependency.t \
+	t1096-flux-account-bank-info.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/python/t1021_bank_info.py
+++ b/t/python/t1021_bank_info.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import unittest
+import sys
+import os
+import time
+import sqlite3
+
+from fluxacct.accounting import bank_subcommands as b
+from fluxacct.accounting import user_subcommands as u
+from fluxacct.accounting import create_db as c
+
+
+class TestBankInfo(unittest.TestCase):
+    # create test flux-accounting database
+    @classmethod
+    def setUpClass(self):
+        self.dbname = f"TestDB_{os.path.basename(__file__)[:5]}_{round(time.time())}.db"
+        c.create_db(self.dbname)
+        global acct_conn
+        global cur
+        try:
+            acct_conn = sqlite3.connect(
+                f"file:{self.dbname}?mode=rw", uri=True, timeout=60
+            )
+            acct_conn.row_factory = sqlite3.Row
+            cur = acct_conn.cursor()
+        except sqlite3.OperationalError:
+            print(f"Unable to open test database file", file=sys.stderr)
+            sys.exit(-1)
+
+        # set up a bank hierarchy for testing
+        b.add_bank(acct_conn, bank="root", shares=100)
+        b.add_bank(acct_conn, bank="A", parent_bank="root", shares=50)
+        b.add_bank(acct_conn, bank="B", parent_bank="root", shares=50)
+
+        # add associations
+        u.add_user(
+            acct_conn,
+            username="user1",
+            bank="A",
+            shares=10,
+        )
+        u.add_user(
+            acct_conn,
+            username="user2",
+            bank="B",
+            shares=20,
+        )
+        u.add_user(
+            acct_conn,
+            username="user3",
+            bank="B",
+            shares=5,
+        )
+
+    # test basic tree output with users
+    def test_01_tree_with_users(self):
+        result = b.bank_info(acct_conn, tree="root")
+        self.assertIsNotNone(result)
+        self.assertIn("root", result)
+        self.assertIn("A", result)
+        self.assertIn("B", result)
+        self.assertIn("user1", result)
+        self.assertIn("user2", result)
+
+    # test tree output without users
+    def test_02_tree_without_users(self):
+        result = b.bank_info(acct_conn, tree_no_users="root")
+        self.assertIsNotNone(result)
+        self.assertIn("root", result)
+        self.assertIn("A", result)
+        # should not include users
+        self.assertNotIn("user1", result)
+        self.assertNotIn("user2", result)
+
+    # test to_root for a bank
+    def test_03_to_root_bank(self):
+        result = b.bank_info(acct_conn, to_root="A")
+        self.assertIsNotNone(result)
+        self.assertIn("A", result)
+        self.assertIn("root", result)
+        # should not include siblings
+        self.assertNotIn("B", result)
+
+    # test to_root for a user
+    def test_04_to_root_user(self):
+        result = b.bank_info(acct_conn, user="user3")
+        self.assertIsNotNone(result)
+        self.assertIn("user3", result)
+        self.assertIn("B", result)
+        self.assertIn("root", result)
+
+    # test verbose output
+    def test_05_verbose_output(self):
+        result = b.bank_info(acct_conn, tree="root", verbose=True)
+        self.assertIsNotNone(result)
+        self.assertIn("Usage", result)
+        self.assertIn("Type", result)
+
+    # test parsable output
+    def test_06_parseable_output(self):
+        result = b.bank_info(acct_conn, tree="root", parsable=True)
+        self.assertIsNotNone(result)
+        # parsable output should use pipe delimiters
+        self.assertIn("|", result)
+
+    # test exclude functionality
+    def test_07_exclude_bank(self):
+        result = b.bank_info(acct_conn, tree="root", exclude="B")
+        self.assertIsNotNone(result)
+        self.assertIn("A", result)
+        # excluded bank should not appear
+        self.assertNotIn("B", result)
+
+    # test noheader option
+    def test_08_noheader(self):
+        result = b.bank_info(acct_conn, tree="root", noheader=True)
+        self.assertIsNotNone(result)
+        # should not include header
+        self.assertNotIn("Name", result)
+
+    # test error for non-existent bank
+    def test_09_nonexistent_bank(self):
+        with self.assertRaises(ValueError):
+            b.bank_info(acct_conn, tree="nonexistent")
+
+    # test error for non-existent user
+    def test_10_nonexistent_user(self):
+        with self.assertRaises(ValueError):
+            b.bank_info(acct_conn, user="nonexistent_user")
+
+    # remove test database and log file
+    @classmethod
+    def tearDownClass(self):
+        acct_conn.close()
+        os.remove(self.dbname)
+
+
+def suite():
+    suite = unittest.TestSuite()
+
+    return suite
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t1096-flux-account-bank-info.t
+++ b/t/t1096-flux-account-bank-info.t
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+test_description='test the bank-info command'
+
+. `dirname $0`/sharness.sh
+DB_PATH=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_NO_JOB_EXEC=y
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 1 job -Slog-stderr-level=1
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB_PATH} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB_PATH} -t
+'
+
+test_expect_success 'bank-info --help works' '
+	flux account bank-info --help
+'
+
+# With two child banks under root, each bank will have 50% of the normalized
+# shares of root
+test_expect_success 'add bank hierarchy' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1 &&
+	flux account add-bank --parent-bank=root B 1 &&
+	flux account add-bank --parent-bank=root C 1
+'
+
+# The two associations added to bank A have equal shares in the bank, so their
+# normalized shares from inside bank A becomes 50% = 0.5 of the bank
+test_expect_success 'add associations to bank A' '
+	username=$(whoami) &&
+	uid=$(id -u) &&
+	flux account add-user --username=${username} --userid=${uid} --bank=A &&
+	flux account add-user --username=user1 --userid=50001 --bank=A
+'
+
+# With just one user under bank B, they get 100% of the normalized shares of
+# the bank
+test_expect_success 'add association to bank B' '
+	flux account add-user --username=user2 --userid=50002 --bank=B
+'
+
+test_expect_success 'add association to bank C' '
+	flux account add-user --username=${username} --userid=${uid} --bank=C
+'
+
+test_expect_success 'bank-info full' '
+	flux account bank-info -t root
+'
+
+test_expect_success 'default shows information for just the association calling it' '
+	flux account bank-info > bank_info_default.test &&
+	grep "${username}" bank_info_default.test &&
+	test_must_fail grep "user1" bank_info_default.test &&
+	test_must_fail grep "user2" bank_info_default.test
+'
+
+test_expect_success '--verbose shows more detailed output' '
+	flux account bank-info -v > bank_info_verbose.test &&
+	grep "${username}" bank_info_verbose.test &&
+	test_must_fail grep "user1" bank_info_verbose.test &&
+	test_must_fail grep "user2" bank_info_verbose.test
+'
+
+test_expect_success '--parsable shows parsable output' '
+	flux account bank-info -P > bank_info_parsable.test &&
+	grep "Name|Shares|Norm_Shares|Norm_Usage|Norm_FS" bank_info_parsable.test &&
+	grep "${username}|1|0.166667|0.000000|0.500" bank_info_parsable.test
+'
+
+test_expect_success '--no-header suppresses output' '
+	flux account bank-info -n > bank_info_no_header.test &&
+	test_must_fail \
+		grep "Name|Shares|Norm_Shares|Norm_Usage|Norm_FS" bank_info_no_header.test
+'
+
+test_expect_success '-x excludes a bank' '
+	flux account bank-info -x A > bank_info_no_bank_A.test &&
+	test_must_fail grep "A" bank_info_no_bank_A.test &&
+	grep "C" bank_info_no_bank_A.test
+'
+
+test_expect_success '-t with no bank raises error' '
+	test_must_fail flux account bank-info -t > no_bank_passed.err 2>&1 &&
+	grep "error: argument -t/--tree: expected one argument" no_bank_passed.err
+'
+
+test_expect_success '-t with nonexistent bank raises error' '
+	test_must_fail flux account bank-info -t foo > nonexistent_bank_passed.err 2>&1 &&
+	grep "bank-info: ValueError: Could not find \"foo\"" nonexistent_bank_passed.err
+'
+
+test_expect_success '-t with root bank displays entire tree' '
+	flux account bank-info -t root > full_tree.test &&
+	grep "root" full_tree.test &&
+	grep "A" full_tree.test &&
+	grep "B" full_tree.test &&
+	grep "C" full_tree.test &&
+	grep "${username}" full_tree.test &&
+	grep "user1" full_tree.test &&
+	grep "user2" full_tree.test
+'
+
+test_expect_success '-T with no bank raises error' '
+	test_must_fail flux account bank-info -T > no_bank_passed_2.err 2>&1 &&
+	grep "error: argument -T/--tree-no-users: expected one argument" no_bank_passed_2.err
+'
+
+test_expect_success '-T with root bank displays entire tree with no users' '
+	flux account bank-info -T root > full_tree.test &&
+	grep "root" full_tree.test &&
+	grep "A" full_tree.test &&
+	grep "B" full_tree.test &&
+	grep "C" full_tree.test &&
+	test_must_fail grep "${username}" full_tree.test &&
+	test_must_fail grep "user1" full_tree.test &&
+	test_must_fail grep "user2" full_tree.test
+'
+
+# For this test, we'll add multiple levels of parents to ensure they all show
+# up in the output
+test_expect_success '-r shows all parents for bank' '
+	flux account add-bank --parent-bank=root D 1 &&
+	flux account add-bank --parent-bank=D sub_1 1 &&
+	flux account add-bank --parent-bank=sub_1 sub_2 1 &&
+	flux account add-bank --parent-bank=sub_2 sub_3 1 &&
+	flux account bank-info -r sub_3 > bank_info_to_root.test &&
+	grep "root" bank_info_to_root.test &&
+	grep "D" bank_info_to_root.test &&
+	grep "sub_1" bank_info_to_root.test &&
+	grep "sub_2" bank_info_to_root.test &&
+	grep "sub_3" bank_info_to_root.test
+'
+
+test_expect_success '-u with nonexistent user raises error' '
+	test_must_fail flux account bank-info -u foo_user > nonexistent_user_passed.err 2>&1 &&
+	grep "bank-info: ValueError: Could not find \"foo_user\"" nonexistent_user_passed.err
+'
+
+test_expect_success '-u displays all banks for a user' '
+	flux account bank-info -u ${username} > bank_info_u.test1 &&
+	grep "A" bank_info_u.test1 &&
+	grep "C" bank_info_u.test1 &&
+	flux account bank-info -u user1 > bank_info_u.test2 &&
+	grep "A" bank_info_u.test2 &&
+	flux account bank-info -u user2 > bank_info_u.test3 &&
+	grep "B" bank_info_u.test3
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

Users need a way to view hierarchical bank and user information with normalized and effective share calculations to understand their resource allocations within the bank hierarchy.

---

This PR adds a new `bank-info` command to the flux-accounting command suite, drawn from the work by @ryanday36. This command builds and displays a tree structure of all of the banks and users in the flux-accounting database and calculates normalized and effective shares for banks and users.

Some basic unit and sharness tests are added for the command and its corresponding function. A new page is added to the ReadTheDocs site for flux-accounting where it goes into detail about exactly how it calculates normalized shares for a given user or bank in the flux-accounting database.

Fixes #884