### PR TITLE
`update-db`: add copy of original DB to a `.backup` file

### DIFF
--- a/src/cmd/flux-account-update-db.py
+++ b/src/cmd/flux-account-update-db.py
@@ -343,6 +343,11 @@ def migrate_job_usage_to_per_assoc(cur):
 
 def update_db(path, new_db):
     LOGGER.info("starting database update for %s", path)
+    # create a backup of the database
+    backup_path = path + ".backup"
+    shutil.copy2(path, backup_path)
+    LOGGER.info("created backup at %s", backup_path)
+
     old_conn = est_sqlite_conn(path)
     old_cur = old_conn.cursor()
 
@@ -391,11 +396,11 @@ def update_db(path, new_db):
             new_db,
             exc,
         )
-        shutil.rmtree(tmp_dir_name)
+        old_conn.close()
         sys.exit(1)
     except sqlite3.IntegrityError as exc:
         LOGGER.exception("SQLite integrity error: %s", exc)
-        shutil.rmtree(tmp_dir_name)
+        old_conn.close()
         sys.exit(1)
 
 

--- a/t/t1017-update-db.t
+++ b/t/t1017-update-db.t
@@ -120,6 +120,8 @@ for db in ${SHARNESS_TEST_SRCDIR}/expected/test_dbs/*; do
 		chmod +rw $tmp_db
 		test_expect_success 'update old DB: '$(basename $db) \
 			"flux account-update-db -v -p $tmp_db > update.test 2>&1"
+		test_expect_success 'verify backup was created: '$(basename $db) \
+			"test -f ${tmp_db}.backup"
 		test_expect_success 'verify INFO logs appear: '$(basename $db) \
 			"grep -E '(checking for new tables|\
 checking for new columns|\


### PR DESCRIPTION
#### Problem

If database migration fails or contains logic bugs that only surface after commit, the original database state is lost with no way to recover.

---

This PR creates a `.backup` copy of the database before any modifications begin. If either `OperationalError` or `IntegrityError` is raised during a database migration, it restores the original database from the backup before exiting.

A simple test is added to **t1017-update-db.t** to check the existence of a `.backup` when the update is first started.