### PR TITLE
NEWS: add release notes for v0.59.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+flux-accounting version 0.59.1 - 2026-07-16
+-------------------------------------------
+
+#### Features
+
+* add new `bank-info` command for viewing normalized shares, usage on a cluster
+(#896)
+
+* `JobRecord`: add ncores, ngpus properties (#901)
+
+* job usage: extend usage calculation to consider cores, GPUs (#902)
+
+#### Fixes
+
+* update-db: miscellaneous fixes to improve migration to new job usage table
+(#904)
+
 flux-accounting version 0.59.0 - 2026-07-06
 -------------------------------------------
 


### PR DESCRIPTION
#### Problem

There are no release notes for flux-accounting `v0.59.1`.

---

This PR adds some release notes for flux-accounting `v0.59.1`. Once its predecessor PRs land, I will create an annotated tag with the following:

```console
git tag -a v0.59.1 -m "Tag v0.59.1" && git push upstream v0.59.1
```