### PR TITLE
t: add tests for managing unknown queues

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -99,6 +99,7 @@ TESTSCRIPTS = \
 	t1094-edit-user-properties.t \
 	t1095-max-sched-resources-queue-dependency.t \
 	t1096-flux-account-bank-info.t \
+	t1097-mf-priority-unknown-queues.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/t1097-mf-priority-unknown-queues.t
+++ b/t/t1097-mf-priority-unknown-queues.t
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+test_description='test accepting jobs to queues unknown to flux-accounting'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+MULTI_FACTOR_PRIORITY=${FLUX_BUILD_DIR}/src/plugins/.libs/mf_priority.so
+SUBMIT_AS=${SHARNESS_TEST_SRCDIR}/scripts/submit_as.py
+DB=$(pwd)/FluxAccountingTest.db
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success 'allow guest access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+test_expect_success 'create flux-accounting DB' '
+	flux account -p ${DB} create-db
+'
+
+test_expect_success 'start flux-accounting service' '
+	flux account-service -p ${DB} -t
+'
+
+test_expect_success 'add a queue to DB' '
+	flux account add-queue pdebug
+'
+
+test_expect_success 'add banks to DB' '
+	flux account add-bank root 1 &&
+	flux account add-bank --parent-bank=root A 1
+'
+
+test_expect_success 'add an association to DB' '
+	flux account add-user \
+		--username=user1 \
+		--bank=A \
+		--userid=50001 \
+		--queues=pdebug
+'
+
+test_expect_success 'load and initialize priority plugin' '
+	flux jobtap load -r .priority-default \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap list | grep mf_priority
+'
+
+# Add a queue that flux-accounting does not know about
+test_expect_success 'configure flux with queues' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.pdebug]
+	[queues.foo]
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
+
+test_expect_success 'pdebug queue is listed in internal data structure' '
+	flux jobtap query mf_priority.so > query.json &&
+	test_debug "jq -S . <query.json" &&
+	grep "pdebug" query.json
+'
+
+test_expect_success 'association can submit job to pdebug queue' '
+	job1=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job1} alloc
+'
+
+test_expect_success 'association can also submit job to foo queue' '
+	job2=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=foo sleep inf) &&
+	flux job wait-event -t 5 ${job2} alloc
+'
+
+test_expect_success 'cancel job' '
+	flux cancel ${job1} &&
+	flux cancel ${job2}
+'
+
+test_expect_success 'shut down flux-accounting service' '
+	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
+'
+
+test_done


### PR DESCRIPTION
#### Problem

flux-accounting does not have a dedicated set of tests for validating jobs submitted to queues it does not know about.

---

This PR adds a set of tests that confirms the required behavior defined in [RFC 33](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_33.html) that an external validator shall not reject a job submitted under a queue unknown to the external validator.