### PR TITLE
update-db: miscellaneous fixes to improve migration to new job usage table

### DIFF
--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -299,17 +299,12 @@ def migrate_job_usage_to_per_assoc(cur):
     """
     Migrate existing usage bin columns from job_usage_factor_table into the
     new row-per-period job_usage_per_association table. Each usage_factor_period_N
-    column becomes a row with period=N. Skips migration if the new table
-    already has data, so this is safe to call multiple times.
+    column becomes a row with period=N. Uses INSERT OR IGNORE to skip users
+    who already have entries, so this is safe to call multiple times.
 
     Args:
         cur: the Cursor object used to interact with the database.
     """
-    cur.execute("SELECT COUNT(*) FROM job_usage_per_association_table")
-    if cur.fetchone()[0] > 0:
-        # migration has already been done; just return
-        return
-
     # find all usage bin columns from job_usage_factor_table
     cur.execute("PRAGMA table_info('job_usage_factor_table')")
     columns = cur.fetchall()
@@ -361,13 +356,12 @@ def update_db(path, new_db):
             new_cur = new_conn.cursor()
 
             update_tables(old_cur, new_cur)
+            migrate_job_usage_to_per_assoc(old_cur)
 
             update_columns(old_cur, new_cur)
 
             init_priority_factor_table(old_cur)
             init_config_table(old_cur)
-
-            migrate_job_usage_to_per_assoc(old_cur)
 
             # update user_version for DB
             old_cur.execute(

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -166,9 +166,9 @@ def update_tables(old_cur, new_cur):
                     add_stmt += ", "
 
             # look for primary key in new table to add
-            for column in new_columns:
-                if column[5] == 1:
-                    add_stmt += ", PRIMARY KEY (" + column[1] + ")"
+            primary_keys = [column[1] for column in new_columns if column[5] > 0]
+            if primary_keys:
+                add_stmt += ", PRIMARY KEY (" + ", ".join(primary_keys) + ")"
 
             add_stmt += ");"
 

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -305,6 +305,7 @@ def migrate_job_usage_to_per_assoc(cur):
     Args:
         cur: the Cursor object used to interact with the database.
     """
+    print("migrating job usage data to per-association table...")
     # find all usage bin columns from job_usage_factor_table
     cur.execute("PRAGMA table_info('job_usage_factor_table')")
     columns = cur.fetchall()
@@ -313,13 +314,16 @@ def migrate_job_usage_to_per_assoc(cur):
     ]
 
     if not bin_columns:
+        print("no usage_factor_period_* columns found, skipping migration")
         return
 
+    print(f"found {len(bin_columns)} usage period columns to migrate")
     # fetch all rows from the old table
     cur.execute(
         f"SELECT username, userid, bank, {', '.join(bin_columns)} FROM job_usage_factor_table"
     )
     rows = cur.fetchall()
+    print(f"migrating {len(rows)} associations...")
 
     for row in rows:
         username, userid, bank = row[0], row[1], row[2]
@@ -334,6 +338,7 @@ def migrate_job_usage_to_per_assoc(cur):
                 """,
                 (username, userid, bank, period, value),
             )
+    print("migration complete")
 
 
 def update_db(path, new_db):

--- a/t/scripts/db_integrity_check.py
+++ b/t/scripts/db_integrity_check.py
@@ -22,6 +22,40 @@ def main():
     result = cur.fetchone()[0]
     print("result:", result)
 
+    # check if migration succeeded: every association in job_usage_factor_table
+    # should have entries in job_usage_per_association_table
+    cur.execute("SELECT username, bank FROM job_usage_factor_table")
+    usage_factor_users = cur.fetchall()
+
+    # check if legacy usage columns exist to determine expected period count
+    cur.execute("PRAGMA table_info(job_usage_factor_table)")
+    columns = cur.fetchall()
+    bin_columns = [
+        col[1] for col in columns if col[1].startswith("usage_factor_period_")
+    ]
+    expected_periods = len(bin_columns) if bin_columns else 0
+
+    for username, bank in usage_factor_users:
+        cur.execute(
+            "SELECT COUNT(*) FROM job_usage_per_association_table WHERE username=? AND bank=?",
+            (username, bank),
+        )
+        count = cur.fetchone()[0]
+        if count == 0:
+            print(
+                f"error: user {username} in bank {bank} missing from job_usage_per_association_table",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # if legacy columns existed, verify correct number of periods migrated
+        if expected_periods > 0 and count != expected_periods:
+            print(
+                f"error: user {username} in bank {bank} has {count} periods but expected {expected_periods}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
#### Problem

- `update_tables()` only added the first column of composite primary keys (checking `column[5] == 1` instead of `column[5] > 0`), causing `job_usage_per_association_table` to be created with only `'username'` as the primary key instead of `(username, bank, period)`. This resulted in `UNIQUE` constraint errors when migrating usage data.
- `migrate_job_usage_to_per_assoc()` ran _after_ `update_columns()`, which dropped the legacy `usage_factor_period_N` columns before migration could read them. This caused all historical job usage data to be lost during database updates.
- Database updates were silently failing to migrate usage data, leaving associations without entries in `job_usage_per_association_table`.

---

This PR adds some miscellaneous fixes to `flux-account-update-db.py` to fix the problems listed above. It joins _all_ columns that are part of a table's PRIMARY KEY when migrating a table from an older version to a newer version. It also moves the call to `migrate_job_usage_to_per_assoc()` before `update_columns()` so that association data is not lost during the update.

**db_integrity_check.py** is slightly expanded to actually check the contents of `job_usage_per_assoc_table()` to make sure that the update to an older version of a flux-accounting DB actually populates the table like it should.

Some expanded logging is also added to the script. In the future, it might be nice to change this script to actually make use of the `logging` module instead of using `print()` statements, similar to the `update-usage` command.

Closes #903 