### PR TITLE
`edit-config`: remove confirmation prompt

### DIFF
--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -358,21 +358,6 @@ def edit_config(conn, cursor, key_value_strings):
             raise ValueError(f"key {key} not found in config_table")
 
     if requires_rebin:
-        choice = (
-            input(
-                "WARNING: changing one or more of priority_usage_reset_period, "
-                "priority_decay_half_life, or decay_factor requires re-binning all "
-                "of the job usage bins for every association in the flux-accounting "
-                "database and will reset the usage for every association to 0.0; are "
-                "you sure you want to continue? [y/n] "
-            )
-            .strip()
-            .lower()
-        )
-        if choice != "y":
-            # roll back the config_table updates
-            conn.rollback()
-            return 0
         # pylint: disable=no-value-for-parameter
         reconfigure_usage_bins(conn)
 

--- a/src/cmd/flux-account.py
+++ b/src/cmd/flux-account.py
@@ -1572,6 +1572,9 @@ def add_edit_config_arg(subparsers):
         "edit-config",
         help="edit one or more key-value pairs in config_table",
         formatter_class=flux.util.help_formatter(),
+        description="Edit configuration values. WARNING: changing "
+        "priority_usage_reset_period, priority_decay_half_life, or decay_factor "
+        "will re-bin all job usage bins and reset usage for every association to 0.0.",
     )
     subparsers_edit_config.set_defaults(func="edit_config")
     subparsers_edit_config.add_argument(

--- a/t/python/t1017_config_cmds.py
+++ b/t/python/t1017_config_cmds.py
@@ -13,7 +13,6 @@ import unittest
 import os
 import sqlite3
 import time
-from unittest.mock import patch
 
 from fluxacct.accounting import create_db as c
 from fluxacct.accounting import db_info_subcommands as d
@@ -56,8 +55,7 @@ class TestAccountingCLI(unittest.TestCase):
             d.edit_config(conn, key_value_strings=["priority_usage_reset_period=foo"])
 
     # successfully edit PriorityUsageResetPeriod
-    @patch("builtins.input", return_value="y")
-    def test_05_edit_priority_usage_reset_period_success(self, mock_input):
+    def test_05_edit_priority_usage_reset_period_success(self):
         d.edit_config(conn, key_value_strings=["priority_usage_reset_period=1234"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
@@ -65,8 +63,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(test["value"], "1234.0")
 
     # edit PriorityUsageResetPeriod using a Flux Standard Duration value
-    @patch("builtins.input", return_value="y")
-    def test_06_edit_priority_usage_reset_period_fsd_success(self, mock_input):
+    def test_06_edit_priority_usage_reset_period_fsd_success(self):
         d.edit_config(conn, key_value_strings=["priority_usage_reset_period=1d"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_usage_reset_period'"
@@ -79,8 +76,7 @@ class TestAccountingCLI(unittest.TestCase):
             d.edit_config(conn, key_value_strings=["priority_decay_half_life=foo"])
 
     # successfully edit PriorityDecayHalfLife
-    @patch("builtins.input", return_value="y")
-    def test_08_edit_priority_decay_half_life_success(self, mock_input):
+    def test_08_edit_priority_decay_half_life_success(self):
         d.edit_config(conn, key_value_strings=["priority_decay_half_life=1234"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
@@ -88,8 +84,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(test["value"], "1234.0")
 
     # edit PriorityDecayHalfLife using a Flux Standard Duration value
-    @patch("builtins.input", return_value="y")
-    def test_09_edit_priority_decay_half_life_fsd_success(self, mock_input):
+    def test_09_edit_priority_decay_half_life_fsd_success(self):
         d.edit_config(conn, key_value_strings=["priority_decay_half_life=1h"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='priority_decay_half_life'"
@@ -109,8 +104,7 @@ class TestAccountingCLI(unittest.TestCase):
             d.edit_config(conn, key_value_strings=["decay_factor=1.1"])
 
     # successfully edit decay_factor
-    @patch("builtins.input", return_value="y")
-    def test_12_edit_decay_factor_success(self, mock_input):
+    def test_12_edit_decay_factor_success(self):
         d.edit_config(conn, key_value_strings=["decay_factor=0.9"])
         test = cur.execute(
             "SELECT value FROM config_table WHERE key='decay_factor'"

--- a/t/python/t1019_recalculate_usage.py
+++ b/t/python/t1019_recalculate_usage.py
@@ -171,31 +171,18 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(job_usage_breakdown[1]["value"], 0.0)
         self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
 
-    # If "n" is input after editing some of the configuration parameters, the changes are
-    # not committed and rolled back
-    @mock.patch("builtins.input", return_value="n")
-    @mock.patch("time.time", mock.MagicMock(return_value=1600))
-    def test_04_reconfigure_bins_deny_confirm(self, mock_input):
-        d.edit_config(
-            conn, ["priority_usage_reset_period=6h", "priority_decay_half_life=1h"]
-        )
-        # make sure parameters remain the same as before the above edit_config() call
-        result = d.list_configs(conn)
-        self.assertIn("priority_usage_reset_period | 1200", result)
-        self.assertIn("priority_decay_half_life    | 400", result)
-
     # decay_factor can be changed and the amount of decay applied to past jobs will be
     # different
     @mock.patch("builtins.input", return_value="y")
     @mock.patch("time.time", mock.MagicMock(return_value=2600))
-    def test_05_edit_decay_factor(self, mock_input):
+    def test_04_edit_decay_factor(self, mock_input):
         d.edit_config(conn, ["decay_factor=0.1"])
         result = d.list_configs(conn)
         print(result)
         self.assertIn("decay_factor                | 0.1", result)
 
     @mock.patch("time.time", mock.MagicMock(return_value=3200))
-    def test_06_insert_new_job(self):
+    def test_05_insert_new_job(self):
         # insert another 1-node, 1000-second-long job
         self.insert_job(3, 50001, "A", 100, 2100, 3100)
         jobs.update_job_usage(conn)
@@ -211,7 +198,7 @@ class TestAccountingCLI(unittest.TestCase):
         self.assertEqual(job_usage_breakdown[2]["value"], 0.0)
 
     @mock.patch("time.time", mock.MagicMock(return_value=3600))
-    def test_07_update_usage_new_decay_factor(self):
+    def test_06_update_usage_new_decay_factor(self):
         jobs.update_job_usage(conn)
         total_usage = u.view_user(conn, user="user1", format_string="{job_usage}")
         self.assertIn("100.0", total_usage)

--- a/t/t1093-config-table-commands.t
+++ b/t/t1093-config-table-commands.t
@@ -160,6 +160,17 @@ test_expect_success 'list all configs with format string' '
 	test_cmp list_configs_format.test list_configs_format.expected
 '
 
+test_expect_success 'edit the usage parameters successfully' '
+	flux account edit-config \
+		priority_decay_half_life=15m \
+		priority_usage_reset_period=1h \
+		decay_factor=0.2 &&
+	flux account list-configs -o "{key}->{value}" > edit_usage_configs.test &&
+	grep "priority_decay_half_life->900" edit_usage_configs.test &&
+	grep "priority_usage_reset_period->3600" edit_usage_configs.test &&
+	grep "decay_factor->0.2" edit_usage_configs.test
+'
+
 test_expect_success 'shut down flux-accounting service' '
 	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
 '


### PR DESCRIPTION
#### Problem

The `edit_config()` function calls the `input()` to confirm re-binning operations when changing `priority_usage_reset_period`, `priority_decay_half_life`, or `decay_factor`. This causes an `EOFError` when called from the flux-accounting service, which runs without a controlling terminal.

---

This PR removes the interactive prompt and apply config changes directly and moves the warning text to the command help in **flux-account.py** so users are still informed of the consequences. I also removed @patch decorators from a number of unit tests since `input()` is no longer called.

I've also added a simple sharness test to edit the usage parameters with the `edit-config` command in the flux-accounting service to confirm that no `EOFError` is raised.