### PR TITLE
plugin: add option to toggle rejecting unknown queues during job validation

### DIFF
--- a/doc/guide/accounting-guide.rst
+++ b/doc/guide/accounting-guide.rst
@@ -396,14 +396,6 @@ To enforce these kinds of permissions, ensure that both flux-accounting's
 ``queue_table`` is configured with the queues you want to restrict access to as
 well as the associations' ``queues`` attributes.
 
-.. warning::
-
-  If queues are dynamically added to Flux but are not configured in
-  flux-accounting (i.e it is not in flux-accounting's ``queue_table``), *all*
-  users are allowed to submit jobs under this queue by default (see `RFC 33`_
-  for more details on queue access policy) unless restricted by another
-  validator mechanism.
-
 example
 -------
 
@@ -493,6 +485,100 @@ The above example will set a max running jobs limit of 3 running jobs
 per-association. Any subsequently submitted jobs will be held with a
 queue-specific dependency until one of the association's currently running jobs
 in that queue completes.
+
+Unknown Queue Handling
+======================
+
+By default, flux-accounting uses a permissive approach when handling jobs
+submitted to queues: if a queue is configured in Flux but not registered in
+flux-accounting's ``queue_table``, jobs to that queue are still accepted.
+Administrators can enable strict validation to reject such jobs.
+
+When ``deny_unknown_queues`` is set to ``false`` (the default), jobs may be
+submitted to any queue configured in Flux, even if that queue is not
+registered in flux-accounting's ``queue_table``. This allows for flexible
+queue configuration where Flux and flux-accounting queue lists may differ.
+
+However, this means that dynamically added queues bypass flux-accounting's
+queue permission controls, and *all* users can submit to them (see `RFC 33`_
+for more details on queue access policy).
+
+When ``deny_unknown_queues`` is set to ``true``, the multi-factor priority
+plugin will reject any job submitted to a queue that is not present in
+flux-accounting's ``queue_table``. This ensures that all queue access is
+governed by flux-accounting's permission system.
+
+Jobs submitted to unknown queues will be rejected with an error message:
+
+.. code-block:: console
+
+  queue 'X' is unknown to flux-accounting and deny-unknown-queues is enabled
+
+Configuration
+~~~~~~~~~~~~~
+
+To view the current setting:
+
+::
+
+  $ flux account view-config deny_unknown_queues
+
+To enable strict validation:
+
+::
+
+  $ flux account edit-config deny_unknown_queues=true
+  $ flux account-priority-update -p /path/to/FluxAccounting.db
+
+To disable and return to permissive mode:
+
+::
+
+  $ flux account edit-config deny_unknown_queues=false
+  $ flux account-priority-update -p /path/to/FluxAccounting.db
+
+See :man1:`flux-account-edit-config` and
+:man1:`flux-account-view-config` for more details.
+
+Example
+~~~~~~~
+
+Consider a scenario where:
+
+- flux-accounting knows about queue ``debug``
+- Flux is configured with queues ``debug`` and ``batch``
+- A user has permission to submit to ``debug``
+
+**With permissive mode (default):**
+
+::
+
+  $ flux account view-config deny_unknown_queues
+  key                 | value
+  --------------------+------
+  deny_unknown_queues | false
+  $ flux submit --queue=debug sleep 60
+  f12345
+  $ flux submit --queue=batch sleep 60
+  f67890
+
+**With strict validation enabled:**
+
+::
+
+  $ flux account edit-config deny_unknown_queues=true
+  $ flux account-priority-update -p /path/to/FluxAccounting.db
+  $ flux submit --queue=debug sleep 60
+  f12345
+  $ flux submit --queue=batch sleep 60
+  flux-job: queue "foo" is unknown to flux-accounting and deny-unknown-queues
+  is enabled
+
+.. note::
+
+  The ``deny_unknown_queues`` configuration key is protected and cannot be
+  deleted. Changes to this setting require updating the plugin configuration
+  via ``flux account-priority-update`` to take effect.
 
 .. _glossary-section:
 

--- a/src/bindings/python/fluxacct/accounting/create_db.py
+++ b/src/bindings/python/fluxacct/accounting/create_db.py
@@ -303,6 +303,13 @@ def create_db(
             "0.0",
         ),
     )
+    conn.execute(
+        f"INSERT INTO config_table VALUES (?, ?)",
+        (
+            "deny_unknown_queues",
+            "false",
+        ),
+    )
     conn.commit()
     LOGGER.info("Created config_table successfully")
 

--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -282,6 +282,18 @@ def export_as_json(conn, cursor):
 
     config["banks"] = banks
 
+    # fetch options for plugin
+    plugin_config = {}
+    cursor.execute("SELECT value FROM config_table WHERE key='deny_unknown_queues'")
+    row = cursor.fetchone()
+    if row:
+        plugin_config["deny_unknown_queues"] = row["value"].lower() == "true"
+    else:
+        # if key is missing, default to False
+        plugin_config["deny_unknown_queues"] = False
+
+    config["config"] = plugin_config
+
     # fetch rows from priority_factor_weight_table
     for row in cursor.execute("SELECT * FROM priority_factor_weight_table"):
         factor = {

--- a/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
+++ b/src/bindings/python/fluxacct/accounting/db_info_subcommands.py
@@ -350,6 +350,10 @@ def edit_config(conn, cursor, key_value_strings):
                     "decay_factor must be a floating-point value between 0 and 1"
                 )
             requires_rebin = True
+        if key == "deny_unknown_queues":
+            # ensure value is exactly "true" or "false" (case-insensitive)
+            if value.lower() not in ["true", "false"]:
+                raise ValueError("deny_unknown_queues must be 'true' or 'false'")
         cursor.execute(
             "UPDATE config_table SET value=? WHERE key=?",
             (value, key),
@@ -377,6 +381,7 @@ def delete_config(conn, cursor, key):
         "node_weight",
         "core_weight",
         "gpu_weight",
+        "deny_unknown_queues",
     ]:
         raise ValueError(
             "key-value pair is not allowed to be removed from config_table"

--- a/src/cmd/flux-account-priority-update.py
+++ b/src/cmd/flux-account-priority-update.py
@@ -157,6 +157,19 @@ def bulk_update(path):
     data = {"data": bulk_factor_data}
     flux.Flux().rpc("job-manager.mf_priority.rec_fac_update", data).get()
 
+    # fetch config values for plugin
+    plugin_config = {}
+    cur.execute("SELECT value FROM config_table WHERE key='deny_unknown_queues'")
+    row = cur.fetchone()
+    if row:
+        plugin_config["deny_unknown_queues"] = row["value"].lower() == "true"
+    else:
+        # if key is missing, default to False
+        plugin_config["deny_unknown_queues"] = False
+
+    data = {"data": plugin_config}
+    flux.Flux().rpc("job-manager.mf_priority.rec_config_update", data).get()
+
     flux.Flux().rpc("job-manager.mf_priority.reprioritize")
 
     # close DB connection

--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -297,6 +297,13 @@ def init_config_table(cur):
             "0.0",
         ),
     )
+    cur.execute(
+        "INSERT OR IGNORE INTO config_table VALUES (?, ?)",
+        (
+            "deny_unknown_queues",
+            "false",
+        ),
+    )
 
 
 def migrate_job_usage_to_per_assoc(cur):

--- a/src/plugins/accounting.cpp
+++ b/src/plugins/accounting.cpp
@@ -847,5 +847,15 @@ int initialize_plugin (
             return -1;
     }
 
+    // unpack optional configuration parameters and options
+    json_t *db_config = NULL;
+    if (json_unpack_ex (config_obj, &error, 0, "{s?o}", "config", &db_config) == 0
+        && db_config) {
+        int deny_unknown_queues_int = 0;
+        json_unpack (db_config, "{s?b}", "deny_unknown_queues", &deny_unknown_queues_int);
+        extern bool deny_unknown_queues;
+        deny_unknown_queues = (deny_unknown_queues_int != 0);
+    }
+
     return 0;
 }

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -55,6 +55,7 @@ std::map<std::string, Bank> banks;
 std::map<int, std::string> users_def_bank;
 std::vector<std::string> projects;
 std::map<std::string, int> priority_weights;
+bool deny_unknown_queues = false;
 
 /******************************************************************************
  *                                                                            *
@@ -902,6 +903,46 @@ static void rec_bank_cb (flux_t *h,
         b->name = bank_name;
         b->priority = priority;
     }
+
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "flux_respond");
+    return;
+error:
+    flux_respond_error (h, msg, errno, flux_msg_last_error (msg));
+}
+
+
+/*
+ * Unpack a payload from an external bulk update service and update the
+ * deny_unknown_queues config option.
+ */
+static void rec_config_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    json_t *data = NULL;
+    json_error_t error;
+    int deny_unknown_queues_int = 0;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "data", &data) < 0) {
+        flux_log_error (h, "failed to unpack config update msg");
+        goto error;
+    }
+
+    if (!data || !json_is_object (data)) {
+        flux_log (h, LOG_ERR, "mf_priority: invalid config payload");
+        goto error;
+    }
+
+    if (json_unpack_ex (data, &error, 0,
+                        "{s?b}",
+                        "deny_unknown_queues", &deny_unknown_queues_int) < 0) {
+        flux_log (h, LOG_ERR, "mf_priority config unpack: %s", error.text);
+        goto error;
+    }
+
+    deny_unknown_queues = (deny_unknown_queues_int != 0);
 
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "flux_respond");
@@ -2163,6 +2204,7 @@ extern "C" int flux_plugin_init (flux_plugin_t *p)
     users_def_bank.clear ();
     projects.clear ();
     priority_weights.clear ();
+    deny_unknown_queues = false;
 
     json_t *config_obj = NULL;
     flux_t *h = flux_jobtap_get_flux (p);
@@ -2205,6 +2247,8 @@ extern "C" int flux_plugin_init (flux_plugin_t *p)
         || flux_jobtap_service_register (p, "rec_bank_update", rec_bank_cb, p)
         < 0
         || flux_jobtap_service_register (p, "rec_fac_update", rec_factor_cb, p)
+        < 0
+        || flux_jobtap_service_register (p, "rec_config_update", rec_config_cb, p)
         < 0)
         return -1;
 

--- a/src/plugins/mf_priority.cpp
+++ b/src/plugins/mf_priority.cpp
@@ -1249,6 +1249,17 @@ static int validate_cb (flux_plugin_t *p,
         return flux_jobtap_reject_job (p, args, "user/bank entry has been "
                                        "disabled from flux-accounting DB");
 
+    // check if deny_unknown_queues is enabled and queue is unknown to
+    // flux-accounting (not in the global queues map)
+    if (deny_unknown_queues && queue != NULL &&
+        queues.find (std::string (queue)) == queues.end ()) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "queue \"%s\" is unknown to "
+                                       "flux-accounting and deny-unknown-queues "
+                                       "is enabled",
+                                       queue);
+    }
     if (get_queue_info (queue, a->queues, queues) == INVALID_QUEUE) {
         // the association specified a queue that they do not belong to; reject
         // the job and return which queues they belong to

--- a/src/plugins/test/accounting_test01.cpp
+++ b/src/plugins/test/accounting_test01.cpp
@@ -30,6 +30,7 @@ std::map<int, std::string> users_def_bank;
 std::map<std::string, Queue> queues;
 // define a vector of chargeable projects
 std::vector<std::string> projects;
+bool deny_unknown_queues = false;
 
 
 /*

--- a/src/plugins/test/banks_test04.cpp
+++ b/src/plugins/test/banks_test04.cpp
@@ -26,6 +26,7 @@ extern "C" {
 
 // define a test banks map
 std::map<std::string, Bank> banks;
+bool deny_unknown_queues = false;
 
 
 /*

--- a/src/plugins/test/dependencies_test03.cpp
+++ b/src/plugins/test/dependencies_test03.cpp
@@ -28,6 +28,7 @@ extern "C" {
 std::map<int, std::map<std::string, Association>> users;
 // define a test queues map
 std::map<std::string, Queue> queues;
+bool deny_unknown_queues = false;
 
 
 /*

--- a/src/plugins/test/queue_limits_test05.cpp
+++ b/src/plugins/test/queue_limits_test05.cpp
@@ -28,6 +28,7 @@ extern "C" {
 std::map<int, std::map<std::string, Association>> users;
 // define a test queues map
 std::map<std::string, Queue> queues;
+bool deny_unknown_queues = false;
 
 
 /*

--- a/t/python/t1017_config_cmds.py
+++ b/t/python/t1017_config_cmds.py
@@ -192,6 +192,46 @@ class TestAccountingCLI(unittest.TestCase):
         with self.assertRaises(ValueError):
             d.edit_config(conn, key_value_strings=["i_dont_exist=foo"])
 
+    # trying to remove deny_unknown_queues option will raise a ValueError
+    def test_27_delete_deny_unknown_queues(self):
+        with self.assertRaises(ValueError):
+            d.delete_config(conn, key="deny_unknown_queues")
+
+    def test_28_edit_deny_unknown_queues_true(self):
+        d.edit_config(conn, key_value_strings=["deny_unknown_queues=true"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='deny_unknown_queues'"
+        ).fetchone()
+        self.assertEqual(test["value"], "true")
+
+    def test_29_edit_deny_unknown_queues_false(self):
+        d.edit_config(conn, key_value_strings=["deny_unknown_queues=false"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='deny_unknown_queues'"
+        ).fetchone()
+        self.assertEqual(test["value"], "false")
+
+    def test_30_edit_deny_unknown_queues_case_insensitive(self):
+        d.edit_config(conn, key_value_strings=["deny_unknown_queues=True"])
+        test = cur.execute(
+            "SELECT value FROM config_table WHERE key='deny_unknown_queues'"
+        ).fetchone()
+        self.assertEqual(test["value"], "True")
+
+    # trying to set deny_unknown_queues to invalid value will raise a ValueError
+    def test_31_edit_deny_unknown_queues_bad_1(self):
+        with self.assertRaisesRegex(
+            ValueError, "deny_unknown_queues must be 'true' or 'false'"
+        ):
+            d.edit_config(conn, key_value_strings=["deny_unknown_queues=yes"])
+
+    # trying to set deny_unknown_queues to invalid value will raise a ValueError
+    def test_32_edit_deny_unknown_queues_bad_2(self):
+        with self.assertRaisesRegex(
+            ValueError, "deny_unknown_queues must be 'true' or 'false'"
+        ):
+            d.edit_config(conn, key_value_strings=["deny_unknown_queues=1"])
+
     # remove database and log file
     @classmethod
     def tearDownClass(self):

--- a/t/t1093-config-table-commands.t
+++ b/t/t1093-config-table-commands.t
@@ -109,6 +109,7 @@ test_expect_success 'list all configs in config_table' '
 	node_weight                 | 1.0    
 	core_weight                 | 0.0    
 	gpu_weight                  | 0.0    
+	deny_unknown_queues         | false  
 	key1                        | foo1   
 	key2                        | foo2   
 	EOF
@@ -133,6 +134,7 @@ test_expect_success 'list all configs with --fields' '
 	---------------------------
 	core_weight                
 	decay_factor               
+	deny_unknown_queues        
 	gpu_weight                 
 	key1                       
 	key2                       
@@ -154,6 +156,7 @@ test_expect_success 'list all configs with format string' '
 	node_weight->1.0
 	core_weight->0.0
 	gpu_weight->0.0
+	deny_unknown_queues->false
 	key1->foo1
 	key2->foo2
 	EOF

--- a/t/t1097-mf-priority-unknown-queues.t
+++ b/t/t1097-mf-priority-unknown-queues.t
@@ -82,6 +82,89 @@ test_expect_success 'cancel job' '
 	flux cancel ${job2}
 '
 
+test_expect_success 'enable deny_unknown_queues config option' '
+	flux account edit-config deny_unknown_queues=true
+'
+
+test_expect_success 'reload plugin with deny_unknown_queues enabled' '
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)" &&
+	flux jobtap query mf_priority.so > query.json &&
+	cat query.json | jq
+'
+
+test_expect_success 'job to known queue (pdebug) still works' '
+	job3=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job3} alloc &&
+	flux cancel ${job3}
+'
+
+test_expect_success 'job to unknown queue (foo) now rejected' '
+	test_must_fail flux python ${SUBMIT_AS} 50001 -N1 --queue=foo sleep inf 2>err &&
+	grep "queue.*foo.*unknown.*flux-accounting.*deny-unknown-queues" err
+'
+
+test_expect_success 'disable deny_unknown_queues and reload plugin' '
+	flux account edit-config deny_unknown_queues=false &&
+	flux jobtap remove mf_priority.so &&
+	flux jobtap load \
+		${MULTI_FACTOR_PRIORITY} "config=$(flux account export-json)"
+'
+
+test_expect_success 'job to unknown queue (foo) accepted again' '
+	job4=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=foo sleep inf) &&
+	flux job wait-event -t 5 ${job4} alloc &&
+	flux cancel ${job4}
+'
+
+test_expect_success 'enable deny_unknown_queues via priority-update' '
+	flux account edit-config deny_unknown_queues=true &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'job to known queue (pdebug) still works after priority-update' '
+	job5=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=pdebug sleep inf) &&
+	flux job wait-event -t 5 ${job5} alloc &&
+	flux cancel ${job5}
+'
+
+test_expect_success 'job to unknown queue (foo) rejected after priority-update' '
+	test_must_fail flux python ${SUBMIT_AS} 50001 -N1 --queue=foo sleep inf 2>err2 &&
+	grep "queue.*foo.*unknown.*flux-accounting.*deny-unknown-queues" err2
+'
+
+test_expect_success 'disable deny_unknown_queues via priority-update' '
+	flux account edit-config deny_unknown_queues=false &&
+	flux account-priority-update -p ${DB}
+'
+
+test_expect_success 'job to unknown queue (foo) accepted after priority-update disable' '
+	job6=$(flux python ${SUBMIT_AS} 50001 -N1 --queue=foo sleep inf) &&
+	flux job wait-event -t 5 ${job6} alloc &&
+	flux cancel ${job6}
+'
+
+test_expect_success 'reject invalid value for deny_unknown_queues (yes)' '
+	test_must_fail flux account edit-config deny_unknown_queues=yes 2>invalid_err1 &&
+	grep "must be.*true.*false" invalid_err1
+'
+
+test_expect_success 'reject invalid value for deny_unknown_queues (1)' '
+	test_must_fail flux account edit-config deny_unknown_queues=1 2>invalid_err2 &&
+	grep "must be.*true.*false" invalid_err2
+'
+
+test_expect_success 'reject invalid value for deny_unknown_queues (enabled)' '
+	test_must_fail flux account edit-config deny_unknown_queues=enabled 2>invalid_err3 &&
+	grep "must be.*true.*false" invalid_err3
+'
+
+test_expect_success 'verify deny_unknown_queues still set to false after invalid attempts' '
+	flux account view-config deny_unknown_queues > view_output &&
+	grep "false" view_output
+'
+
 test_expect_success 'shut down flux-accounting service' '
 	flux python -c "import flux; flux.Flux().rpc(\"accounting.shutdown_service\").get()"
 '


### PR DESCRIPTION
#### Problem

There is no way to change the behavior for flux-accounting to reject jobs that are submitted to a queue that it does not know about.

---

This PR adds a new built-in option to flux-accounting (stored in `config_table`) that can toggle this behavior on and off. By default, this feature is turned off, which maintains backwards compatibility and the priority plugin still allows jobs to be submitted to queues it does not know about. However, if turned on, the plugin will begin rejecting jobs during `job.validate` if it is submitted to a queue unknown to flux-accounting.

Toggling this option on and off does not require a plugin reload, but just a push of database information to the plugin via `flux account-priority-update`. However, tests are added that cover both cases: toggling the option and completely reloading the plugin, and toggling the option and updating the already-loaded plugin.

Assisted-By:Claude:sonnet-4.5

Closes #909