### PR TITLE
commands: add fair-share emulator

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -46,7 +46,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-account-view-config.1 \
 	man1/flux-account-edit-config.1 \
 	man1/flux-account-delete-config.1 \
-	man1/flux-account-list-configs.1
+	man1/flux-account-list-configs.1 \
+	man1/flux-account-fairshare-emulate.1
 
 RST_FILES  = \
 	$(MAN1_FILES_PRIMARY:.1=.rst)

--- a/doc/man1/flux-account-fairshare-emulate.rst
+++ b/doc/man1/flux-account-fairshare-emulate.rst
@@ -1,0 +1,106 @@
+.. flux-help-section: flux account
+
+=================================
+flux-account-fairshare-emulate(1)
+=================================
+
+
+SYNOPSIS
+========
+
+**flux** **account-fairshare-emulate** [OPTIONS]
+
+DESCRIPTION
+===========
+
+.. program:: flux account-fairshare-emulate
+
+:program:`flux account-fairshare-emulate` calculates fair-share values
+from a JSON input file without requiring a database. This command is
+useful for testing fair-share scenarios, previewing the effects of
+configuration changes before applying them to production, and for
+educational or documentation purposes.
+
+The fair-share algorithm is a weighted tree traversal that considers
+bank hierarchies, user shares, and historical job usage to calculate
+priority values. This emulator implements the same algorithm as
+:program:`flux-account-update-fshare`, allowing you to experiment with
+different configurations offline.
+
+OPTIONS
+=======
+
+.. option:: -i, --input FILE
+
+   Path to input JSON file containing the bank hierarchy, shares, and
+   usage values. This option is required.
+
+.. option:: --json, -j
+
+   Output results in JSON format. Each user is represented as a JSON
+   object with username, bank, shares, usage, and fair-share fields.
+
+.. option:: -o, --format FORMAT_STRING
+
+   Output results using a Python format string. Available fields are:
+   {username}, {bank}, {shares}, {usage}, and {fairshare}.
+   Example: "{username:<10} {fairshare:.4f}"
+
+.. option:: --parsable, -P
+
+   Output results in pipe-delimited format suitable for parsing:
+   username|bank|shares|usage|fairshare
+
+JSON INPUT FORMAT
+=================
+
+The input JSON file must contain a "root" key with a hierarchical
+structure of banks and users. Each node in the hierarchy must have:
+
+- **shares**: allocation shares (integer)
+- **usage**: historical job usage (float)
+- **bank**: bank name (for bank nodes)
+- **username**: user name (for leaf user nodes)
+- **children**: array of child nodes (optional, for bank nodes)
+
+Nodes with a "username" field are treated as leaf user associations.
+Nodes with a "bank" field and "children" array are treated as banks.
+
+EXAMPLE JSON
+============
+
+.. code-block:: json
+
+    {
+      "root": {
+        "bank": "root",
+        "shares": 1000,
+        "usage": 132,
+        "children": [
+          {
+            "bank": "bank1",
+            "shares": 1000,
+            "usage": 121,
+            "children": [
+              {"username": "user1", "shares": 10000, "usage": 100},
+              {"username": "user2", "shares": 1000, "usage": 11},
+              {"username": "user3", "shares": 100000, "usage": 10}
+            ]
+          },
+          {
+            "bank": "bank2",
+            "shares": 100,
+            "usage": 11,
+            "children": [
+              {"username": "user4", "shares": 100000, "usage": 8},
+              {"username": "user5", "shares": 10000, "usage": 3}
+            ]
+          }
+        ]
+      }
+    }
+
+SEE ALSO
+========
+
+flux-account-update-fshare(1), flux-account-update-usage(1)

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -300,4 +300,11 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-account-fairshare-emulate",
+        "flux-account-fairshare-emulate",
+        "emulate fair-share calculation for a given database hierarchy",
+        [author],
+        1,
+    ),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -563,3 +563,5 @@ msc
 msn
 noheader
 configs
+FairShare
+fshare

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -176,4 +176,5 @@ dist_fluxcmd_SCRIPTS = \
 	cmd/flux-account-update-db.py \
 	cmd/flux-account-service.py \
 	cmd/flux-account-fetch-job-records.py \
-	cmd/flux-account-update-usage.py
+	cmd/flux-account-update-usage.py \
+	cmd/flux-account-fairshare-emulate.py

--- a/src/bindings/python/fluxacct/accounting/Makefile.am
+++ b/src/bindings/python/fluxacct/accounting/Makefile.am
@@ -7,6 +7,7 @@ acctpy_PYTHON = \
 	job_usage_calculation.py \
 	jobs_table_subcommands.py \
 	db_info_subcommands.py \
+	fairshare_emulator.py \
 	create_db.py \
 	formatter.py \
 	sql_util.py \

--- a/src/bindings/python/fluxacct/accounting/fairshare_emulator.py
+++ b/src/bindings/python/fluxacct/accounting/fairshare_emulator.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import sys
+import json
+
+
+class FairShareNode:
+    """Represents a node in the fair-share hierarchy."""
+
+    EPSILON = 1e-9
+    MAX_UINT64 = (1 << 64) - 1
+
+    def __init__(self, name, shares, usage, bank=None, is_user=False):
+        self.name = name
+        self.bank = bank
+        self.shares = shares
+        self.usage = usage
+        self.is_user = is_user
+        self.children = []
+        self.weight = 0.0
+        self.fairshare = 0.5
+        self.tie_with_next = False
+
+    def add_child(self, child):
+        self.children.append(child)
+
+    def calculate_children_weights(self):
+        """Calculate weights for all children based on shares/usage ratios."""
+        if not self.children:
+            return
+
+        # sum shares and usage across siblings
+        sibling_shares_sum = sum(c.shares for c in self.children)
+        sibling_usage_sum = sum(c.usage for c in self.children)
+
+        # calculate weight for each child
+        for child in self.children:
+            child.calculate_weight(sibling_shares_sum, sibling_usage_sum)
+
+    def calculate_weight(self, sibling_shares_sum, sibling_usage_sum):
+        """Calculate weight for this node based on shares/usage ratio."""
+        if self.shares == 0:
+            self.weight = 0.0
+        elif abs(self.usage) < self.EPSILON:
+            # zero usage → highest priority
+            self.weight = float(self.MAX_UINT64) + 1.0
+        else:
+            s_weight = self.shares / sibling_shares_sum
+            u_weight = self.usage / sibling_usage_sum
+            # higher shares + lower usage = higher weight
+            self.weight = s_weight / u_weight
+
+    def sort_children_by_weight(self):
+        """Sort children by weight descending (highest weight first)."""
+        self.children.sort(key=lambda c: c.weight, reverse=True)
+
+    def mark_ties(self):
+        """Mark children that have equal weights with their next sibling."""
+        for i in range(len(self.children) - 1):
+            curr = self.children[i]
+            next_child = self.children[i + 1]
+            # only tie if both are users or both are banks
+            if curr.is_user == next_child.is_user:
+                if self.is_equal(curr.weight, next_child.weight):
+                    curr.tie_with_next = True
+
+    @staticmethod
+    def is_equal(val_a, val_b):
+        """Floating-point equality check."""
+        threshold = sys.float_info.epsilon * max(abs(val_a), max(abs(val_b), 1.0))
+        return abs(val_a - val_b) < threshold
+
+
+class FairShareCalculator:
+    """Implements the weighted tree fair-share algorithm."""
+
+    def __init__(self, root_node):
+        self.root = root_node
+        self.users = []
+        self.current_rank = 0
+        self.stride_size = 0
+        self.total_users = 0
+
+    def calculate(self):
+        """Calculate fair-share values for all users in the tree."""
+        # count total users
+        total_users = self._count_users(self.root)
+        if total_users == 0:
+            return []
+
+        # calculate weights throughout the tree
+        self._calculate_all_weights(self.root)
+
+        # sort children by weight and mark ties
+        self._prepare_tree(self.root)
+
+        # traverse and assign fair-share values
+        # rank starts at total_users for highest priority, counts down
+        self.current_rank = total_users
+        self.stride_size = 0
+        self.users = []
+        self.total_users = total_users
+        self._traverse(self.root)
+
+        return self.users
+
+    def _count_users(self, node):
+        """Count leaf users in tree."""
+        if node.is_user:
+            return 1
+        return sum(self._count_users(c) for c in node.children)
+
+    def _calculate_all_weights(self, node):
+        """Recursively calculate weights for all nodes."""
+        node.calculate_children_weights()
+        for child in node.children:
+            if not child.is_user:
+                self._calculate_all_weights(child)
+
+    def _prepare_tree(self, node):
+        """
+        Sort children and mark ties throughout the tree.
+        Recursively prepares all bank nodes in the hierarchy.
+        """
+        if not node.children:
+            return
+
+        # recursively prepare each child bank
+        for child in node.children:
+            if not child.is_user:
+                self._prepare_tree(child)
+
+        # sort and mark ties at this level
+        node.sort_children_by_weight()
+        node.mark_ties()
+
+    @staticmethod
+    def _build_tie_aware_children(node):
+        """Build a tie-aware children list, merging grandchildren from tied banks."""
+        tie_aware = []
+        in_stride = False
+        virtual_children = []
+
+        for i, child in enumerate(node.children):
+            # User children are added directly
+            if child.is_user:
+                tie_aware.append(child)
+                continue
+
+            # Bank children: check if tied with next
+            is_tied = (
+                i < len(node.children) - 1
+                and FairShareNode.is_equal(child.weight, node.children[i + 1].weight)
+                and not child.is_user
+                and not node.children[i + 1].is_user
+            )
+
+            if is_tied:
+                if not in_stride:
+                    # Start of a new tie group
+                    in_stride = True
+                    virtual_children = []
+                # Add this bank's children to the virtual node
+                virtual_children.extend(child.children)
+            else:
+                if in_stride:
+                    # End of tie group - add last bank's children
+                    virtual_children.extend(child.children)
+                    # Sort merged children and add as virtual node
+                    virtual_children.sort(key=lambda c: c.weight, reverse=True)
+                    # Mark ties within the merged group
+                    for j in range(len(virtual_children) - 1):
+                        if FairShareNode.is_equal(
+                            virtual_children[j].weight, virtual_children[j + 1].weight
+                        ):
+                            virtual_children[j].tie_with_next = True
+                    tie_aware.extend(virtual_children)
+                    in_stride = False
+                    virtual_children = []
+                else:
+                    # Not tied, add bank as-is
+                    tie_aware.append(child)
+
+        return tie_aware
+
+    def _traverse(self, node):
+        """
+        Depth-first traversal to assign fair-share values.
+        From weighted_walk.cpp::handle_leaf() and handle_internal()
+
+        Rank starts at total_users for the highest priority user.
+        Tied users all get the same rank (and thus same fairshare).
+        After processing all tied users, rank decrements by 1 + stride_size.
+
+        fairshare = current_rank / total_users
+        """
+        if node.is_user:
+            # Calculate fairshare using current rank
+            node.fairshare = self.current_rank / self.total_users
+
+            # Handle ties: tied nodes all use the SAME rank
+            if node.tie_with_next:
+                # This node is tied with the next one
+                # Don't decrement rank yet, just increment stride
+                self.stride_size += 1
+                node.tie_with_next = False
+            else:
+                # This node is NOT tied with next (or is the last of a tie group)
+                # Decrement rank by 1 + number of nodes we were tied with
+                self.current_rank = self.current_rank - 1 - self.stride_size
+                self.stride_size = 0
+
+            self.users.append(node)
+        else:
+            # For internal nodes, build tie-aware children list
+            # This merges grandchildren from tied banks
+            tie_aware_children = self._build_tie_aware_children(node)
+
+            # Traverse tie-aware children
+            for child in tie_aware_children:
+                self._traverse(child)
+
+
+def parse_json_input(json_data):
+    """
+    Parse JSON input and build fair-share tree.
+
+    Expected format:
+    {
+      "root": {
+        "bank": "root",
+        "shares": 1000,
+        "usage": 133,
+        "children": [
+          {
+            "bank": "account1",
+            "shares": 1000,
+            "usage": 121,
+            "children": [
+              {"username": "user1", "shares": 10000, "usage": 100},
+              ...
+            ]
+          },
+          ...
+        ]
+      }
+    }
+    """
+    if "root" not in json_data:
+        raise ValueError("JSON must contain 'root' key")
+
+    root_data = json_data["root"]
+    return _build_tree(root_data, parent_bank=None)
+
+
+def _build_tree(node_data, parent_bank):
+    """Recursively build tree from JSON data."""
+    # determine if this is a user or bank node
+    is_user = "username" in node_data
+    name = node_data.get("username") if is_user else node_data.get("bank")
+
+    if not name:
+        raise ValueError("Node must have 'username' or 'bank' key")
+
+    shares = node_data.get("shares", 1)
+    usage = node_data.get("usage", 0.0)
+
+    # for users, bank is the parent; for banks, bank is self
+    bank = parent_bank if is_user else name
+
+    node = FairShareNode(name, shares, usage, bank=bank, is_user=is_user)
+
+    # recursively add children
+    if "children" in node_data:
+        for child_data in node_data["children"]:
+            child = _build_tree(child_data, parent_bank=bank)
+            node.add_child(child)
+
+    return node
+
+
+def format_results(users, json_fmt=False, format_string=""):
+    """Format fair-share results for output."""
+    if not users:
+        raise ValueError("no users found in input")
+
+    if json_fmt:
+        results = []
+        for user in users:
+            results.append(
+                {
+                    "username": user.name,
+                    "bank": user.bank,
+                    "shares": user.shares,
+                    "usage": user.usage,
+                    "fairshare": round(user.fairshare, 6),
+                }
+            )
+        return json.dumps(results, indent=2)
+
+    if format_string:
+        lines = []
+        for user in users:
+            try:
+                lines.append(
+                    format_string.format(
+                        username=user.name,
+                        bank=user.bank,
+                        shares=user.shares,
+                        usage=user.usage,
+                        fairshare=round(user.fairshare, 6),
+                    )
+                )
+            except KeyError as err:
+                raise ValueError(f"Invalid format string key: {err}") from err
+        return "\n".join(lines)
+
+    # default: table format
+    rows = []
+    for user in users:
+        rows.append(
+            (
+                user.name,
+                user.bank,
+                user.shares,
+                round(user.usage, 2),
+                round(user.fairshare, 6),
+            )
+        )
+
+    headers = ["Username", "Bank", "Shares", "Usage", "FairShare"]
+    col_widths = [
+        max(len(str(header)), max(len(str(row[i])) for row in rows))
+        for i, header in enumerate(headers)
+    ]
+
+    def format_row(row):
+        return " | ".join(
+            f"{str(val).ljust(col_widths[i])}" for i, val in enumerate(row)
+        )
+
+    header = format_row(headers)
+    separator = "-+-".join(["-" * width for width in col_widths])
+    data_rows = "\n".join([format_row(row) for row in rows])
+
+    return f"{header}\n{separator}\n{data_rows}"

--- a/src/cmd/flux-account-fairshare-emulate.py
+++ b/src/cmd/flux-account-fairshare-emulate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import argparse
+import json
+import sys
+
+from fluxacct.accounting import fairshare_emulator
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+        Fair-share emulator: Calculate fair-share values from JSON input
+        without requiring a database. Useful for testing fair-share scenarios
+        and previewing changes before applying them to production.
+        """
+    )
+
+    parser.add_argument(
+        "-i",
+        "--input",
+        dest="input_file",
+        required=True,
+        help="path to input JSON file containing bank hierarchy, shares, and usage",
+    )
+    parser.add_argument(
+        "--json",
+        "-j",
+        action="store_true",
+        help="output results as JSON",
+    )
+    parser.add_argument(
+        "-o",
+        "--format",
+        dest="format_string",
+        default="",
+        help="output results using Python format string (e.g., '{username} {fairshare}')",
+    )
+    parser.add_argument(
+        "--parsable",
+        "-P",
+        action="store_true",
+        help="output results in parsable pipe-delimited format",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        with open(args.input_file, "r") as input_file:
+            json_data = json.load(input_file)
+    except FileNotFoundError:
+        print(
+            f"fairshare-emulate: FileNotFoundError: input file not found: {args.input_file}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(
+            f"fairshare-emulate: JSONDecodeError: invalid JSON in input file: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        root = fairshare_emulator.parse_json_input(json_data)
+    except ValueError as exc:
+        print(f"fairshare-emulate: ValueError: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    calculator = fairshare_emulator.FairShareCalculator(root)
+    users = calculator.calculate()
+
+    if args.parsable:
+        format_string = "{username}|{bank}|{shares}|{usage}|{fairshare}"
+    else:
+        format_string = args.format_string
+
+    try:
+        output = fairshare_emulator.format_results(
+            users, json_fmt=args.json, format_string=format_string
+        )
+        print(output)
+    except ValueError as exc:
+        print(f"fairshare-emulate: ValueError: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -100,6 +100,7 @@ TESTSCRIPTS = \
 	t1095-max-sched-resources-queue-dependency.t \
 	t1096-flux-account-bank-info.t \
 	t1097-mf-priority-unknown-queues.t \
+	t1098-fairshare-emulate.t \
 	t5000-valgrind.t \
 	python/t1000-example.py \
 	python/t1001_db.py \

--- a/t/expected/fairshare_emulate/small_tie_all_json.expected
+++ b/t/expected/fairshare_emulate/small_tie_all_json.expected
@@ -1,0 +1,65 @@
+[
+  {
+    "username": "leaf.1.3",
+    "bank": "account1",
+    "shares": 100000,
+    "usage": 10,
+    "fairshare": 1.0
+  },
+  {
+    "username": "leaf.2.3",
+    "bank": "account2",
+    "shares": 100000,
+    "usage": 1,
+    "fairshare": 1.0
+  },
+  {
+    "username": "leaf.3.3",
+    "bank": "account3",
+    "shares": 100000,
+    "usage": 100,
+    "fairshare": 1.0
+  },
+  {
+    "username": "leaf.1.2",
+    "bank": "account1",
+    "shares": 1000,
+    "usage": 10,
+    "fairshare": 0.666667
+  },
+  {
+    "username": "leaf.2.2",
+    "bank": "account2",
+    "shares": 1000,
+    "usage": 1,
+    "fairshare": 0.666667
+  },
+  {
+    "username": "leaf.3.2",
+    "bank": "account3",
+    "shares": 1000,
+    "usage": 100,
+    "fairshare": 0.666667
+  },
+  {
+    "username": "leaf.1.1",
+    "bank": "account1",
+    "shares": 10000,
+    "usage": 100,
+    "fairshare": 0.666667
+  },
+  {
+    "username": "leaf.2.1",
+    "bank": "account2",
+    "shares": 10000,
+    "usage": 10,
+    "fairshare": 0.666667
+  },
+  {
+    "username": "leaf.3.1",
+    "bank": "account3",
+    "shares": 10000,
+    "usage": 1000,
+    "fairshare": 0.666667
+  }
+]

--- a/t/t1098-fairshare-emulate.t
+++ b/t/t1098-fairshare-emulate.t
@@ -1,0 +1,380 @@
+#!/bin/bash
+
+test_description='test fair-share emulator'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+EXPECTED_FILES=${SHARNESS_TEST_SRCDIR}/expected/fairshare_emulate
+
+export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
+test_under_flux 4 job -o,--config-path=$(pwd)/config -Slog-stderr-level=1
+
+test_expect_success '--help message works' '
+	flux account-fairshare-emulate --help
+'
+
+test_expect_success 'nonexistent input file raises error' '
+	test_must_fail flux account-fairshare-emulate -i foo.json > no_json_file.err 2>&1 &&
+	grep "fairshare-emulate: FileNotFoundError: input file not found: foo.json" no_json_file.err
+'
+
+test_expect_success 'malformed JSON input raises error' '
+	cat <<-EOF >bad.json
+	{
+		this sure is bad JSON
+	}
+	EOF
+	test_must_fail flux account-fairshare-emulate -i bad.json > bad_json.err 2>&1 &&
+	grep -E "(fairshare-emulate)|\
+(JSONDecodeError)|\
+(Expecting property name enclosed in double quotes)" bad_json.err
+'
+
+test_expect_success 'create small_no_tie JSON input' '
+	cat <<-EOF >small_no_tie.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 133,
+		"children": [
+		  {
+			"bank": "account1",
+			"shares": 1000,
+			"usage": 121,
+			"children": [
+			  {"username": "leaf.1.1", "shares": 10000, "usage": 100},
+			  {"username": "leaf.1.2", "shares": 1000, "usage": 11},
+			  {"username": "leaf.1.3", "shares": 100000, "usage": 10}
+			]
+		  },
+		  {
+			"bank": "account2",
+			"shares": 100,
+			"usage": 11,
+			"children": [
+			  {"username": "leaf.2.1", "shares": 100000, "usage": 8},
+			  {"username": "leaf.2.2", "shares": 10000, "usage": 3}
+			]
+		  },
+		  {
+			"bank": "account3",
+			"shares": 10,
+			"usage": 1,
+			"children": [
+			  {"username": "leaf.3.1", "shares": 100, "usage": 0},
+			  {"username": "leaf.3.2", "shares": 10, "usage": 1}
+			]
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'run fairshare-emulate on small_no_tie' '
+	flux account-fairshare-emulate \
+		-i small_no_tie.json -o "{username},{fairshare}" > small_no_tie.test &&
+	cat <<-EOF >small_no_tie.expected &&
+	leaf.3.1,1.0
+	leaf.3.2,0.857143
+	leaf.2.1,0.714286
+	leaf.2.2,0.571429
+	leaf.1.3,0.428571
+	leaf.1.1,0.285714
+	leaf.1.2,0.142857
+	EOF
+	test_cmp small_no_tie.test small_no_tie.expected
+'
+
+test_expect_success 'create small_tie JSON input' '
+	cat <<-EOF >small_tie.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 133,
+		"children": [
+		  {
+			"bank": "account1",
+			"shares": 1000,
+			"usage": 120,
+			"children": [
+			  {"username": "leaf.1.1", "shares": 10000, "usage": 100},
+			  {"username": "leaf.1.2", "shares": 1000, "usage": 10},
+			  {"username": "leaf.1.3", "shares": 100000, "usage": 10}
+			]
+		  },
+		  {
+			"bank": "account2",
+			"shares": 100,
+			"usage": 12,
+			"children": [
+			  {"username": "leaf.2.1", "shares": 10000, "usage": 10},
+			  {"username": "leaf.2.2", "shares": 1000, "usage": 1},
+			  {"username": "leaf.2.3", "shares": 100000, "usage": 1}
+			]
+		  },
+		  {
+			"bank": "account3",
+			"shares": 10,
+			"usage": 1,
+			"children": [
+			  {"username": "leaf.3.1", "shares": 100, "usage": 0},
+			  {"username": "leaf.3.2", "shares": 10, "usage": 1}
+			]
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'run fairshare-emulate on small_tie' '
+	flux account-fairshare-emulate \
+		-i small_tie.json -o "{username},{fairshare}" > small_tie.test &&
+	cat <<-EOF >small_tie.expected &&
+	leaf.3.1,1.0
+	leaf.3.2,0.875
+	leaf.1.3,0.75
+	leaf.2.3,0.75
+	leaf.1.2,0.5
+	leaf.2.2,0.5
+	leaf.1.1,0.5
+	leaf.2.1,0.5
+	EOF
+	test_cmp small_tie.test small_tie.expected
+'
+
+test_expect_success 'create small_tie_all JSON input' '
+	cat <<-EOF >small_tie_all.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 1332,
+		"children": [
+		  {
+			"bank": "account1",
+			"shares": 1000,
+			"usage": 120,
+			"children": [
+			  {"username": "leaf.1.1", "shares": 10000, "usage": 100},
+			  {"username": "leaf.1.2", "shares": 1000, "usage": 10},
+			  {"username": "leaf.1.3", "shares": 100000, "usage": 10}
+			]
+		  },
+		  {
+			"bank": "account2",
+			"shares": 100,
+			"usage": 12,
+			"children": [
+			  {"username": "leaf.2.1", "shares": 10000, "usage": 10},
+			  {"username": "leaf.2.2", "shares": 1000, "usage": 1},
+			  {"username": "leaf.2.3", "shares": 100000, "usage": 1}
+			]
+		  },
+		  {
+			"bank": "account3",
+			"shares": 10000,
+			"usage": 1200,
+			"children": [
+			  {"username": "leaf.3.1", "shares": 10000, "usage": 1000},
+			  {"username": "leaf.3.2", "shares": 1000, "usage": 100},
+			  {"username": "leaf.3.3", "shares": 100000, "usage": 100}
+			]
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'run fairshare-emulate on small_tie_all' '
+	flux account-fairshare-emulate \
+		-i small_tie_all.json -o "{username},{fairshare}" > small_tie_all.test &&
+	cat <<-EOF >small_tie_all.expected &&
+	leaf.1.3,1.0
+	leaf.2.3,1.0
+	leaf.3.3,1.0
+	leaf.1.2,0.666667
+	leaf.2.2,0.666667
+	leaf.3.2,0.666667
+	leaf.1.1,0.666667
+	leaf.2.1,0.666667
+	leaf.3.1,0.666667
+	EOF
+	test_cmp small_tie_all.test small_tie_all.expected
+'
+
+test_expect_success 'fairshare-emulate on small_tie_all with JSON output' '
+	flux account-fairshare-emulate \
+		-i small_tie_all.json --json > small_tie_all_json.test &&
+	test_cmp small_tie_all_json.test ${EXPECTED_FILES}/small_tie_all_json.expected
+'
+
+test_expect_success 'fairshare-emulate on small_tie_all with parsable output' '
+	flux account-fairshare-emulate \
+		-i small_tie_all.json -P > small_tie_all_parsable.test &&
+	cat <<-EOF >small_tie_all_parsable.expected &&
+	leaf.1.3|account1|100000|10|1.0
+	leaf.2.3|account2|100000|1|1.0
+	leaf.3.3|account3|100000|100|1.0
+	leaf.1.2|account1|1000|10|0.666667
+	leaf.2.2|account2|1000|1|0.666667
+	leaf.3.2|account3|1000|100|0.666667
+	leaf.1.1|account1|10000|100|0.666667
+	leaf.2.1|account2|10000|10|0.666667
+	leaf.3.1|account3|10000|1000|0.666667
+	EOF
+	test_cmp small_tie_all_parsable.test small_tie_all_parsable.expected
+'
+
+test_expect_success 'create single_user JSON input' '
+	cat <<-EOF >single_user.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 100,
+		"children": [
+		  {
+			"bank": "account1",
+			"shares": 1000,
+			"usage": 100,
+			"children": [
+			  {"username": "only.user", "shares": 1000, "usage": 100}
+			]
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'single user in hierarchy gets fairshare 1.0' '
+	flux account-fairshare-emulate \
+		-i single_user.json -o "{username},{fairshare}" > single_user.test &&
+	cat <<-EOF >single_user.expected &&
+	only.user,1.0
+	EOF
+	test_cmp single_user.test single_user.expected
+'
+
+test_expect_success 'create empty_hierarchy JSON input' '
+	cat <<-EOF >empty_hierarchy.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 0,
+		"children": [
+		  {
+			"bank": "account1",
+			"shares": 1000,
+			"usage": 0,
+			"children": []
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'empty hierarchy produces no users message' '
+	test_must_fail flux account-fairshare-emulate \
+		-i empty_hierarchy.json > empty_hierarchy.err 2>&1 &&
+	grep "no users found in input" empty_hierarchy.err
+'
+
+test_expect_success 'invalid format string raises error' '
+	test_must_fail flux account-fairshare-emulate \
+		-i single_user.json -o "{username},{invalid_field}" > bad_format.err 2>&1 &&
+	grep "Invalid format string key" bad_format.err
+'
+
+test_expect_success 'create deeply_nested JSON input' '
+	cat <<-EOF >deeply_nested.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 100,
+		"children": [
+		  {
+			"bank": "level1",
+			"shares": 1000,
+			"usage": 100,
+			"children": [
+			  {
+				"bank": "level2",
+				"shares": 1000,
+				"usage": 100,
+				"children": [
+				  {
+					"bank": "level3",
+					"shares": 1000,
+					"usage": 100,
+					"children": [
+					  {"username": "deep.user1", "shares": 1000, "usage": 50},
+					  {"username": "deep.user2", "shares": 1000, "usage": 50}
+					]
+				  }
+				]
+			  }
+			]
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'deeply nested hierarchy calculates correctly' '
+	flux account-fairshare-emulate \
+		-i deeply_nested.json -o "{username},{fairshare}" > deeply_nested.test &&
+	cat <<-EOF >deeply_nested.expected &&
+	deep.user1,1.0
+	deep.user2,1.0
+	EOF
+	test_cmp deeply_nested.test deeply_nested.expected
+'
+
+test_expect_success 'create identical_weights JSON input' '
+	cat <<-EOF >identical_weights.json
+	{
+	  "root": {
+		"bank": "root",
+		"shares": 1000,
+		"usage": 300,
+		"children": [
+		  {
+			"bank": "account1",
+			"shares": 1000,
+			"usage": 300,
+			"children": [
+			  {"username": "user.a", "shares": 1000, "usage": 100},
+			  {"username": "user.b", "shares": 1000, "usage": 100},
+			  {"username": "user.c", "shares": 1000, "usage": 100}
+			]
+		  }
+		]
+	  }
+	}
+	EOF
+'
+
+test_expect_success 'users with identical weights get equal fairshare' '
+	flux account-fairshare-emulate \
+		-i identical_weights.json -o "{username},{fairshare}" > identical_weights.test &&
+	cat <<-EOF >identical_weights.expected &&
+	user.a,1.0
+	user.b,1.0
+	user.c,1.0
+	EOF
+	test_cmp identical_weights.test identical_weights.expected
+'
+
+test_done


### PR DESCRIPTION
#### Problem

There is no way to calculate fair-share values from input data without a flux-accounting database. This makes it difficult
to test fair-share scenarios, preview configuration changes, or just to demonstrate the algorithm.

---

This PR adds a new command to the flux-accounting command suite, `fairshare-emulate`, which emulates fair-share calculation over a hierarchy of banks and users. It introduces a Python implementation of the weighted tree fair-share algorithm in `src/fairness/` to calculate these fair-share value for a given hierarchy and outputs the results in a number of optional formats. It does not require an active connection to the flux-accounting SQLite database, so it is implemented as a command separate from those present in the flux-accounting service.

A number of simple sharness tests are added to verify that the results calculated by the emulator line up with those calculated by the C++ implementation.

A man(1) page is also added with a more detailed description of the command as well as how to format JSON input for the command itself.

Closes #829